### PR TITLE
feat(health): wellness reports file Linear tickets directly (QUA-970)

### DIFF
--- a/.github/workflows/render-monitor.yml
+++ b/.github/workflows/render-monitor.yml
@@ -42,14 +42,13 @@ jobs:
           PLAYWRIGHT_BASE_URL: https://www.longtermwiki.com
         run: cd apps/web && npx playwright test e2e/render-audit.spec.ts --reporter=list
 
-      - name: Manage GitHub issue on failure
+      - name: Upsert Linear ticket on failure
+        # QUA-970: Linear-first auto-filer. Comments on the existing open
+        # ticket if one exists, or creates a new one in the right project.
         if: steps.audit.outcome == 'failure'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         run: |
-          # Search for existing open issue
-          EXISTING=$(gh issue list --label render-monitor --state open --limit 1 --json number --jq '.[0].number // empty')
-
           BODY_FILE=$(mktemp)
           cat >| "$BODY_FILE" <<BODYEOF
           Render quality audit failed against production.
@@ -57,31 +56,20 @@ jobs:
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BODYEOF
 
-          if [ -n "$EXISTING" ]; then
-            echo "Updating existing issue #${EXISTING}"
-            gh issue comment "$EXISTING" --body-file "$BODY_FILE"
-          else
-            echo "Creating new issue"
-            gh issue create \
-              --title "Render quality regression detected" \
-              --label "render-monitor" \
-              --body-file "$BODY_FILE"
-          fi
+          pnpm crux linear monitor upsert \
+            --title="Render quality regression detected" \
+            --body-file="$BODY_FILE" \
+            --project="Dashboards & Visibility"
           rm -f "$BODY_FILE"
 
-      - name: Close issue on success
+      - name: Resolve Linear ticket on success
         if: steps.audit.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         run: |
-          EXISTING=$(gh issue list --label render-monitor --state open --limit 1 --json number --jq '.[0].number // empty')
-          if [ -n "$EXISTING" ]; then
-            echo "Closing resolved issue #${EXISTING}"
-            gh issue comment "$EXISTING" --body "Render quality audit passing again. Closing.
-
-            **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            gh issue close "$EXISTING"
-          fi
+          pnpm crux linear monitor resolve \
+            --title="Render quality regression detected" \
+            --comment="Render quality audit passing again. Auto-closing. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Fail workflow if audit failed
         if: steps.audit.outcome == 'failure'

--- a/.github/workflows/render-monitor.yml
+++ b/.github/workflows/render-monitor.yml
@@ -4,8 +4,14 @@ name: Render Quality Monitor
 # Catches display regressions (raw numbers, JSON leaks) between deploys.
 # Runs every 6 hours + manual trigger.
 #
-# On failure: creates or updates a GitHub issue with label "render-monitor".
-# On success after prior failure: closes the issue with a resolution comment.
+# On failure: upserts a Linear ticket in "Dashboards & Visibility" via
+#   `crux linear monitor upsert` (QUA-970). The job step fails non-zero on
+#   transient Linear errors; the next 6h cron tick re-attempts. We trade
+#   immediate redundancy for cleaner ticket management — a single missed
+#   alert at 6h cadence is acceptable. Wellness keeps a GH fallback because
+#   it runs every few minutes.
+# On success after prior failure: `crux linear monitor resolve` closes any
+#   open ticket with the same title.
 #
 # Phase 3 of Discussion #3768 (Rendering Quality & Test Infrastructure).
 
@@ -13,6 +19,19 @@ on:
   schedule:
     - cron: "0 */6 * * *"
   workflow_dispatch: {}
+
+# Prevent the cron tick and a manual workflow_dispatch from racing — both
+# would otherwise call upsert, miss each other's in-flight searches, and
+# create two Linear tickets. cancel-in-progress: false because the manual
+# trigger should serialize behind the cron, not abort it.
+concurrency:
+  group: render-monitor
+  cancel-in-progress: false
+
+# Least-privilege: workflow now writes to Linear (off-GitHub), so the
+# default GITHUB_TOKEN only needs read access for `actions/checkout`.
+permissions:
+  contents: read
 
 jobs:
   render-audit:

--- a/.github/workflows/server-health-monitor.yml
+++ b/.github/workflows/server-health-monitor.yml
@@ -33,10 +33,30 @@ jobs:
     needs: [preflight]
     name: Verify monitoring is active
     runs-on: ubuntu-latest
+    # `issues: write` is no longer needed (Linear-first under QUA-970), but
+    # it's a default-deny scope on this token and harmless to leave; removing
+    # it costs a force-pause incident (e.g. if a future revert needs to
+    # re-enable GH filing temporarily).
     permissions:
       issues: write
 
     steps:
+      # Checkout + pnpm setup are needed for `pnpm crux linear monitor`
+      # invocations below. The previous bash `gh issue ...` flow needed
+      # nothing beyond the pre-installed `gh` CLI; the Linear-first flow
+      # has to compile + run our crux command.
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Check wiki-server and groundskeeper status
         id: check
         env:
@@ -96,83 +116,61 @@ jobs:
             echo "error=Groundskeeper status is '${GK_STATUS}'. Health monitoring may be inactive." >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create or update issue (monitoring gap detected)
+      - name: Upsert Linear ticket on monitoring gap
+        # QUA-970: Linear-first auto-filer. Title is intentionally stable
+        # ("Wiki server dead-man-switch alert") so consecutive runs in the
+        # same outage converge on the same Linear ticket regardless of
+        # which CHECK_STATUS variant fired. The status variant lives in the
+        # body, where it's still visible but doesn't fragment the dedup key.
         if: steps.check.outputs.status != 'ok'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           CHECK_STATUS: ${{ steps.check.outputs.status }}
           CHECK_ERROR: ${{ steps.check.outputs.error }}
         run: |
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          BODY_FILE=$(mktemp)
+          {
+            echo "## Dead-man-switch: monitoring gap detected"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| **Check** | ${CHECK_STATUS} |"
+            echo "| **Detected at** | ${TIMESTAMP} |"
+            echo "| **Detail** | ${CHECK_ERROR} |"
+            echo ""
+            echo "### What this means"
+            echo ""
+            echo "The weekly dead-man-switch detected a potential gap in health monitoring:"
+            echo ""
+            echo "- **\`server-down\`** — Wiki-server is unreachable. The groundskeeper should be creating issues for this, but if both are down, this is the fallback alert."
+            echo "- **\`server-unhealthy\`** — Wiki-server is up but degraded. The groundskeeper should have caught this already — if it didn't, the groundskeeper may be down too."
+            echo "- **\`groundskeeper-down\`** — Wiki-server is healthy but the groundskeeper daemon hasn't sent a heartbeat recently. Health monitoring is not running."
+            echo "- **\`monitoring-unavailable\`** — The monitoring status endpoint is not reachable. Cannot verify groundskeeper liveness."
+            echo "- **\`error\`** — Configuration issue (missing secrets)."
+            echo ""
+            echo "### Actions"
+            echo ""
+            echo "1. Check groundskeeper pod: \`kubectl get pods -n longtermwiki -l app=groundskeeper\`"
+            echo "2. Check groundskeeper logs: \`kubectl logs -n longtermwiki -l app=groundskeeper --tail=50\`"
+            echo "3. Check wiki-server pod: \`kubectl get pods -n longtermwiki -l app=longterm-wiki-server-wiki-server\`"
+            echo ""
+            echo "---"
+            echo "*Created by the [dead-man-switch workflow](https://github.com/quantified-uncertainty/longterm-wiki/actions/workflows/server-health-monitor.yml). Runs weekly to verify the groundskeeper health monitor is active.*"
+          } >| "$BODY_FILE"
 
-          EXISTING=$(gh issue list \
-            --repo "${{ github.repository }}" \
-            --label "server-health" \
-            --state open \
-            --json number \
-            --jq '.[0].number // empty')
+          pnpm crux linear monitor upsert \
+            --title="Wiki server dead-man-switch alert" \
+            --body-file="$BODY_FILE" \
+            --project="Automation & Infrastructure"
+          rm -f "$BODY_FILE"
 
-          if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" \
-              --repo "${{ github.repository }}" \
-              --body "[Dead-man-switch] ${TIMESTAMP}: ${CHECK_ERROR}"
-          else
-            gh label create "server-health" --repo "${{ github.repository }}" \
-              --color "d73a4a" --description "Wiki server health monitoring" 2>/dev/null || true
-
-            {
-              echo "## Dead-man-switch: monitoring gap detected"
-              echo ""
-              echo "| Field | Value |"
-              echo "|-------|-------|"
-              echo "| **Check** | ${CHECK_STATUS} |"
-              echo "| **Detected at** | ${TIMESTAMP} |"
-              echo "| **Detail** | ${CHECK_ERROR} |"
-              echo ""
-              echo "### What this means"
-              echo ""
-              echo "The weekly dead-man-switch detected a potential gap in health monitoring:"
-              echo ""
-              echo "- **\`server-down\`** — Wiki-server is unreachable. The groundskeeper should be creating issues for this, but if both are down, this is the fallback alert."
-              echo "- **\`server-unhealthy\`** — Wiki-server is up but degraded. The groundskeeper should have caught this already — if it didn't, the groundskeeper may be down too."
-              echo "- **\`groundskeeper-down\`** — Wiki-server is healthy but the groundskeeper daemon hasn't sent a heartbeat recently. Health monitoring is not running."
-              echo "- **\`monitoring-unavailable\`** — The monitoring status endpoint is not reachable. Cannot verify groundskeeper liveness."
-              echo "- **\`error\`** — Configuration issue (missing secrets)."
-              echo ""
-              echo "### Actions"
-              echo ""
-              echo "1. Check groundskeeper pod: \`kubectl get pods -n longtermwiki -l app=groundskeeper\`"
-              echo "2. Check groundskeeper logs: \`kubectl logs -n longtermwiki -l app=groundskeeper --tail=50\`"
-              echo "3. Check wiki-server pod: \`kubectl get pods -n longtermwiki -l app=longterm-wiki-server-wiki-server\`"
-              echo ""
-              echo "---"
-              echo "*Created by the [dead-man-switch workflow](https://github.com/quantified-uncertainty/longterm-wiki/actions/workflows/server-health-monitor.yml). Runs weekly to verify the groundskeeper health monitor is active.*"
-            } > /tmp/issue_body.md
-
-            gh issue create \
-              --repo "${{ github.repository }}" \
-              --title "[Dead-man-switch] Monitoring gap: ${CHECK_STATUS}" \
-              --label "server-health,bug" \
-              --body-file /tmp/issue_body.md
-          fi
-
-      - name: Close resolved issue
+      - name: Resolve Linear ticket on recovery
         if: steps.check.outputs.status == 'ok'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         run: |
-          ISSUE=$(gh issue list \
-            --repo "${{ github.repository }}" \
-            --label "server-health" \
-            --state open \
-            --json number \
-            --jq '.[0].number // empty')
-
-          if [ -n "$ISSUE" ]; then
-            TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
-            gh issue comment "$ISSUE" \
-              --repo "${{ github.repository }}" \
-              --body "[Dead-man-switch] ${TIMESTAMP}: All clear — wiki-server healthy, groundskeeper active. Auto-closing."
-            gh issue close "$ISSUE" \
-              --repo "${{ github.repository }}"
-          fi
+          TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          pnpm crux linear monitor resolve \
+            --title="Wiki server dead-man-switch alert" \
+            --comment="[Dead-man-switch] ${TIMESTAMP}: All clear — wiki-server healthy, groundskeeper active. Auto-closing."

--- a/.github/workflows/server-health-monitor.yml
+++ b/.github/workflows/server-health-monitor.yml
@@ -14,9 +14,17 @@ on:
     - cron: "0 6 * * 1" # every Monday at 06:00 UTC
   workflow_dispatch:
 
+# Existing concurrency block already serializes runs of this workflow.
+# After QUA-970 the auto-filer is `crux linear monitor upsert` instead of
+# `gh issue create`, but the race-prevention motivation is identical.
 concurrency:
   group: server-health-monitor
   cancel-in-progress: false
+
+# Least-privilege: post-QUA-970 the workflow writes to Linear (off-GitHub),
+# so the default GITHUB_TOKEN only needs read access for actions/checkout.
+permissions:
+  contents: read
 
 jobs:
   paused-notice:
@@ -33,12 +41,6 @@ jobs:
     needs: [preflight]
     name: Verify monitoring is active
     runs-on: ubuntu-latest
-    # `issues: write` is no longer needed (Linear-first under QUA-970), but
-    # it's a default-deny scope on this token and harmless to leave; removing
-    # it costs a force-pause incident (e.g. if a future revert needs to
-    # re-enable GH filing temporarily).
-    permissions:
-      issues: write
 
     steps:
       # Checkout + pnpm setup are needed for `pnpm crux linear monitor`

--- a/crux/commands/__tests__/linear-monitor.test.ts
+++ b/crux/commands/__tests__/linear-monitor.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Tests for `crux linear monitor` (QUA-970).
+ *
+ * Verifies the upsert/resolve actions used by render-monitor and
+ * server-health-monitor workflows. These were previously bash `gh issue
+ * create` calls; the migration moves them to Linear-first filing with the
+ * project set so tickets aren't orphaned.
+ *
+ * Test surface:
+ *   upsert
+ *     - existing open match → comments, exit 0
+ *     - no match → resolves project + creates, exit 0
+ *     - project missing → exit 1, no create attempted
+ *     - project archived/completed → exit 1, no create attempted
+ *     - malformed Linear create response (missing identifier/url) → exit 1
+ *     - oldest open ticket wins when multiple match (concurrent runs converge)
+ *     - missing required flags → exit 1 with usage message
+ *   resolve
+ *     - no open match → no-op, exit 0
+ *     - one open match → comment + close, exit 0
+ *     - multiple open matches → close all in parallel, partial-success reported
+ *     - missing comment → close without commenting (comment is optional)
+ *     - missing title → exit 1
+ *
+ * Each test injects a `__deps` mock instead of hitting Linear, so these
+ * are pure unit tests with no network dependency.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { writeFileSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { monitor, type MonitorDeps } from '../linear-monitor.ts';
+import type { SearchedIssue } from '../../lib/linear/issues.ts';
+
+const TITLE = 'Render quality regression detected';
+const BODY = '## Render audit failed\n\nDetail here.';
+const PROJECT = 'Dashboards & Visibility';
+
+function makeIssue(overrides: Partial<SearchedIssue> = {}): SearchedIssue {
+  return {
+    identifier: 'QUA-500',
+    title: TITLE,
+    priority: 0,
+    state: { name: 'Backlog', type: 'backlog' },
+    url: 'https://linear.app/q/issue/QUA-500',
+    createdAt: '2026-04-30T00:00:00.000Z',
+    updatedAt: '2026-04-30T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<MonitorDeps> = {}): MonitorDeps {
+  return {
+    search: vi.fn().mockResolvedValue([]),
+    comment: vi.fn().mockResolvedValue(undefined),
+    create: vi.fn().mockResolvedValue({ identifier: 'QUA-9999', url: 'https://linear.app/q/issue/QUA-9999' }),
+    setState: vi.fn().mockResolvedValue(undefined),
+    getProject: vi.fn().mockResolvedValue({ id: 'project-uuid-aaaa', name: PROJECT, state: 'started' }),
+    ...overrides,
+  };
+}
+
+describe('crux linear monitor — upsert', () => {
+  it('comments on the oldest open match instead of creating a new ticket', async () => {
+    const deps = makeDeps({
+      search: vi.fn().mockResolvedValue([
+        makeIssue({ identifier: 'QUA-555' }),
+        makeIssue({ identifier: 'QUA-500' }),
+        makeIssue({ identifier: 'QUA-700' }),
+      ]),
+    });
+
+    const result = await monitor(['upsert'], {
+      title: TITLE,
+      body: BODY,
+      project: PROJECT,
+      __deps: deps,
+    });
+
+    expect(result.exitCode).toBe(0);
+    // Oldest (QUA-500) wins — concurrent monitor runs converge.
+    expect(deps.comment).toHaveBeenCalledWith('QUA-500', BODY);
+    expect(deps.create).not.toHaveBeenCalled();
+  });
+
+  it('filters out title near-matches (Linear search is token-based)', async () => {
+    // Linear's full-text search returns tokens-overlap results too. The
+    // upsert command must filter to EXACT title match before deciding what
+    // to do — otherwise an unrelated ticket with similar words gets
+    // commented on or, worse, dedup-blocks the real ticket from being filed.
+    const deps = makeDeps({
+      search: vi.fn().mockResolvedValue([
+        makeIssue({ identifier: 'QUA-555', title: 'Render quality investigation: auto-update' }),
+      ]),
+    });
+
+    const result = await monitor(['upsert'], {
+      title: TITLE,
+      body: BODY,
+      project: PROJECT,
+      __deps: deps,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.comment).not.toHaveBeenCalled();
+    expect(deps.create).toHaveBeenCalled();
+  });
+
+  it('skips closed tickets when picking a comment target', async () => {
+    // Closed tickets must NOT be commented on; we want a brand-new ticket
+    // when every prior match is closed.
+    const deps = makeDeps({
+      search: vi.fn().mockResolvedValue([
+        makeIssue({ identifier: 'QUA-500', state: { name: 'Done', type: 'completed' } }),
+      ]),
+    });
+
+    const result = await monitor(['upsert'], {
+      title: TITLE,
+      body: BODY,
+      project: PROJECT,
+      __deps: deps,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.comment).not.toHaveBeenCalled();
+    expect(deps.create).toHaveBeenCalled();
+  });
+
+  it('creates a new ticket with the resolved project when no open match exists', async () => {
+    const deps = makeDeps();
+
+    const result = await monitor(['upsert'], {
+      title: TITLE,
+      body: BODY,
+      project: PROJECT,
+      __deps: deps,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.getProject).toHaveBeenCalledWith(PROJECT);
+    expect(deps.create).toHaveBeenCalledWith({
+      title: TITLE,
+      description: BODY,
+      projectId: 'project-uuid-aaaa',
+    });
+  });
+
+  it('refuses with exit 1 when the project does not resolve', async () => {
+    // Rename detection. Don't file orphans silently.
+    const deps = makeDeps({ getProject: vi.fn().mockResolvedValue(null) });
+
+    const result = await monitor(['upsert'], {
+      title: TITLE,
+      body: BODY,
+      project: PROJECT,
+      __deps: deps,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(deps.create).not.toHaveBeenCalled();
+  });
+
+  it('refuses with exit 1 when the project is archived (state=completed)', async () => {
+    // Filing into an archived project produces invisible tickets.
+    const deps = makeDeps({
+      getProject: vi.fn().mockResolvedValue({ id: 'p', name: PROJECT, state: 'completed' }),
+    });
+
+    const result = await monitor(['upsert'], {
+      title: TITLE,
+      body: BODY,
+      project: PROJECT,
+      __deps: deps,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(deps.create).not.toHaveBeenCalled();
+  });
+
+  it('refuses with exit 1 when Linear create returns malformed response', async () => {
+    const deps = makeDeps({
+      create: vi.fn().mockResolvedValue({ identifier: undefined, url: undefined }),
+    });
+
+    const result = await monitor(['upsert'], {
+      title: TITLE,
+      body: BODY,
+      project: PROJECT,
+      __deps: deps,
+    });
+
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('reads body from --body-file when --body is omitted', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'linear-monitor-test-'));
+    const path = join(tmp, 'body.md');
+    writeFileSync(path, BODY, 'utf-8');
+
+    const deps = makeDeps();
+
+    const result = await monitor(['upsert'], {
+      title: TITLE,
+      bodyFile: path,
+      project: PROJECT,
+      __deps: deps,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.create).toHaveBeenCalledWith(
+      expect.objectContaining({ description: BODY }),
+    );
+  });
+
+  it('refuses with exit 1 when --title is missing', async () => {
+    const deps = makeDeps();
+    const result = await monitor(['upsert'], { body: BODY, project: PROJECT, __deps: deps });
+    expect(result.exitCode).toBe(1);
+    expect(deps.create).not.toHaveBeenCalled();
+  });
+
+  it('refuses with exit 1 when --project is missing', async () => {
+    const deps = makeDeps();
+    const result = await monitor(['upsert'], { title: TITLE, body: BODY, __deps: deps });
+    expect(result.exitCode).toBe(1);
+    expect(deps.create).not.toHaveBeenCalled();
+  });
+
+  it('refuses with exit 1 when neither --body nor --body-file is provided', async () => {
+    const deps = makeDeps();
+    const result = await monitor(['upsert'], { title: TITLE, project: PROJECT, __deps: deps });
+    expect(result.exitCode).toBe(1);
+    expect(deps.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('crux linear monitor — resolve', () => {
+  it('returns no-op exit 0 when there are no matching open tickets', async () => {
+    const deps = makeDeps();
+
+    const result = await monitor(['resolve'], { title: TITLE, comment: 'All clear', __deps: deps });
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.setState).not.toHaveBeenCalled();
+    expect(deps.comment).not.toHaveBeenCalled();
+  });
+
+  it('comments + closes a single matching open ticket', async () => {
+    const deps = makeDeps({
+      search: vi.fn().mockResolvedValue([makeIssue({ identifier: 'QUA-500' })]),
+    });
+
+    const result = await monitor(['resolve'], { title: TITLE, comment: 'All clear', __deps: deps });
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.comment).toHaveBeenCalledWith('QUA-500', 'All clear');
+    expect(deps.setState).toHaveBeenCalledWith('QUA-500', 'Done');
+  });
+
+  it('closes without commenting when --comment is omitted', async () => {
+    const deps = makeDeps({
+      search: vi.fn().mockResolvedValue([makeIssue({ identifier: 'QUA-500' })]),
+    });
+
+    const result = await monitor(['resolve'], { title: TITLE, __deps: deps });
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.comment).not.toHaveBeenCalled();
+    expect(deps.setState).toHaveBeenCalledWith('QUA-500', 'Done');
+  });
+
+  it('closes every matching open ticket in parallel', async () => {
+    // Multiple concurrent monitor runs occasionally race and produce
+    // duplicates. Resolve should sweep all of them, not just one.
+    const deps = makeDeps({
+      search: vi.fn().mockResolvedValue([
+        makeIssue({ identifier: 'QUA-500' }),
+        makeIssue({ identifier: 'QUA-501' }),
+      ]),
+    });
+
+    const result = await monitor(['resolve'], { title: TITLE, __deps: deps });
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.setState).toHaveBeenCalledWith('QUA-500', 'Done');
+    expect(deps.setState).toHaveBeenCalledWith('QUA-501', 'Done');
+  });
+
+  it('reports partial failures via exit 1 but keeps the successful closes', async () => {
+    const setState = vi
+      .fn()
+      .mockResolvedValueOnce(undefined) // QUA-500 succeeds
+      .mockRejectedValueOnce(new Error('Linear 500')); // QUA-501 fails
+    const deps = makeDeps({
+      search: vi.fn().mockResolvedValue([
+        makeIssue({ identifier: 'QUA-500' }),
+        makeIssue({ identifier: 'QUA-501' }),
+      ]),
+      setState,
+    });
+
+    const result = await monitor(['resolve'], { title: TITLE, __deps: deps });
+
+    expect(result.exitCode).toBe(1);
+    // Both attempts happened — partial failure shouldn't abort the sweep.
+    expect(setState).toHaveBeenCalledTimes(2);
+  });
+
+  it('refuses with exit 1 when --title is missing', async () => {
+    const deps = makeDeps();
+    const result = await monitor(['resolve'], { __deps: deps });
+    expect(result.exitCode).toBe(1);
+    expect(deps.setState).not.toHaveBeenCalled();
+  });
+
+  it('does not match closed tickets (only open ones get resolved)', async () => {
+    // Already-closed tickets must not be re-closed — that would post a
+    // misleading comment and a no-op state transition.
+    const deps = makeDeps({
+      search: vi.fn().mockResolvedValue([
+        makeIssue({ identifier: 'QUA-500', state: { name: 'Done', type: 'completed' } }),
+      ]),
+    });
+
+    const result = await monitor(['resolve'], { title: TITLE, comment: 'All clear', __deps: deps });
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.setState).not.toHaveBeenCalled();
+  });
+
+  it('returns JSON output with --json flag', async () => {
+    const deps = makeDeps({
+      search: vi.fn().mockResolvedValue([makeIssue({ identifier: 'QUA-500' })]),
+    });
+
+    const result = await monitor(['resolve'], { title: TITLE, json: true, __deps: deps });
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    expect(parsed).toEqual({
+      action: 'resolved',
+      closed: ['QUA-500'],
+      failed: [],
+    });
+  });
+});
+
+describe('crux linear monitor — dispatch', () => {
+  it('returns help when called with no subcommand', async () => {
+    const result = await monitor([], {});
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Usage: crux linear monitor');
+  });
+
+  it('returns help with exit 0 when called with explicit help', async () => {
+    const result = await monitor(['help'], {});
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('Usage: crux linear monitor');
+  });
+
+  it('returns exit 1 on unknown subcommand', async () => {
+    const result = await monitor(['fishbowl'], {});
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Unknown subcommand');
+  });
+
+  it('accepts `up` as an alias for `upsert`', async () => {
+    const deps = makeDeps();
+    const result = await monitor(['up'], {
+      title: TITLE,
+      body: BODY,
+      project: PROJECT,
+      __deps: deps,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(deps.create).toHaveBeenCalled();
+  });
+
+  it('accepts `down` as an alias for `resolve`', async () => {
+    const deps = makeDeps();
+    const result = await monitor(['down'], { title: TITLE, __deps: deps });
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/crux/commands/__tests__/linear-monitor.test.ts
+++ b/crux/commands/__tests__/linear-monitor.test.ts
@@ -235,6 +235,43 @@ describe('crux linear monitor — upsert', () => {
     expect(result.exitCode).toBe(1);
     expect(deps.create).not.toHaveBeenCalled();
   });
+
+  it('refuses with exit 1 and a friendly message when --body-file does not exist', async () => {
+    // Bare readFileSync would throw and bubble a stack trace; the command
+    // catches it and surfaces a structured error.
+    const deps = makeDeps();
+    const result = await monitor(['upsert'], {
+      title: TITLE,
+      bodyFile: '/tmp/this-path-definitely-does-not-exist-12345',
+      project: PROJECT,
+      __deps: deps,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Failed to read --body-file');
+    expect(deps.create).not.toHaveBeenCalled();
+  });
+
+  it('matches titles case-insensitively and ignores leading/trailing whitespace', async () => {
+    // A human renaming the canonical ticket to fix capitalization or
+    // accidentally adding whitespace must not fragment the dedup. The
+    // existing ticket is found and commented on, no duplicate is created.
+    const deps = makeDeps({
+      search: vi.fn().mockResolvedValue([
+        makeIssue({ identifier: 'QUA-500', title: '  RENDER QUALITY REGRESSION DETECTED  ' }),
+      ]),
+    });
+
+    const result = await monitor(['upsert'], {
+      title: TITLE,
+      body: BODY,
+      project: PROJECT,
+      __deps: deps,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.comment).toHaveBeenCalledWith('QUA-500', BODY);
+    expect(deps.create).not.toHaveBeenCalled();
+  });
 });
 
 describe('crux linear monitor — resolve', () => {

--- a/crux/commands/linear-monitor.ts
+++ b/crux/commands/linear-monitor.ts
@@ -1,0 +1,280 @@
+/**
+ * `crux linear monitor` — upsert / resolve a Linear ticket by exact title.
+ *
+ * Used by automated monitor pipelines (render-monitor, server-health) that
+ * previously filed GitHub issues directly. Linear-first under QUA-970 so
+ * tickets land with their correct project instead of as orphans via the
+ * GitHub-mirror sync.
+ *
+ * Two operations, one command:
+ *
+ *   upsert   On failure: comment on the open ticket with this title if one
+ *            exists; otherwise create a new ticket under --project.
+ *   resolve  On recovery: comment + close every open ticket with this title.
+ *
+ * Title-match semantics:
+ *   - Exact case-sensitive title match against Linear search results.
+ *     Linear's free-text search is token-based, so we filter the response.
+ *   - Title is the dedup key. Pick a stable title for your monitor and put
+ *     varying detail (timestamp, status, run URL) in the body.
+ *
+ * No GitHub fallback. If Linear is unreachable, the workflow step fails and
+ * the next scheduled run picks it up. The wellness check has GH fallback
+ * because it runs every few minutes; render/server-health run weekly or
+ * 6-hourly so a single missed alert is not a coverage gap.
+ */
+
+import { readFileSync } from 'fs';
+
+import {
+  searchIssues,
+  commentOnIssue,
+  createIssue,
+  updateIssueState,
+  type SearchedIssue,
+} from '../lib/linear/issues.ts';
+import { getProject } from '../lib/linear/projects.ts';
+import { isOpenStateType } from '../lib/linear/workflow-states.ts';
+import { createLogger } from '../lib/output.ts';
+import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
+
+interface MonitorOptions extends CommandOptions {
+  ci?: boolean;
+  json?: boolean;
+  title?: string;
+  body?: string;
+  bodyFile?: string;
+  description?: string;
+  comment?: string;
+  project?: string;
+  /**
+   * Override the underlying Linear client functions (used by tests). Not a
+   * CLI flag — only injected from `monitor()` callers in the test suite.
+   */
+  __deps?: MonitorDeps;
+}
+
+export interface MonitorDeps {
+  search: typeof searchIssues;
+  comment: typeof commentOnIssue;
+  create: typeof createIssue;
+  setState: typeof updateIssueState;
+  getProject: typeof getProject;
+}
+
+const DEFAULT_DEPS: MonitorDeps = {
+  search: searchIssues,
+  comment: commentOnIssue,
+  create: createIssue,
+  setState: updateIssueState,
+  getProject,
+};
+
+const HELP = `Usage: crux linear monitor <upsert|resolve> [options]
+
+  upsert   --title=<exact-title> --project=<name>
+           [--body=<text> | --body-file=<path>]
+           Comment on an existing open ticket with this exact title, or
+           create a new one in <project> if none exists. Body content is
+           used as the create-time description AND the comment-on-existing
+           message.
+
+  resolve  --title=<exact-title> [--comment=<message>]
+           Comment + close every open ticket with this exact title.
+           No-op if none are open. The optional --comment is posted before
+           the close.
+
+The title is the dedup key — pick a stable string per monitor. Vary detail
+(timestamps, status codes, run URLs) inside the body, not the title.
+`;
+
+function readBody(options: MonitorOptions): string | null {
+  if (options.bodyFile) {
+    return readFileSync(options.bodyFile, 'utf-8');
+  }
+  if (options.body) {
+    return options.body;
+  }
+  return null;
+}
+
+function pickOldestOpen(matches: SearchedIssue[]): SearchedIssue | null {
+  // Mirrors the wellness convention: keep the oldest open ticket as the
+  // canonical one so concurrent runs converge on the same dedup target.
+  // Sort by identifier suffix (QUA-NNN where lower = older).
+  const open = matches.filter((m) => isOpenStateType(m.state.type));
+  if (open.length === 0) return null;
+  open.sort((a, b) => {
+    const an = Number(a.identifier.match(/^QUA-(\d+)$/)?.[1] ?? 0);
+    const bn = Number(b.identifier.match(/^QUA-(\d+)$/)?.[1] ?? 0);
+    return an - bn;
+  });
+  return open[0];
+}
+
+async function upsertCommand(
+  options: MonitorOptions,
+): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+  const deps = options.__deps ?? DEFAULT_DEPS;
+
+  if (!options.title) {
+    return { output: `${c.red}--title is required${c.reset}\n${HELP}`, exitCode: 1 };
+  }
+  if (!options.project) {
+    return { output: `${c.red}--project is required${c.reset}\n${HELP}`, exitCode: 1 };
+  }
+  const body = readBody(options);
+  if (!body) {
+    return { output: `${c.red}--body or --body-file is required${c.reset}\n${HELP}`, exitCode: 1 };
+  }
+
+  const title = options.title;
+
+  // 1. Search Linear for existing tickets with this exact title.
+  const candidates = (await deps.search(title, 20)).filter((r) => r.title === title);
+  const existing = pickOldestOpen(candidates);
+
+  if (existing) {
+    // Comment on the existing open ticket. Failure here is an actual problem
+    // (Linear is up, the ticket is open, but the comment refused) — surface
+    // it with a non-zero exit so the workflow step fails loudly.
+    await deps.comment(existing.identifier, body);
+    if (options.json) {
+      return {
+        output: JSON.stringify({ action: 'commented', identifier: existing.identifier, url: existing.url }) + '\n',
+        exitCode: 0,
+      };
+    }
+    return {
+      output: `${c.green}✓${c.reset} Commented on existing ${c.cyan}${existing.identifier}${c.reset}\n  ${existing.url}\n`,
+      exitCode: 0,
+    };
+  }
+
+  // 2. No open match — create a new ticket. Resolve the project first so
+  // we fail loudly on a project rename instead of filing a projectless
+  // orphan (the exact failure mode QUA-824 documented).
+  const project = await deps.getProject(options.project);
+  if (!project) {
+    return {
+      output: `${c.red}Project "${options.project}" not found in Linear.${c.reset}\n  Run ${c.cyan}crux linear project list${c.reset} to see available projects.\n`,
+      exitCode: 1,
+    };
+  }
+  if (project.state === 'completed' || project.state === 'canceled') {
+    return {
+      output: `${c.red}Project "${options.project}" is in state "${project.state}" — refusing to file into an archived/closed project. Pick a live project or unarchive.${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const created = await deps.create({
+    title,
+    description: body,
+    projectId: project.id,
+  });
+
+  if (!created.identifier || !created.url) {
+    // Defensive: Linear's issueCreate mutation can return success with a
+    // malformed payload. Treat as an error so the workflow rerun retries.
+    return {
+      output: `${c.red}Linear createIssue returned a malformed response (missing identifier or url).${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  if (options.json) {
+    return {
+      output: JSON.stringify({ action: 'created', identifier: created.identifier, url: created.url }) + '\n',
+      exitCode: 0,
+    };
+  }
+  return {
+    output: `${c.green}✓${c.reset} Created ${c.cyan}${created.identifier}${c.reset} in project ${c.cyan}${options.project}${c.reset}\n  ${created.url}\n`,
+    exitCode: 0,
+  };
+}
+
+async function resolveCommand(
+  options: MonitorOptions,
+): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+  const deps = options.__deps ?? DEFAULT_DEPS;
+
+  if (!options.title) {
+    return { output: `${c.red}--title is required${c.reset}\n${HELP}`, exitCode: 1 };
+  }
+
+  const title = options.title;
+  const candidates = (await deps.search(title, 20))
+    .filter((r) => r.title === title && isOpenStateType(r.state.type));
+
+  if (candidates.length === 0) {
+    if (options.json) {
+      return { output: JSON.stringify({ action: 'none', closed: [] }) + '\n', exitCode: 0 };
+    }
+    return { output: `No open tickets matching "${title}" — nothing to resolve.\n`, exitCode: 0 };
+  }
+
+  // Close in parallel; partial failures are reported but don't fail the whole
+  // operation. The next run will catch any stragglers.
+  const results = await Promise.allSettled(
+    candidates.map(async (issue) => {
+      if (options.comment) {
+        await deps.comment(issue.identifier, options.comment);
+      }
+      await deps.setState(issue.identifier, 'Done');
+      return issue.identifier;
+    }),
+  );
+  const closed: string[] = [];
+  const failed: Array<{ identifier: string; error: string }> = [];
+  results.forEach((r, i) => {
+    if (r.status === 'fulfilled') {
+      closed.push(r.value);
+    } else {
+      const error = r.reason instanceof Error ? r.reason.message : String(r.reason);
+      failed.push({ identifier: candidates[i].identifier, error });
+    }
+  });
+
+  if (options.json) {
+    return {
+      output: JSON.stringify({ action: 'resolved', closed, failed }) + '\n',
+      exitCode: failed.length > 0 ? 1 : 0,
+    };
+  }
+
+  let out = '';
+  for (const id of closed) {
+    out += `${c.green}✓${c.reset} Closed ${c.cyan}${id}${c.reset}\n`;
+  }
+  for (const f of failed) {
+    out += `${c.red}✗${c.reset} ${f.identifier}: ${f.error}\n`;
+  }
+  return { output: out, exitCode: failed.length > 0 ? 1 : 0 };
+}
+
+/** `crux linear monitor` entry point. */
+export async function monitor(
+  args: string[],
+  options: MonitorOptions,
+): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const sub = args[0];
+
+  if (!sub || sub === 'help' || sub === '--help') {
+    return { output: HELP, exitCode: sub ? 0 : 1 };
+  }
+
+  if (sub === 'upsert' || sub === 'up') return upsertCommand(options);
+  if (sub === 'resolve' || sub === 'down') return resolveCommand(options);
+
+  return {
+    output: `${log.colors.red}Unknown subcommand: ${sub}${log.colors.reset}\n${HELP}`,
+    exitCode: 1,
+  };
+}

--- a/crux/commands/linear-monitor.ts
+++ b/crux/commands/linear-monitor.ts
@@ -88,14 +88,30 @@ The title is the dedup key — pick a stable string per monitor. Vary detail
 (timestamps, status codes, run URLs) inside the body, not the title.
 `;
 
-function readBody(options: MonitorOptions): string | null {
+function readBody(options: MonitorOptions): string | { error: string } {
   if (options.bodyFile) {
-    return readFileSync(options.bodyFile, 'utf-8');
+    try {
+      return readFileSync(options.bodyFile, 'utf-8');
+    } catch (err) {
+      return { error: `Failed to read --body-file=${options.bodyFile}: ${err instanceof Error ? err.message : String(err)}` };
+    }
   }
   if (options.body) {
     return options.body;
   }
-  return null;
+  return { error: '--body or --body-file is required' };
+}
+
+/**
+ * Normalize a title for matching purposes. Trim leading/trailing whitespace
+ * and lowercase to make matches resilient to common manual edits — a human
+ * renaming "Render quality regression detected" → " Render quality
+ * regression detected " or "render quality regression detected" must not
+ * fragment the dedup. Linear titles preserve display case, so this only
+ * affects the match comparison, not what gets stored.
+ */
+function normalizeTitle(title: string): string {
+  return title.trim().toLowerCase();
 }
 
 function pickOldestOpen(matches: SearchedIssue[]): SearchedIssue | null {
@@ -112,6 +128,13 @@ function pickOldestOpen(matches: SearchedIssue[]): SearchedIssue | null {
   return open[0];
 }
 
+function preflightApiKey(): string | null {
+  if (!process.env.LINEAR_API_KEY) {
+    return 'LINEAR_API_KEY is not set in the environment. Set it before invoking `crux linear monitor`.';
+  }
+  return null;
+}
+
 async function upsertCommand(
   options: MonitorOptions,
 ): Promise<CommandResult> {
@@ -126,14 +149,27 @@ async function upsertCommand(
     return { output: `${c.red}--project is required${c.reset}\n${HELP}`, exitCode: 1 };
   }
   const body = readBody(options);
-  if (!body) {
-    return { output: `${c.red}--body or --body-file is required${c.reset}\n${HELP}`, exitCode: 1 };
+  if (typeof body !== 'string') {
+    return { output: `${c.red}${body.error}${c.reset}\n${HELP}`, exitCode: 1 };
+  }
+  // Skip preflight when deps are injected (tests). The default deps go
+  // through the real Linear client, which reads LINEAR_API_KEY at call time.
+  if (!options.__deps) {
+    const preflightError = preflightApiKey();
+    if (preflightError) {
+      return { output: `${c.red}${preflightError}${c.reset}\n`, exitCode: 1 };
+    }
   }
 
   const title = options.title;
+  const normTitle = normalizeTitle(title);
 
-  // 1. Search Linear for existing tickets with this exact title.
-  const candidates = (await deps.search(title, 20)).filter((r) => r.title === title);
+  // 1. Search Linear for existing tickets with this exact title (case-
+  //    insensitive, trimmed). Linear's search is token-based, so the post-
+  //    filter is required to avoid acting on near-matches.
+  const candidates = (await deps.search(title, 20)).filter(
+    (r) => normalizeTitle(r.title) === normTitle,
+  );
   const existing = pickOldestOpen(candidates);
 
   if (existing) {
@@ -207,10 +243,17 @@ async function resolveCommand(
   if (!options.title) {
     return { output: `${c.red}--title is required${c.reset}\n${HELP}`, exitCode: 1 };
   }
+  if (!options.__deps) {
+    const preflightError = preflightApiKey();
+    if (preflightError) {
+      return { output: `${c.red}${preflightError}${c.reset}\n`, exitCode: 1 };
+    }
+  }
 
   const title = options.title;
+  const normTitle = normalizeTitle(title);
   const candidates = (await deps.search(title, 20))
-    .filter((r) => r.title === title && isOpenStateType(r.state.type));
+    .filter((r) => normalizeTitle(r.title) === normTitle && isOpenStateType(r.state.type));
 
   if (candidates.length === 0) {
     if (options.json) {

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -66,6 +66,7 @@ import { currentBranch } from '../lib/session/session-checklist.ts';
 import { buildStartCommentBody, getSessionContext } from '../lib/session/session-context.ts';
 import { execSync, execFileSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
+import { monitor } from './linear-monitor.ts';
 
 interface CommandOptions extends BaseOptions {
   ci?: boolean;
@@ -1349,6 +1350,7 @@ export const commands = {
   'states-list': statesList,
   parse,
   project,
+  monitor,
 };
 
 export function getHelp(): string {
@@ -1365,6 +1367,7 @@ Commands:
   done <QUA-NNN> [--pr=URL]     Move to In Review (with PR) or Done, post comment
   audit                         Classify active issues (In Progress + In Review) by PR health
   hygiene                       Metadata hygiene scan: orphans, label coverage, priority gaps, stuck tickets
+  monitor <upsert|resolve>      Upsert or close a Linear ticket by exact title (used by automated monitors — render-monitor, server-health-monitor)
   release-stale                 Auto-release tickets whose agent session went stale without producing a branch (QUA-815)
   verify-pr <PR>                Watchdog: ensure merged PR's Fixes QUA-NNN issues are actually Done
   leak-check                    Scan current session for QUA refs beyond the primary; warn about leaks

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -852,7 +852,12 @@ async function main(): Promise<void> {
         : undefined;
 
       const issueResult = await manageWellnessIssue(report, { runUrl });
-      console.log(`\nIssue management: ${issueResult.action}${issueResult.issueNumber ? ` (#${issueResult.issueNumber})` : ''}`);
+      const issueRef = issueResult.issueNumber
+        ? ` (#${issueResult.issueNumber})`
+        : issueResult.linearIdentifier
+          ? ` (${issueResult.linearIdentifier})`
+          : '';
+      console.log(`\nIssue management: ${issueResult.action}${issueRef}`);
     }
   } else {
     const allOk = results.every((r) => r.ok);

--- a/crux/health/wellness-linear-dedup.test.ts
+++ b/crux/health/wellness-linear-dedup.test.ts
@@ -564,4 +564,40 @@ describe('createLinearWellnessIssue (QUA-970)', () => {
     if (result.kind === 'failed') expect(result.reason).toBe('api-error');
     expect(createIssue).not.toHaveBeenCalled();
   });
+
+  it('returns failed/api-error when createIssue resolves with a malformed shape (missing identifier/url)', async () => {
+    // Linear's issueCreate mutation returns `success: true` even with an
+    // empty issue payload in some failure modes. Without this guard the
+    // caller would record a "Linear ticket created" with `identifier:undefined`,
+    // hiding the failure. Treat missing identifier/url as api-error so the
+    // resilience fallback fires.
+    const getProject = vi
+      .fn()
+      .mockResolvedValue({ id: 'project-uuid-aaaa', name: WELLNESS_PROJECT_NAME });
+    // Deliberately malformed payload — exercises the response-shape guard
+    // in createLinearWellnessIssue. vi.fn() is loosely typed so the cast
+    // through the returned Mock is enough to satisfy the createIssue signature.
+    const createIssue = vi.fn().mockResolvedValue({ identifier: undefined, url: undefined });
+
+    const result = await createLinearWellnessIssue(TITLE, BODY, { getProject, createIssue });
+
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') expect(result.reason).toBe('api-error');
+  });
+
+  it('returns failed/project-missing when the project is in a non-active state (archived/completed)', async () => {
+    // A renamed-then-archived project would still resolve by name; filing
+    // into it produces tickets that are invisible in default views and
+    // defeats the migration. Defensive guard against that case.
+    const getProject = vi
+      .fn()
+      .mockResolvedValue({ id: 'project-uuid-aaaa', name: WELLNESS_PROJECT_NAME, state: 'completed' });
+    const createIssue = vi.fn();
+
+    const result = await createLinearWellnessIssue(TITLE, BODY, { getProject, createIssue });
+
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') expect(result.reason).toBe('project-missing');
+    expect(createIssue).not.toHaveBeenCalled();
+  });
 });

--- a/crux/health/wellness-linear-dedup.test.ts
+++ b/crux/health/wellness-linear-dedup.test.ts
@@ -19,9 +19,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   dedupLinearWellnessIssue,
+  createLinearWellnessIssue,
   closeLinearWellnessOnAllClear,
   isMissingLinearApiKeyError,
   REOPEN_WINDOW_MS,
+  WELLNESS_PROJECT_NAME,
 } from './wellness-linear-dedup.ts';
 import type { SearchedIssue } from '../lib/linear/issues.ts';
 
@@ -468,5 +470,98 @@ describe('isMissingLinearApiKeyError', () => {
     // the err.message access. The String(err) fallback covers it.
     expect(isMissingLinearApiKeyError('LINEAR_API_KEY not set in env')).toBe(true);
     expect(isMissingLinearApiKeyError({ toString: () => 'LINEAR_API_KEY not set yo' })).toBe(true);
+  });
+});
+
+describe('createLinearWellnessIssue (QUA-970)', () => {
+  const BODY = '## Wellness check failed\n\nSee details below.';
+
+  it('creates a Linear ticket with the wellness project', async () => {
+    const getProject = vi
+      .fn()
+      .mockResolvedValue({ id: 'project-uuid-aaaa', name: WELLNESS_PROJECT_NAME });
+    const createIssue = vi
+      .fn()
+      .mockResolvedValue({ identifier: 'QUA-9999', url: 'https://linear.app/q/issue/QUA-9999' });
+
+    const result = await createLinearWellnessIssue(TITLE, BODY, { getProject, createIssue });
+
+    expect(result).toEqual({
+      kind: 'created',
+      identifier: 'QUA-9999',
+      url: 'https://linear.app/q/issue/QUA-9999',
+    });
+    // Project lookup is the load-bearing piece — without it we'd file a
+    // projectless orphan, which is exactly the leak this migration closes.
+    expect(getProject).toHaveBeenCalledWith(WELLNESS_PROJECT_NAME);
+    expect(createIssue).toHaveBeenCalledWith({
+      title: TITLE,
+      description: BODY,
+      projectId: 'project-uuid-aaaa',
+    });
+  });
+
+  it('returns failed/misconfig when LINEAR_API_KEY is missing during project lookup', async () => {
+    const apiKeyError = new Error('LINEAR_API_KEY not set. Required for Linear API calls.');
+    const getProject = vi.fn().mockRejectedValue(apiKeyError);
+    const createIssue = vi.fn();
+
+    const result = await createLinearWellnessIssue(TITLE, BODY, { getProject, createIssue });
+
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') expect(result.reason).toBe('misconfig');
+    // Critical: the create call must NOT have been attempted without a valid key.
+    expect(createIssue).not.toHaveBeenCalled();
+  });
+
+  it('returns failed/misconfig when LINEAR_API_KEY is missing during create call', async () => {
+    // Possible if the project lookup is mocked or cached but the create still hits the API.
+    const apiKeyError = new Error('LINEAR_API_KEY not set');
+    const getProject = vi
+      .fn()
+      .mockResolvedValue({ id: 'project-uuid-aaaa', name: WELLNESS_PROJECT_NAME });
+    const createIssue = vi.fn().mockRejectedValue(apiKeyError);
+
+    const result = await createLinearWellnessIssue(TITLE, BODY, { getProject, createIssue });
+
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') expect(result.reason).toBe('misconfig');
+  });
+
+  it('returns failed/project-missing when the project name does not resolve', async () => {
+    // Exercises the rename-detection path — if someone renames the project in
+    // Linear, we surface it loudly instead of silently filing a projectless
+    // ticket. The fallback behavior in the caller is to drop to GitHub.
+    const getProject = vi.fn().mockResolvedValue(null);
+    const createIssue = vi.fn();
+
+    const result = await createLinearWellnessIssue(TITLE, BODY, { getProject, createIssue });
+
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') expect(result.reason).toBe('project-missing');
+    expect(createIssue).not.toHaveBeenCalled();
+  });
+
+  it('returns failed/api-error on a transient Linear outage during create', async () => {
+    const getProject = vi
+      .fn()
+      .mockResolvedValue({ id: 'project-uuid-aaaa', name: WELLNESS_PROJECT_NAME });
+    const createIssue = vi.fn().mockRejectedValue(new Error('Linear 503'));
+
+    const result = await createLinearWellnessIssue(TITLE, BODY, { getProject, createIssue });
+
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') expect(result.reason).toBe('api-error');
+  });
+
+  it('returns failed/api-error on a transient Linear outage during project lookup', async () => {
+    const getProject = vi.fn().mockRejectedValue(new Error('Linear 503'));
+    const createIssue = vi.fn();
+
+    const result = await createLinearWellnessIssue(TITLE, BODY, { getProject, createIssue });
+
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') expect(result.reason).toBe('api-error');
+    expect(createIssue).not.toHaveBeenCalled();
   });
 });

--- a/crux/health/wellness-linear-dedup.ts
+++ b/crux/health/wellness-linear-dedup.ts
@@ -314,6 +314,15 @@ export async function createLinearWellnessIssue(
       console.warn(error);
       return { kind: 'failed', reason: 'project-missing', error };
     }
+    // Refuse archived projects: filing into one produces tickets that are
+    // invisible in Linear's default views, defeating the migration. The
+    // operator should rename the live project (or update WELLNESS_PROJECT_NAME)
+    // before this code can resume Linear-first filing.
+    if (project.state === 'completed' || project.state === 'canceled') {
+      const error = `Linear project "${WELLNESS_PROJECT_NAME}" is in state "${project.state}" — falling back to GitHub create. Update WELLNESS_PROJECT_NAME or unarchive the project.`;
+      console.warn(error);
+      return { kind: 'failed', reason: 'project-missing', error };
+    }
     projectId = project.id;
   } catch (err) {
     if (isMissingLinearApiKeyError(err)) {
@@ -331,6 +340,18 @@ export async function createLinearWellnessIssue(
       description: body,
       projectId,
     });
+    // Defensive: Linear's `issueCreate` mutation returns `success: true` even
+    // if the underlying issue payload is missing fields. The wrapping
+    // `createIssue` in lib/linear/issues.ts only checks `success`, so a
+    // malformed shape would leak through as `{identifier:undefined, url:undefined}`
+    // here and the caller would log a confusing "(undefined)" line. Treat
+    // missing identifier/url as an api-error so we drop to GH fallback
+    // instead of pretending we filed a Linear ticket.
+    if (!result.identifier || !result.url) {
+      const error = `Linear createIssue returned malformed response (missing identifier or url)`;
+      console.warn(`${error} — falling back to GitHub create`);
+      return { kind: 'failed', reason: 'api-error', error };
+    }
     return { kind: 'created', identifier: result.identifier, url: result.url };
   } catch (err) {
     if (isMissingLinearApiKeyError(err)) {

--- a/crux/health/wellness-linear-dedup.ts
+++ b/crux/health/wellness-linear-dedup.ts
@@ -28,10 +28,20 @@
 import {
   searchIssues,
   commentOnIssue,
+  createIssue as createLinearIssueRaw,
   updateIssueState,
   type SearchedIssue,
 } from '../lib/linear/issues.ts';
+import { getProject } from '../lib/linear/projects.ts';
 import { isOpenStateType } from '../lib/linear/workflow-states.ts';
+
+/**
+ * Project that owns wellness tickets. Past wellness tickets (QUA-577,
+ * QUA-676, QUA-590, QUA-607) all live here, so new ones land alongside them.
+ * Per `docs/agent-rules/linear-project-ownership.md`, Automation & Infrastructure
+ * owns "scheduled jobs" — wellness checks are scheduled health monitors.
+ */
+export const WELLNESS_PROJECT_NAME = 'Automation & Infrastructure';
 
 /**
  * Window for treating a closed Linear wellness ticket as "still recent
@@ -69,6 +79,14 @@ export interface LinearDedupDeps {
    * for both transitions (Backlog on reopen, Done on all-clear close).
    */
   setState: typeof updateIssueState;
+  /**
+   * Linear issue creation + project lookup, used by the new
+   * `createLinearWellnessIssue` Linear-first path. Bundled into the same
+   * deps interface (rather than its own type) so tests inject one
+   * `linearDedupDeps` object instead of two.
+   */
+  createIssue: typeof createLinearIssueRaw;
+  getProject: typeof getProject;
   now: () => number;
 }
 
@@ -76,6 +94,8 @@ const DEFAULT_DEPS: LinearDedupDeps = {
   search: searchIssues,
   comment: commentOnIssue,
   setState: updateIssueState,
+  createIssue: createLinearIssueRaw,
+  getProject,
   now: Date.now,
 };
 
@@ -257,4 +277,68 @@ export async function closeLinearWellnessOnAllClear(
   });
   if (closed.length > 0) return { kind: 'closed', identifiers: closed };
   return { kind: 'close-failed', attempted: candidates.map((c) => c.identifier) };
+}
+
+export type CreateLinearWellnessResult =
+  | { kind: 'created'; identifier: string; url: string }
+  /** LINEAR_API_KEY missing — caller should fall back to GitHub create with the misconfig banner. */
+  | { kind: 'failed'; reason: 'misconfig'; error: string }
+  /** Project name didn't resolve, OR the create call threw. Caller should fall back to GitHub. */
+  | { kind: 'failed'; reason: 'project-missing' | 'api-error'; error: string };
+
+/**
+ * Create a new Linear wellness ticket (QUA-970). Replaces the legacy GitHub
+ * create path: instead of letting Linear's GitHub-mirror integration produce
+ * an orphan synced ticket, this files directly into Linear with the right
+ * project (so it doesn't show up as orphaned in `crux linear hygiene`).
+ *
+ * Returns a discriminated union so the caller can decide whether to fall
+ * back to GitHub. The fallback path is preserved for resilience: if Linear
+ * is misconfigured or unreachable we still want the alert recorded SOMEWHERE.
+ */
+export async function createLinearWellnessIssue(
+  title: string,
+  body: string,
+  deps: Partial<LinearDedupDeps> = {},
+): Promise<CreateLinearWellnessResult> {
+  const { createIssue, getProject: _getProject } = { ...DEFAULT_DEPS, ...deps };
+
+  let projectId: string;
+  try {
+    const project = await _getProject(WELLNESS_PROJECT_NAME);
+    if (!project) {
+      // Project missing is a config drift on Linear's side, not the same as
+      // a missing API key. Surfaced as a separate reason so the caller logs
+      // it loudly rather than treating it as a transient blip.
+      const error = `Linear project "${WELLNESS_PROJECT_NAME}" not found — has it been renamed? Falling back to GitHub create.`;
+      console.warn(error);
+      return { kind: 'failed', reason: 'project-missing', error };
+    }
+    projectId = project.id;
+  } catch (err) {
+    if (isMissingLinearApiKeyError(err)) {
+      const error = err instanceof Error ? err.message : String(err);
+      return { kind: 'failed', reason: 'misconfig', error };
+    }
+    const error = err instanceof Error ? err.message : String(err);
+    console.warn(`Linear project lookup failed (${error}) — falling back to GitHub create`);
+    return { kind: 'failed', reason: 'api-error', error };
+  }
+
+  try {
+    const result = await createIssue({
+      title,
+      description: body,
+      projectId,
+    });
+    return { kind: 'created', identifier: result.identifier, url: result.url };
+  } catch (err) {
+    if (isMissingLinearApiKeyError(err)) {
+      const error = err instanceof Error ? err.message : String(err);
+      return { kind: 'failed', reason: 'misconfig', error };
+    }
+    const error = err instanceof Error ? err.message : String(err);
+    console.warn(`Linear wellness create failed (${error}) — falling back to GitHub create`);
+    return { kind: 'failed', reason: 'api-error', error };
+  }
 }

--- a/crux/health/wellness-report.test.ts
+++ b/crux/health/wellness-report.test.ts
@@ -261,6 +261,118 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
     );
   });
 
+  it('reopens a recently-closed Linear ticket when the dedup window applies (linear-reopened)', async () => {
+    // Coverage for the third dedup branch (commented + reopened + skipped).
+    // Verifies the wellness-report layer routes a `reopened` action correctly
+    // and never reaches the new createLinearWellnessIssue path.
+    const NOW = Date.parse('2026-04-19T20:00:00.000Z');
+    const closedRecently = NOW - 6 * 60 * 60 * 1000; // 6h ago, well under the 48h reopen window
+    const search = vi.fn().mockResolvedValue([
+      {
+        identifier: 'QUA-570',
+        title: WELLNESS_ISSUE_TITLE,
+        priority: 0,
+        state: { name: 'Done', type: 'completed' },
+        url: 'https://linear.app/q/issue/QUA-570',
+        createdAt: new Date(closedRecently).toISOString(),
+        updatedAt: new Date(closedRecently).toISOString(),
+      },
+    ]);
+    const comment = vi.fn().mockResolvedValue(undefined);
+    const setState = vi.fn().mockResolvedValue(undefined);
+    const createIssue = vi.fn();
+    const getProject = vi.fn();
+
+    const report = buildWellnessReport(failingChecks);
+    const result = await manageWellnessIssue(report, {
+      linearDedupDeps: { search, comment, setState, createIssue, getProject, now: () => NOW },
+    });
+
+    expect(result.action).toBe('linear-reopened');
+    expect(result.linearIdentifier).toBe('QUA-570');
+    // Critical: neither the new Linear-create path nor the GH fallback should fire.
+    expect(createIssue).not.toHaveBeenCalled();
+    expect(mockCreateIssue).not.toHaveBeenCalled();
+    expect(setState).toHaveBeenCalledWith('QUA-570', 'Backlog');
+  });
+
+  it('falls back to GitHub create on Linear lookup-failed without the misconfig banner', async () => {
+    // Regression lock: the misconfig banner must NOT stamp on transient
+    // lookup failures (Linear API down). The banner's "set the LINEAR_API_KEY
+    // secret" advice doesn't apply, so leaving it off keeps the GH issue
+    // accurate. If someone widens the misconfig predicate later, this test
+    // would catch it.
+    const search = vi.fn().mockRejectedValue(new Error('Linear API timed out'));
+    mockCreateIssue.mockResolvedValue({ number: 9999 });
+
+    vi.useFakeTimers();
+    try {
+      const report = buildWellnessReport(failingChecks);
+      const promise = manageWellnessIssue(report, {
+        linearDedupDeps: {
+          search,
+          comment: vi.fn(),
+          setState: vi.fn(),
+          createIssue: vi.fn(),
+          getProject: vi.fn(),
+          now: () => 0,
+        },
+      });
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.action).toBe('created');
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.not.stringContaining(MISCONFIG_BANNER_MARKER),
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('falls back to GitHub create on project-missing without the misconfig banner', async () => {
+    // End-to-end coverage of the project-missing path: rename detection in
+    // Linear should drop us to GH fallback (so the alert isn't lost) but
+    // shouldn't stamp the misconfig banner (the cause is project rename,
+    // not missing secret).
+    const search = vi.fn().mockResolvedValue([]);
+    const createIssue = vi.fn();
+    const getProject = vi.fn().mockResolvedValue(null);
+    mockCreateIssue.mockResolvedValue({ number: 9999 });
+
+    vi.useFakeTimers();
+    try {
+      const report = buildWellnessReport(failingChecks);
+      const promise = manageWellnessIssue(report, {
+        linearDedupDeps: {
+          search,
+          comment: vi.fn(),
+          setState: vi.fn(),
+          createIssue,
+          getProject,
+          now: () => 0,
+        },
+      });
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.action).toBe('created');
+      expect(result.issueNumber).toBe(9999);
+      // GH fallback fires — but the misconfig banner does NOT stamp.
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.not.stringContaining(MISCONFIG_BANNER_MARKER),
+        }),
+      );
+      // Linear create should not be reached because project resolution failed.
+      expect(createIssue).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('falls back to GitHub create when Linear create fails on api-error (no banner)', async () => {
     // Resilience: a transient Linear API error during create shouldn't drop
     // the alert. The GH fallback fires, but without the misconfig banner —

--- a/crux/health/wellness-report.test.ts
+++ b/crux/health/wellness-report.test.ts
@@ -21,6 +21,7 @@ const mockCloseIssue = vi.fn();
 const mockCreateIssue = vi.fn();
 const mockEnsureLabel = vi.fn();
 const mockGetGitHubToken = vi.fn();
+const mockIsMissingTokenError = vi.fn().mockReturnValue(false);
 
 vi.mock('../lib/github.ts', () => ({
   REPO: 'quantified-uncertainty/longterm-wiki',
@@ -31,7 +32,7 @@ vi.mock('../lib/github.ts', () => ({
   createIssue: (...args: unknown[]) => mockCreateIssue(...args),
   ensureLabel: (...args: unknown[]) => mockEnsureLabel(...args),
   getGitHubToken: (...args: unknown[]) => mockGetGitHubToken(...args),
-  isMissingTokenError: () => false,
+  isMissingTokenError: (e: unknown) => mockIsMissingTokenError(e),
   MISSING_TOKEN_SUMMARY: 'GITHUB_TOKEN not set',
 }));
 
@@ -186,6 +187,7 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetGitHubToken.mockReturnValue('fake-token');
+    mockIsMissingTokenError.mockReturnValue(false);
     mockEnsureLabel.mockResolvedValue(undefined);
     mockListIssuesByLabel.mockResolvedValue([]);
     mockListRecentOpenIssues.mockResolvedValue([]);
@@ -485,6 +487,43 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
       vi.useRealTimers();
       consoleLogSpy.mockRestore();
     }
+  });
+
+  it('still creates a Linear ticket when GitHub token is missing (GitHub-independent path)', async () => {
+    // New behaviour from the GitHub-decoupling fix: a missing GITHUB_TOKEN must
+    // NOT prevent the Linear-first create path from running. Without this fix,
+    // the early-return on missing token would silently drop the wellness alert
+    // even when Linear is fully available.
+    mockGetGitHubToken.mockImplementation(() => {
+      throw new Error('GITHUB_TOKEN not set');
+    });
+    mockIsMissingTokenError.mockReturnValue(true);
+
+    const search = vi.fn().mockResolvedValue([]);
+    const createIssue = vi
+      .fn()
+      .mockResolvedValue({ identifier: 'QUA-9999', url: 'https://linear.app/q/issue/QUA-9999' });
+    const getProject = vi
+      .fn()
+      .mockResolvedValue({ id: 'project-uuid-aaaa', name: 'Automation & Infrastructure' });
+
+    const report = buildWellnessReport(failingChecks);
+    const result = await manageWellnessIssue(report, {
+      linearDedupDeps: {
+        search,
+        comment: vi.fn(),
+        setState: vi.fn(),
+        createIssue,
+        getProject,
+        now: () => 0,
+      },
+    });
+
+    expect(result.action).toBe('linear-created');
+    expect(result.linearIdentifier).toBe('QUA-9999');
+    // The GitHub fallback must NOT have been reached.
+    expect(mockCreateIssue).not.toHaveBeenCalled();
+    expect(mockEnsureLabel).not.toHaveBeenCalled();
   });
 
   it('closes a lingering open Linear ticket when checks recover and no GitHub issue is open', async () => {

--- a/crux/health/wellness-report.test.ts
+++ b/crux/health/wellness-report.test.ts
@@ -208,7 +208,14 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
 
     const report = buildWellnessReport(failingChecks);
     const result = await manageWellnessIssue(report, {
-      linearDedupDeps: { search, comment, setState, now: () => Date.parse('2026-04-19T20:00:00.000Z') },
+      linearDedupDeps: {
+        search,
+        comment,
+        setState,
+        createIssue: vi.fn(),
+        getProject: vi.fn(),
+        now: () => Date.parse('2026-04-19T20:00:00.000Z'),
+      },
     });
 
     expect(result.action).toBe('linear-commented');
@@ -217,29 +224,77 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
     expect(comment).toHaveBeenCalledWith('QUA-570', expect.stringContaining('failing again'));
   });
 
-  it('falls through to GitHub create when Linear has no match', async () => {
+  it('creates a Linear ticket directly (Linear-first) when no Linear match exists (QUA-970)', async () => {
+    // Linear-first migration: instead of letting the GitHub-mirror sync produce
+    // an orphan ticket without a project, file directly into Linear.
     const search = vi.fn().mockResolvedValue([]);
+    const createIssue = vi
+      .fn()
+      .mockResolvedValue({ identifier: 'QUA-9999', url: 'https://linear.app/q/issue/QUA-9999' });
+    const getProject = vi
+      .fn()
+      .mockResolvedValue({ id: 'project-uuid-aaaa', name: 'Automation & Infrastructure' });
+
+    const report = buildWellnessReport(failingChecks);
+    const result = await manageWellnessIssue(report, {
+      linearDedupDeps: {
+        search,
+        comment: vi.fn(),
+        setState: vi.fn(),
+        createIssue,
+        getProject,
+        now: () => 0,
+      },
+    });
+
+    expect(result.action).toBe('linear-created');
+    expect(result.linearIdentifier).toBe('QUA-9999');
+    // Critical: the GitHub create path must NOT have been taken.
+    expect(mockCreateIssue).not.toHaveBeenCalled();
+    // The Linear create must carry the wellness project so the ticket isn't orphaned.
+    expect(getProject).toHaveBeenCalledWith('Automation & Infrastructure');
+    expect(createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: WELLNESS_ISSUE_TITLE,
+        projectId: 'project-uuid-aaaa',
+      }),
+    );
+  });
+
+  it('falls back to GitHub create when Linear create fails on api-error (no banner)', async () => {
+    // Resilience: a transient Linear API error during create shouldn't drop
+    // the alert. The GH fallback fires, but without the misconfig banner —
+    // that banner is for the missing-secret case only.
+    const search = vi.fn().mockResolvedValue([]);
+    const apiError = new Error('Linear API unreachable');
+    const createIssue = vi.fn().mockRejectedValue(apiError);
+    const getProject = vi
+      .fn()
+      .mockResolvedValue({ id: 'project-uuid-aaaa', name: 'Automation & Infrastructure' });
     mockCreateIssue.mockResolvedValue({ number: 9999 });
 
-    // `deduplicateWellnessIssues` uses fake timers to skip the 2s concurrent-
-    // create settle delay in tests. Advance the single pending timer as soon
-    // as it's registered so the create path returns without sleeping.
     vi.useFakeTimers();
     try {
       const report = buildWellnessReport(failingChecks);
       const promise = manageWellnessIssue(report, {
-        linearDedupDeps: { search, comment: vi.fn(), setState: vi.fn(), now: () => 0 },
+        linearDedupDeps: {
+          search,
+          comment: vi.fn(),
+          setState: vi.fn(),
+          createIssue,
+          getProject,
+          now: () => 0,
+        },
       });
-      // Let microtasks run, advance the 2s settle timer, then await.
       await vi.runAllTimersAsync();
       const result = await promise;
 
       expect(result.action).toBe('created');
       expect(result.issueNumber).toBe(9999);
+      // GH fallback runs without the misconfig banner.
       expect(mockCreateIssue).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: WELLNESS_ISSUE_TITLE,
-          labels: ['wellness', 'bug'],
+          body: expect.not.stringContaining(MISCONFIG_BANNER_MARKER),
         }),
       );
     } finally {
@@ -253,7 +308,14 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
 
     const report = buildWellnessReport(failingChecks);
     const result = await manageWellnessIssue(report, {
-      linearDedupDeps: { search, comment: vi.fn(), setState: vi.fn(), now: () => 0 },
+      linearDedupDeps: {
+        search,
+        comment: vi.fn(),
+        setState: vi.fn(),
+        createIssue: vi.fn(),
+        getProject: vi.fn(),
+        now: () => 0,
+      },
     });
 
     expect(result.action).toBe('updated');
@@ -264,10 +326,15 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
 
   it('stamps the misconfig banner on the new GitHub issue when LINEAR_API_KEY is missing (QUA-676)', async () => {
     // Reproduces the QUA-676 cascade: Linear-side dedup throws because the
-    // secret is missing → caller falls through to createIssue. The new issue
-    // body must carry the misconfig banner so whoever reads the ticket sees
-    // the cause + the fix path. Without the banner, the duplicate cascade
+    // secret is missing → caller falls through to GitHub createIssue. The new
+    // issue body must carry the misconfig banner so whoever reads the ticket
+    // sees the cause + the fix path. Without the banner, the duplicate cascade
     // recurs invisibly (which is what happened from QUA-577 → QUA-686).
+    //
+    // Post-QUA-970: Linear-first means we try createLinearWellnessIssue
+    // BEFORE the GH fallback. The misconfig path must reject at search time
+    // so we never reach Linear create either — otherwise the test would also
+    // need to mock createIssue.
     const apiKeyError = new Error('LINEAR_API_KEY not set. Required for Linear API calls.');
     const search = vi.fn().mockRejectedValue(apiKeyError);
     mockCreateIssue.mockResolvedValue({ number: 4577 });
@@ -277,7 +344,14 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
     try {
       const report = buildWellnessReport(failingChecks);
       const promise = manageWellnessIssue(report, {
-        linearDedupDeps: { search, comment: vi.fn(), setState: vi.fn(), now: () => 0 },
+        linearDedupDeps: {
+          search,
+          comment: vi.fn(),
+          setState: vi.fn(),
+          createIssue: vi.fn(),
+          getProject: vi.fn(),
+          now: () => 0,
+        },
       });
       await vi.runAllTimersAsync();
       const result = await promise;
@@ -319,7 +393,14 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
     const passing = [makeCheck({ ok: true })];
     const report = buildWellnessReport(passing);
     const result = await manageWellnessIssue(report, {
-      linearDedupDeps: { search, comment, setState, now: () => 0 },
+      linearDedupDeps: {
+        search,
+        comment,
+        setState,
+        createIssue: vi.fn(),
+        getProject: vi.fn(),
+        now: () => 0,
+      },
     });
 
     expect(result.action).toBe('closed');

--- a/crux/health/wellness-report.ts
+++ b/crux/health/wellness-report.ts
@@ -26,7 +26,9 @@ import {
 import type { GitHubIssue } from '../lib/github.ts';
 import {
   dedupLinearWellnessIssue,
+  createLinearWellnessIssue,
   closeLinearWellnessOnAllClear,
+  type CreateLinearWellnessResult,
   type LinearDedupDeps,
   type LinearWellnessAction,
 } from './wellness-linear-dedup.ts';
@@ -256,13 +258,29 @@ function handleLinearDedupAction(
   }
 }
 
+/**
+ * Translate a `CreateLinearWellnessResult` into a short-circuit result, or
+ * return null when the caller should fall through to the GitHub create path.
+ * `failed` always returns null so the caller's resilience fallback runs.
+ */
+function handleLinearCreateResult(
+  result: CreateLinearWellnessResult,
+): WellnessIssueResult | null {
+  if (result.kind === 'created') {
+    console.log(`Created new Linear wellness ticket ${result.identifier} (${result.url})`);
+    return { action: 'linear-created', linearIdentifier: result.identifier };
+  }
+  return null;
+}
+
 export type WellnessIssueAction =
   | 'created'
   | 'updated'
   | 'closed'
   | 'none'
   | 'linear-commented'
-  | 'linear-reopened';
+  | 'linear-reopened'
+  | 'linear-created';
 
 export interface WellnessIssueResult {
   action: WellnessIssueAction;
@@ -309,9 +327,8 @@ export async function manageWellnessIssue(
       return { action: 'updated', issueNumber: existingIssue };
     }
 
-    // No open GitHub issue. Before filing a new one (which Linear's GitHub
-    // integration would mirror into a brand-new Linear ticket), check Linear
-    // directly for an existing open or recently-closed wellness ticket.
+    // No open GitHub issue. Check Linear for an existing open or recently
+    // closed wellness ticket so we don't duplicate.
     // See QUA-577 for the 8-duplicate-tickets incident this prevents.
     const linearComment = runUrl
       ? `Wellness check failing again at ${report.timestamp}. See [run](${runUrl}) for details.`
@@ -324,12 +341,35 @@ export async function manageWellnessIssue(
     const handled = handleLinearDedupAction(linearAction);
     if (handled) return handled;
 
-    // Misconfig path (QUA-676): if Linear dedup is dormant because the
-    // LINEAR_API_KEY secret is missing, every close-then-reopen cycle of the
-    // GitHub issue mirrors into a fresh QUA ticket — that's the duplicate
-    // cascade. We can't fix the secret from code, but we can stamp a banner
-    // on the GitHub issue so whoever reads it sees the cause + the action.
-    const misconfig = linearAction.kind === 'skipped' && linearAction.reason === 'misconfig';
+    // Linear-first path (QUA-970): on `no-match` (Linear is healthy, just no
+    // existing ticket), file the wellness ticket DIRECTLY in Linear — no
+    // longer via the GitHub-mirror sync, which produced orphan tickets without
+    // projects. The misconfig and lookup-failed reasons fall through to the
+    // GitHub create below as a resilience fallback so a Linear outage doesn't
+    // silently drop the alert entirely.
+    let linearCreateResult: CreateLinearWellnessResult | null = null;
+    if (linearAction.kind === 'skipped' && linearAction.reason === 'no-match') {
+      linearCreateResult = await createLinearWellnessIssue(
+        WELLNESS_ISSUE_TITLE,
+        report.issueBody,
+        options.linearDedupDeps,
+      );
+      const linearHandled = handleLinearCreateResult(linearCreateResult);
+      if (linearHandled) return linearHandled;
+      // Fell through: createLinearWellnessIssue returned a `failed` result.
+      // Continue to the GitHub fallback below.
+    }
+
+    // GitHub fallback path. Reaches here when Linear is unreachable (misconfig,
+    // transient outage, or project lookup/create failure). The misconfig case
+    // (QUA-676) stamps an in-body banner so whoever reads the synced GitHub
+    // mirror sees the cause + the fix path. The banner ONLY applies when the
+    // underlying cause is the missing LINEAR_API_KEY secret — transient
+    // lookup-failed/api-error reasons don't get the banner because the fix
+    // (set the secret) doesn't apply.
+    const misconfig =
+      (linearAction.kind === 'skipped' && linearAction.reason === 'misconfig') ||
+      (linearCreateResult?.kind === 'failed' && linearCreateResult.reason === 'misconfig');
     const issueBody = misconfig ? prependMisconfigBanner(report.issueBody) : report.issueBody;
 
     // Create new GitHub issue with a stable title (no timestamp) so concurrent

--- a/crux/health/wellness-report.ts
+++ b/crux/health/wellness-report.ts
@@ -298,22 +298,28 @@ export async function manageWellnessIssue(
   report: WellnessReport,
   options: ManageWellnessOptions = {},
 ): Promise<WellnessIssueResult> {
+  // Probe GitHub availability without blocking the Linear-first path. A missing
+  // token only disables GitHub operations — dedupLinearWellnessIssue /
+  // createLinearWellnessIssue run regardless.
+  let githubAvailable = true;
   try {
     getGitHubToken();
   } catch (e) {
     if (isMissingTokenError(e)) {
-      console.warn(`${MISSING_TOKEN_SUMMARY} — skipping wellness issue management`);
-      return { action: 'none' };
+      console.warn(`${MISSING_TOKEN_SUMMARY} — GitHub issue management disabled`);
+      githubAvailable = false;
+    } else {
+      throw e;
     }
-    throw e;
   }
 
-  const existingIssue = await findOpenWellnessIssue();
+  // Skip the GitHub lookup when unavailable to avoid needless API noise;
+  // findOpenWellnessIssue catches its own errors, but null is returned anyway.
+  const existingIssue = githubAvailable ? await findOpenWellnessIssue() : null;
   const runUrl = options.runUrl ?? '';
 
   if (!report.overallOk) {
     // ── Failure case ───────────────────────────────────────────────────
-    await ensureWellnessLabel();
 
     if (existingIssue) {
       // Update existing issue with a comment
@@ -371,6 +377,14 @@ export async function manageWellnessIssue(
       (linearAction.kind === 'skipped' && linearAction.reason === 'misconfig') ||
       (linearCreateResult?.kind === 'failed' && linearCreateResult.reason === 'misconfig');
     const issueBody = misconfig ? prependMisconfigBanner(report.issueBody) : report.issueBody;
+
+    if (!githubAvailable) {
+      console.warn('GitHub unavailable and Linear create did not produce a ticket — alert may be dropped');
+      return { action: 'none' };
+    }
+
+    // ensureWellnessLabel is deferred here — only needed for GitHub issue creation.
+    await ensureWellnessLabel();
 
     // Create new GitHub issue with a stable title (no timestamp) so concurrent
     // workflows can find it via findOpenWellnessIssue(). The timestamp is


### PR DESCRIPTION
## Summary

Closes the auto-filer leak under **QUA-970** by migrating three monitor pipelines from `gh issue create` (which produced orphan Linear tickets via the GitHub-mirror sync) to direct Linear filing under the correct project.

| Pipeline | Project | Title (dedup key) |
|---|---|---|
| Wellness check (`crux health --auto-issue`) | Automation & Infrastructure | `System wellness check failing` |
| Render quality monitor | Dashboards & Visibility | `Render quality regression detected` |
| Wiki server dead-man-switch | Automation & Infrastructure | `Wiki server dead-man-switch alert` |

This is a parallel fix to QUA-824, which addresses the orphan-cleanup path for anything that still slips through (the `app/claude` GitHub App, manual filings, anything we don't control). Together they close the orphan class entirely.

## What changed

**Wellness path** (`crux/health/wellness-linear-dedup.ts`, `wellness-report.ts`)
- New `createLinearWellnessIssue(title, body, deps)` — looks up the wellness project by name and creates a Linear ticket directly.
- Defensive guards: rejects archived/completed projects, rejects malformed Linear `issueCreate` responses where `success:true` came back without `identifier`/`url`.
- GH fallback preserved for resilience: `misconfig`, `lookup-failed`, and Linear-create failures still fall through to a GH issue so a Linear outage never silently drops a wellness alert (wellness runs every few minutes; can't drop alerts).
- The misconfig banner stamp is now scoped to the genuine LINEAR_API_KEY-missing case (not transient outages, where the "set the secret" advice doesn't apply).
- (CodeRabbit autofix on this branch) Linear-first path is fully decoupled from the GitHub preflight — missing `GITHUB_TOKEN` no longer blocks Linear ticket creation.

**Monitor command** (`crux/commands/linear-monitor.ts`, new file)
- `crux linear monitor upsert --title=... --body-file=... --project=...` — comments on existing open ticket with this title (case-insensitive, whitespace-trimmed) or creates a new one in the right project.
- `crux linear monitor resolve --title=... [--comment=...]` — closes every open ticket with this title.
- LINEAR_API_KEY preflight at command entry. Refuses on archived/completed projects. Defensive guard against malformed Linear create responses.
- No GH fallback (unlike wellness): render-monitor runs every 6h and server-health weekly, so a single missed alert isn't a coverage gap. The workflow re-runs on schedule.

**Workflows**
- `.github/workflows/render-monitor.yml`: bash `gh issue create` replaced with `pnpm crux linear monitor upsert/resolve`. Added `concurrency: { group: render-monitor, cancel-in-progress: false }` to serialize cron + workflow_dispatch races. Tightened to `permissions: contents: read`.
- `.github/workflows/server-health-monitor.yml`: same migration. Title is now stable (`Wiki server dead-man-switch alert`) — `CHECK_STATUS` variant lives in the body, not the title, so consecutive runs in the same outage converge on one ticket. Added pnpm setup (the workflow had only curl before). Tightened to `permissions: contents: read`.

**Tests** — 79 wellness/monitor tests pass (was 41 pre-PR, +38 new).
- 14 new wellness tests in `wellness-linear-dedup.test.ts` and `wellness-report.test.ts` covering: happy path, misconfig at lookup/create, project rename, archived project, malformed response, transient outages, banner-vs-no-banner regression locks, `linear-reopened` end-to-end.
- 26 new monitor tests in `linear-monitor.test.ts` covering: oldest-open dedup, near-match filtering, closed-ticket exclusion, project-missing/archived refusal, malformed response, body-file errors, missing-flag errors, case-insensitive whitespace-trimmed title match, multi-ticket close, partial-failure reporting, JSON output, alias subcommands.

## Why a Linear-first design instead of full GH elimination (wellness only)

A LINEAR_API_KEY misconfig (QUA-676 reproducer) or a transient Linear outage shouldn't silently drop frequent alerts. Wellness keeps GH fallback because it runs every few minutes; render/server-health drop to non-zero exit and rely on the next schedule.

## Out of scope

- `.github/workflows/ci.yml` `groundskeeper-autofix` — explicitly deferred under QUA-970. The `groundskeeper-autofix` GitHub label is a real bot trigger (the groundskeeper-docker workflow listens for it), so migrating cleanly requires porting the trigger to Linear webhooks. Will track as a follow-up ticket.
- The `app/claude` GitHub App and manual user filings — out of repo / out of code's control. QUA-824's orphan-cleanup sweep covers them.

## Test plan

- [x] `pnpm vitest run crux/commands/__tests__/linear-monitor.test.ts crux/health/` → 79/79 pass
- [x] `pnpm crux w validate gate --scope=content --no-cache --fix` → green
- [x] `npx tsc --noEmit -p crux/tsconfig.json` → no new errors (pre-existing baseline only)
- [x] `pnpm crux linear monitor help` smoke-test → CLI wired through correctly
- [x] Two hostile-review passes via `/agent-review-pr` — HIGH (malformed-response), MEDIUM (archived project), and the title-case-strict / concurrency / preflight findings all addressed before push
- [ ] Post-merge: trigger a wellness failure and verify a Linear ticket lands in "Automation & Infrastructure" with no GH issue created
- [ ] Post-merge: trigger render-monitor manually and verify Linear ticket lands in "Dashboards & Visibility"
- [ ] Post-merge: monitor next weekly server-health run

Closes part of QUA-970 (wellness, render-monitor, server-health-monitor). QUA-824 remains open for the orphan-cleanup path. Follow-up ticket needed for `ci.yml` groundskeeper-autofix.
