### PR TITLE
fix(pr-patrol): skip release PRs (main → production) — QUA-971

### DIFF
--- a/crux/lib/pr-analysis/detection.ts
+++ b/crux/lib/pr-analysis/detection.ts
@@ -21,7 +21,7 @@ const PR_QUERY = `query($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     pullRequests(first: 50, states: [OPEN], orderBy: {field: UPDATED_AT, direction: DESC}) {
       nodes {
-        id number title headRefName headRefOid mergeable mergeStateStatus isDraft createdAt updatedAt body
+        id number title headRefName baseRefName headRefOid mergeable mergeStateStatus isDraft createdAt updatedAt body
         author { login }
         labels(first: 20) { nodes { name } }
         commits(last: 1) { nodes { commit {
@@ -67,7 +67,7 @@ const PR_QUERY = `query($owner: String!, $name: String!) {
 const SINGLE_PR_QUERY = `query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
-      id number title state headRefName headRefOid mergeable mergeStateStatus isDraft createdAt updatedAt body
+      id number title state headRefName baseRefName headRefOid mergeable mergeStateStatus isDraft createdAt updatedAt body
       author { login }
       labels(first: 20) { nodes { name } }
       commits(last: 1) { nodes { commit {

--- a/crux/lib/pr-analysis/types.ts
+++ b/crux/lib/pr-analysis/types.ts
@@ -263,6 +263,8 @@ export interface GqlPrNode {
   /** PR state: OPEN, CLOSED, or MERGED. Present when the GQL query requests it. */
   state?: string;
   headRefName: string;
+  /** PR base ref (e.g. 'main' or 'production'). Used to skip release PRs. */
+  baseRefName?: string;
   headRefOid: string;
   mergeable: string;
   /** GitHub's mergeStateStatus (DIRTY, BLOCKED, BEHIND, CLEAN, HAS_HOOKS, UNKNOWN, UNSTABLE). */

--- a/crux/pr-patrol/detection.test.ts
+++ b/crux/pr-patrol/detection.test.ts
@@ -9,6 +9,7 @@ function makePrNode(overrides: Partial<GqlPrNode> = {}): GqlPrNode {
     number: 1,
     title: 'Test PR',
     headRefName: 'claude/test',
+    baseRefName: 'main',
     headRefOid: 'abc123def456',
     mergeable: 'MERGEABLE',
     isDraft: false,
@@ -377,6 +378,22 @@ describe('detectAllPrIssuesFromNodes — bot/release PR skipping', () => {
     });
     const result = detectAllPrIssuesFromNodes([pr], defaultConfig);
     expect(result.find((r) => r.number === 22)).toBeUndefined();
+  });
+
+  // QUA-971: release PRs use head=main, base=production. Patrol's worktree of
+  // main collides with coord's checkout, and release PRs belong to the
+  // releases role anyway. Skip by baseRefName.
+  it('skips release PRs (main → production) by baseRefName', () => {
+    const pr = makePrNode({
+      number: 23,
+      headRefName: 'main',
+      baseRefName: 'production',
+      title: 'release: 2026-05-01',
+      author: { login: 'someuser' },
+      body: 'Release rollup',
+    });
+    const result = detectAllPrIssuesFromNodes([pr], defaultConfig);
+    expect(result.find((r) => r.number === 23)).toBeUndefined();
   });
 
   it('does NOT skip normal human-authored PRs', () => {

--- a/crux/pr-patrol/detection.ts
+++ b/crux/pr-patrol/detection.ts
@@ -213,6 +213,15 @@ export function detectAllPrIssuesFromNodes(
         }
         return false;
       }
+      // Skip release PRs (main → production). Patrol's worktree of `main` would
+      // collide with coord's own checkout, and release PRs belong to the
+      // releases role, not slot-orchestration (CLAUDE.md split). QUA-971.
+      if (pr.baseRefName === 'production') {
+        if (config.verbose) {
+          log(`  ${cl.dim}Skipping PR #${pr.number} — release PR (base=production)${cl.reset}`);
+        }
+        return false;
+      }
       return true;
     })
     .map((pr) => {


### PR DESCRIPTION
## Summary

Patrol's PR filter (`crux/pr-patrol/detection.ts`) only skipped by **branch prefix** (`release/`, `dependabot/`, `renovate/`). Release PRs use `main` as their head ref and `production` as base — neither matches any prefix — so patrol picked them up. When it tried to worktree the head ref:

```
✗ Failed to create worktree for PR #4776: Command failed: git worktree add -B main ...
fatal: 'main' is already used by worktree at '/Users/ozziegooen/Documents/GitHub.nosync/lw/coord'
```

That message landed every patrol cycle for any open release PR. Beyond the worktree failure, **patrol shouldn't touch release PRs at all** — they belong to the releases role per the CLAUDE.md role split.

## Change

- Skip PRs with `baseRefName === 'production'` in the patrol filter.
- Add `baseRefName` to both GraphQL queries (`PR_QUERY`, `SINGLE_PR_QUERY`) and to `GqlPrNode` (optional, so the many existing test fixtures don't break).
- Test: `crux/pr-patrol/detection.test.ts` — new case `skips release PRs (main → production) by baseRefName`. All 600 patrol/pr-analysis tests pass.

## Repro

PR #4776 (release: 2026-05-01 #2). `~/.cache/pr-patrol/run.log` had the worktree fatal every 5 minutes.

## Test plan

- [x] `pnpm vitest run crux/pr-patrol crux/lib/pr-analysis` — 600/600 pass
- [x] New test asserts release-PR skip
- [ ] After merge: confirm patrol log no longer reports worktree errors for #4776 (or its successor release PRs)

Closes QUA-971
