### PR TITLE
feat(QUA-488): migrate events + races detail pages to EntityProfileShell

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -78,6 +78,11 @@ const SIDEBAR_ONLY_PAGES = [
   // 404 in the CI build (LONGTERMWIKI_SERVER_URL unset → kb-pg merge skipped).
   // Validated locally with a dev server pointed at prod data.
   "/publications/nature",
+  // Events — migrated to EntityProfileShell in QUA-488. Uses YAML
+  // entity data so it's available in CI without PG access.
+  // Note: races/[id] was also migrated in QUA-488 but its records live
+  // only in PG, so it 404s in the CI build. Validated locally against prod.
+  "/events/cyber-incident-notpetya",
 ];
 
 /**

--- a/apps/web/src/app/events/[slug]/page.tsx
+++ b/apps/web/src/app/events/[slug]/page.tsx
@@ -1,8 +1,8 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Breadcrumbs } from "@/components/directory";
 import { RelatedPages } from "@/components/RelatedPages";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
 import {
   getTypedEntities,
   getTypedEntityById,
@@ -37,6 +37,31 @@ export async function generateMetadata({
   };
 }
 
+const CalendarAvatar = (
+  <div
+    className="w-14 h-14 rounded-xl bg-gradient-to-br from-amber-500/20 to-amber-500/5 flex items-center justify-center"
+    aria-hidden="true"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="text-amber-600 dark:text-amber-400"
+    >
+      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  </div>
+);
+
 export default async function EventDetailPage({
   params,
 }: {
@@ -48,7 +73,6 @@ export default async function EventDetailPage({
 
   const wikiHref = entity.wikiId ? getWikiHref(entity.wikiId) : null;
 
-  // Resolve related entities
   const relatedEntities = entity.relatedEntries
     .map((r) => {
       const ent = getTypedEntityById(r.id);
@@ -57,131 +81,78 @@ export default async function EventDetailPage({
     })
     .filter(Boolean) as Array<{ name: string; href: string; type: string }>;
 
-  return (
-    <div className="max-w-[70rem] mx-auto px-6 py-8">
-      <Breadcrumbs
-        items={[
-          { label: "Events", href: "/events" },
-          { label: entity.title },
-        ]}
-      />
+  const headerLinks = [
+    ...(wikiHref ? [{ label: "Wiki page", href: wikiHref }] : []),
+    { label: "Data", href: `/events/${slug}/data` },
+  ];
 
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-start gap-5">
-          <div
-            className="shrink-0 w-14 h-14 rounded-xl bg-gradient-to-br from-amber-500/20 to-amber-500/5 flex items-center justify-center"
-            aria-hidden="true"
+  const sidebar = entity.tags.length > 0 ? (
+    <section className="rounded-xl border border-border p-4">
+      <h3 className="text-sm font-bold mb-3">Tags</h3>
+      <div className="flex flex-wrap gap-1.5">
+        {entity.tags.map((tag) => (
+          <span
+            key={tag}
+            className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-muted text-muted-foreground"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="text-amber-600 dark:text-amber-400"
-            >
-              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-              <line x1="16" y1="2" x2="16" y2="6" />
-              <line x1="8" y1="2" x2="8" y2="6" />
-              <line x1="3" y1="10" x2="21" y2="10" />
-            </svg>
-          </div>
-          <div className="min-w-0">
-            <h1 className="text-2xl font-extrabold tracking-tight mb-1">
-              {entity.title}
-            </h1>
-            <div className="flex items-center gap-3 text-sm text-muted-foreground flex-wrap mt-1">
-              {wikiHref && (
-                <Link
-                  href={wikiHref}
-                  className="text-primary hover:text-primary/80 font-medium transition-colors"
+            {tag}
+          </span>
+        ))}
+      </div>
+    </section>
+  ) : null;
+
+  return (
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "Events", href: "/events" },
+        { label: entity.title },
+      ]}
+      avatar={CalendarAvatar}
+      title={entity.title}
+      subtitle={entity.description || undefined}
+      headerLinks={headerLinks}
+      sidebar={sidebar}
+    >
+      <div className="space-y-8">
+        {entity.customFields.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold mb-4">Details</h2>
+            <div className="space-y-3">
+              {entity.customFields.map((field) => (
+                <div
+                  key={field.label}
+                  className="px-4 py-3 rounded-lg border border-border/60 bg-card"
                 >
-                  Wiki article &rarr;
-                </Link>
-              )}
-              <Link
-                href={`/events/${slug}/data`}
-                className="text-primary hover:text-primary/80 font-medium transition-colors"
-              >
-                Data &rarr;
-              </Link>
-            </div>
-            {entity.description && (
-              <p className="text-sm text-muted-foreground leading-relaxed mt-2 max-w-prose">
-                {entity.description}
-              </p>
-            )}
-          </div>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_280px] gap-8">
-        <div className="space-y-8">
-          {/* Custom fields */}
-          {entity.customFields.length > 0 && (
-            <section>
-              <h2 className="text-lg font-bold mb-4">Details</h2>
-              <div className="space-y-3">
-                {entity.customFields.map((field) => (
-                  <div
-                    key={field.label}
-                    className="px-4 py-3 rounded-lg border border-border/60 bg-card"
-                  >
-                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                      {field.label}
-                    </span>
-                    <p className="text-sm mt-0.5">{field.value}</p>
-                  </div>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {/* Related entities */}
-          {relatedEntities.length > 0 && (
-            <section>
-              <h2 className="text-lg font-bold mb-4">Related</h2>
-              <div className="flex flex-wrap gap-2">
-                {relatedEntities.map((ref) => (
-                  <Link
-                    key={ref.href}
-                    href={ref.href}
-                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border/60 bg-card hover:bg-muted/50 text-sm transition-colors"
-                  >
-                    <span className="font-medium">{ref.name}</span>
-                  </Link>
-                ))}
-              </div>
-            </section>
-          )}
-
-          <RelatedPages entityId={entity.id} entity={{ entityType: "event" }} />
-        </div>
-
-        {/* Sidebar */}
-        <div className="space-y-6">
-          {entity.tags.length > 0 && (
-            <section className="rounded-xl border border-border p-4">
-              <h3 className="text-sm font-bold mb-3">Tags</h3>
-              <div className="flex flex-wrap gap-1.5">
-                {entity.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-muted text-muted-foreground"
-                  >
-                    {tag}
+                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                    {field.label}
                   </span>
-                ))}
-              </div>
-            </section>
-          )}
-        </div>
+                  <p className="text-sm mt-0.5">{field.value}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {relatedEntities.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold mb-4">Related</h2>
+            <div className="flex flex-wrap gap-2">
+              {relatedEntities.map((ref) => (
+                <Link
+                  key={ref.href}
+                  href={ref.href}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border/60 bg-card hover:bg-muted/50 text-sm transition-colors"
+                >
+                  <span className="font-medium">{ref.name}</span>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <RelatedPages entityId={entity.id} entity={{ entityType: "event" }} />
       </div>
-    </div>
+    </EntityProfileShell>
   );
 }

--- a/apps/web/src/app/races/[id]/page.tsx
+++ b/apps/web/src/app/races/[id]/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { fetchDetailed, fetchFromWikiServer } from "@/lib/wiki-server";
+import { ProfileStatCard } from "@/components/directory";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
 import {
   RACE_STATUS_COLORS,
   AI_STANCE_COLORS,
@@ -143,242 +145,233 @@ export default async function RaceDetailPage({
     0,
   );
 
-  return (
-    <div className="container mx-auto max-w-4xl px-4 py-8">
-      {/* Breadcrumb */}
-      <nav className="text-sm text-muted-foreground mb-4">
-        <Link href="/races" className="hover:underline">
-          Political Races
-        </Link>
-        <span className="mx-1">/</span>
-        <span>{race.name}</span>
-      </nav>
+  const titlePills = (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+        RACE_STATUS_COLORS[race.status] ?? ""
+      }`}
+    >
+      {race.status}
+    </span>
+  );
 
-      {/* Header */}
-      <div className="mb-6">
-        <div className="flex items-center gap-3 mb-2">
-          <h1 className="text-3xl font-bold">{race.name}</h1>
-          <span
-            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-              RACE_STATUS_COLORS[race.status] ?? ""
-            }`}
-          >
-            {race.status}
-          </span>
-        </div>
+  const metadataParts: React.ReactNode[] = [];
+  metadataParts.push(<span key="level">{RACE_LEVEL_LABELS[race.level] ?? race.level}</span>);
+  if (race.district) metadataParts.push(<span key="district">{race.district}</span>);
+  if (race.state) metadataParts.push(<span key="state">{race.state}</span>);
+  if (race.electionDate) metadataParts.push(<span key="election">Election: {race.electionDate}</span>);
+  if (race.party) metadataParts.push(<span key="party" className="capitalize">{race.party}</span>);
 
-        {/* Meta info */}
-        <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
-          <span>{RACE_LEVEL_LABELS[race.level] ?? race.level}</span>
-          {race.district && <span>{race.district}</span>}
-          {race.state && <span>{race.state}</span>}
-          {race.electionDate && <span>Election: {race.electionDate}</span>}
-          {race.party && (
-            <span className="capitalize">{race.party}</span>
-          )}
-          <Link
-            href={`/races/${race.id}/data`}
-            className="text-primary hover:text-primary/80 font-medium transition-colors"
-          >
-            Data &rarr;
-          </Link>
-        </div>
-      </div>
+  const metadata = (
+    <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
+      {metadataParts}
+    </span>
+  );
 
-      {/* AI Angle */}
-      {(race.aiAngle || race.aiAngleSummary) && (
-        <div className="rounded-lg border bg-rose-50 dark:bg-rose-950/20 p-4 mb-6">
-          <h2 className="font-semibold text-rose-900 dark:text-rose-200 mb-1">
-            AI Policy Relevance
-          </h2>
-          {race.aiAngle && (
-            <p className="text-sm font-medium text-rose-800 dark:text-rose-300 mb-1">
-              {race.aiAngle}
-            </p>
-          )}
-          {race.aiAngleSummary && (
-            <p className="text-sm text-rose-700 dark:text-rose-400">
-              {race.aiAngleSummary}
-            </p>
-          )}
-        </div>
-      )}
+  const headerLinks = [
+    { label: "Data", href: `/races/${race.id}/data` },
+  ];
 
-      {/* Ballot measure info */}
-      {race.raceType === "ballot_measure" && (race.measureTitle || race.measureDescription) && (
-        <div className="rounded-lg border p-4 mb-6">
-          <h2 className="font-semibold mb-1">
-            {race.measureTitle ?? "Ballot Measure"}
-          </h2>
-          {race.measureDescription && (
-            <p className="text-sm text-muted-foreground">
-              {race.measureDescription}
-            </p>
-          )}
-        </div>
-      )}
-
-      {/* Outcome */}
-      {race.outcomeDetails && (
-        <div className="rounded-lg border bg-green-50 dark:bg-green-950/20 p-4 mb-6">
-          <h2 className="font-semibold text-green-900 dark:text-green-200 mb-1">
-            Outcome
-          </h2>
-          <p className="text-sm text-green-800 dark:text-green-300">
-            {race.outcomeDetails}
-          </p>
-        </div>
-      )}
-
-      {/* Summary stats */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-        <div className="rounded-lg border p-3 text-center">
-          <div className="text-2xl font-bold">{race.candidates.length}</div>
-          <div className="text-xs text-muted-foreground">Candidates</div>
-        </div>
-        <div className="rounded-lg border p-3 text-center">
-          <div className="text-2xl font-bold">{proRegCandidates.length}</div>
-          <div className="text-xs text-muted-foreground">Pro-regulation</div>
-        </div>
-        <div className="rounded-lg border p-3 text-center">
-          <div className="text-2xl font-bold">{antiRegCandidates.length}</div>
-          <div className="text-xs text-muted-foreground">Anti-regulation</div>
-        </div>
-        <div className="rounded-lg border p-3 text-center">
-          <div className="text-2xl font-bold">
-            {totalPacSpending > 0 ? formatCurrency(totalPacSpending) : "—"}
-          </div>
-          <div className="text-xs text-muted-foreground">PAC Spending</div>
-        </div>
-      </div>
-
-      {/* Candidates table */}
-      <h2 className="text-xl font-semibold mb-3">Candidates</h2>
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b text-left text-muted-foreground">
-              <th className="pb-2 pr-4 font-medium">Candidate</th>
-              <th className="pb-2 pr-4 font-medium">Party</th>
-              <th className="pb-2 pr-4 font-medium">Status</th>
-              <th className="pb-2 pr-4 font-medium">AI Stance</th>
-              <th className="pb-2 pr-4 font-medium">PAC</th>
-              <th className="pb-2 pr-4 font-medium text-right">PAC Spend</th>
-              <th className="pb-2 pr-4 font-medium text-right">Vote %</th>
-            </tr>
-          </thead>
-          <tbody>
-            {race.candidates.map((c) => (
-              <tr key={c.id} className="border-b hover:bg-muted/50">
-                <td className="py-2 pr-4">
-                  {c.candidate.slug ? (
-                    <Link
-                      href={`/people/${c.candidate.slug}`}
-                      className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
-                    >
-                      {c.candidateDisplayName}
-                    </Link>
-                  ) : (
-                    <span className="font-medium">{c.candidateDisplayName}</span>
-                  )}
-                  {c.isIncumbent && (
-                    <span className="ml-1 text-xs text-muted-foreground">(I)</span>
-                  )}
-                  {c.isWinner && (
-                    <span className="ml-1 text-green-600 text-xs font-medium">Winner</span>
-                  )}
-                </td>
-                <td className="py-2 pr-4 capitalize">
-                  {c.party ?? "—"}
-                </td>
-                <td className="py-2 pr-4">
-                  <span
-                    className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                      CANDIDATE_STATUS_COLORS[c.status] ?? ""
-                    }`}
-                  >
-                    {c.status}
-                  </span>
-                </td>
-                <td className="py-2 pr-4">
-                  {c.aiStance ? (
-                    <span
-                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                        AI_STANCE_COLORS[c.aiStance] ?? ""
-                      }`}
-                    >
-                      {AI_STANCE_LABELS[c.aiStance] ?? c.aiStance}
-                    </span>
-                  ) : (
-                    "—"
-                  )}
-                </td>
-                <td className="py-2 pr-4">
-                  {c.pac.slug ? (
-                    <Link
-                      href={`/organizations/${c.pac.slug}`}
-                      className="text-blue-600 dark:text-blue-400 hover:underline text-xs"
-                    >
-                      {c.pac.name ?? c.pacDisplayName}
-                    </Link>
-                  ) : (
-                    <span className="text-xs">{c.pacDisplayName ?? "—"}</span>
-                  )}
-                  {c.pacPosition && (
-                    <span className="ml-1 text-xs text-muted-foreground">
-                      ({c.pacPosition})
-                    </span>
-                  )}
-                </td>
-                <td className="py-2 pr-4 text-right">
-                  {c.pacAmount != null ? formatCurrency(c.pacAmount) : "—"}
-                </td>
-                <td className="py-2 pr-4 text-right">
-                  {c.voteShare != null
-                    ? `${(c.voteShare * 100).toFixed(0)}%`
-                    : "—"}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      {/* Linked policy */}
-      {race.policy.slug && (
-        <div className="mt-6 text-sm">
-          <span className="text-muted-foreground">Linked policy: </span>
-          <Link
-            href={`/legislation/${race.policy.slug}`}
-            className="text-blue-600 dark:text-blue-400 hover:underline"
-          >
-            {race.policy.name ?? race.policy.slug}
-          </Link>
-        </div>
-      )}
-
-      {/* Source */}
-      {race.source && (
-        <div className="mt-2 text-sm">
-          <span className="text-muted-foreground">Source: </span>
-          <a
-            href={race.source}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-600 dark:text-blue-400 hover:underline"
-          >
-            {extractSourceDomain(race.source)}
-          </a>
-        </div>
-      )}
-
-      {/* Notes */}
-      {race.notes && (
-        <div className="mt-4 rounded-lg border p-3">
-          <h3 className="text-sm font-semibold mb-1">Notes</h3>
-          <p className="text-sm text-muted-foreground">{race.notes}</p>
-        </div>
-      )}
+  const statCards = (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <ProfileStatCard label="Candidates" value={String(race.candidates.length)} />
+      <ProfileStatCard label="Pro-regulation" value={String(proRegCandidates.length)} />
+      <ProfileStatCard label="Anti-regulation" value={String(antiRegCandidates.length)} />
+      <ProfileStatCard
+        label="PAC Spending"
+        value={totalPacSpending > 0 ? formatCurrency(totalPacSpending) : "—"}
+      />
     </div>
+  );
+
+  return (
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "Political Races", href: "/races" },
+        { label: race.name },
+      ]}
+      title={race.name}
+      titlePills={titlePills}
+      metadata={metadata}
+      headerLinks={headerLinks}
+      statCards={statCards}
+    >
+      <div className="space-y-6">
+        {/* AI Angle */}
+        {(race.aiAngle || race.aiAngleSummary) && (
+          <div className="rounded-lg border bg-rose-50 dark:bg-rose-950/20 p-4">
+            <h2 className="font-semibold text-rose-900 dark:text-rose-200 mb-1">
+              AI Policy Relevance
+            </h2>
+            {race.aiAngle && (
+              <p className="text-sm font-medium text-rose-800 dark:text-rose-300 mb-1">
+                {race.aiAngle}
+              </p>
+            )}
+            {race.aiAngleSummary && (
+              <p className="text-sm text-rose-700 dark:text-rose-400">
+                {race.aiAngleSummary}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Ballot measure info */}
+        {race.raceType === "ballot_measure" && (race.measureTitle || race.measureDescription) && (
+          <div className="rounded-lg border p-4">
+            <h2 className="font-semibold mb-1">
+              {race.measureTitle ?? "Ballot Measure"}
+            </h2>
+            {race.measureDescription && (
+              <p className="text-sm text-muted-foreground">
+                {race.measureDescription}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Outcome */}
+        {race.outcomeDetails && (
+          <div className="rounded-lg border bg-green-50 dark:bg-green-950/20 p-4">
+            <h2 className="font-semibold text-green-900 dark:text-green-200 mb-1">
+              Outcome
+            </h2>
+            <p className="text-sm text-green-800 dark:text-green-300">
+              {race.outcomeDetails}
+            </p>
+          </div>
+        )}
+
+        {/* Candidates table */}
+        <section>
+          <h2 className="text-xl font-semibold mb-3">Candidates</h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-muted-foreground">
+                  <th className="pb-2 pr-4 font-medium">Candidate</th>
+                  <th className="pb-2 pr-4 font-medium">Party</th>
+                  <th className="pb-2 pr-4 font-medium">Status</th>
+                  <th className="pb-2 pr-4 font-medium">AI Stance</th>
+                  <th className="pb-2 pr-4 font-medium">PAC</th>
+                  <th className="pb-2 pr-4 font-medium text-right">PAC Spend</th>
+                  <th className="pb-2 pr-4 font-medium text-right">Vote %</th>
+                </tr>
+              </thead>
+              <tbody>
+                {race.candidates.map((c) => (
+                  <tr key={c.id} className="border-b hover:bg-muted/50">
+                    <td className="py-2 pr-4">
+                      {c.candidate.slug ? (
+                        <Link
+                          href={`/people/${c.candidate.slug}`}
+                          className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
+                        >
+                          {c.candidateDisplayName}
+                        </Link>
+                      ) : (
+                        <span className="font-medium">{c.candidateDisplayName}</span>
+                      )}
+                      {c.isIncumbent && (
+                        <span className="ml-1 text-xs text-muted-foreground">(I)</span>
+                      )}
+                      {c.isWinner && (
+                        <span className="ml-1 text-green-600 text-xs font-medium">Winner</span>
+                      )}
+                    </td>
+                    <td className="py-2 pr-4 capitalize">
+                      {c.party ?? "—"}
+                    </td>
+                    <td className="py-2 pr-4">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                          CANDIDATE_STATUS_COLORS[c.status] ?? ""
+                        }`}
+                      >
+                        {c.status}
+                      </span>
+                    </td>
+                    <td className="py-2 pr-4">
+                      {c.aiStance ? (
+                        <span
+                          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                            AI_STANCE_COLORS[c.aiStance] ?? ""
+                          }`}
+                        >
+                          {AI_STANCE_LABELS[c.aiStance] ?? c.aiStance}
+                        </span>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
+                    <td className="py-2 pr-4">
+                      {c.pac.slug ? (
+                        <Link
+                          href={`/organizations/${c.pac.slug}`}
+                          className="text-blue-600 dark:text-blue-400 hover:underline text-xs"
+                        >
+                          {c.pac.name ?? c.pacDisplayName}
+                        </Link>
+                      ) : (
+                        <span className="text-xs">{c.pacDisplayName ?? "—"}</span>
+                      )}
+                      {c.pacPosition && (
+                        <span className="ml-1 text-xs text-muted-foreground">
+                          ({c.pacPosition})
+                        </span>
+                      )}
+                    </td>
+                    <td className="py-2 pr-4 text-right">
+                      {c.pacAmount != null ? formatCurrency(c.pacAmount) : "—"}
+                    </td>
+                    <td className="py-2 pr-4 text-right">
+                      {c.voteShare != null
+                        ? `${(c.voteShare * 100).toFixed(0)}%`
+                        : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Linked policy */}
+        {race.policy.slug && (
+          <div className="text-sm">
+            <span className="text-muted-foreground">Linked policy: </span>
+            <Link
+              href={`/legislation/${race.policy.slug}`}
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              {race.policy.name ?? race.policy.slug}
+            </Link>
+          </div>
+        )}
+
+        {/* Source */}
+        {race.source && (
+          <div className="text-sm">
+            <span className="text-muted-foreground">Source: </span>
+            <a
+              href={race.source}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              {extractSourceDomain(race.source)}
+            </a>
+          </div>
+        )}
+
+        {/* Notes */}
+        {race.notes && (
+          <div className="rounded-lg border p-3">
+            <h3 className="text-sm font-semibold mb-1">Notes</h3>
+            <p className="text-sm text-muted-foreground">{race.notes}</p>
+          </div>
+        )}
+      </div>
+    </EntityProfileShell>
   );
 }


### PR DESCRIPTION
## Summary

Part 4 of [QUA-362](https://linear.app/quantifieduncertainty/issue/QUA-362) EntityProfileShell migration epic. Closes [QUA-488](https://linear.app/quantifieduncertainty/issue/QUA-488).

- **`events/[slug]`** (187 → 158 lines): kept the calendar avatar SVG, moved Tags into the shell `sidebar` slot, Wiki/Data links go through `headerLinks`. Events aren't a sourced record type, so no verdict.
- **`races/[id]`** (384 → 333 lines): status badge → `titlePills`, level/district/state/election → `metadata`, the 4-card stat grid → `statCards` via `ProfileStatCard`, body content (AI angle, ballot measure, outcome, candidates table, source/notes) → `children`. No sidebar (matches the original full-width layout). `political-race` isn't a record type in `getSourcingHref`, so no verdict. Preserved `export const dynamic = "force-dynamic"` and the existing wiki-server error fallback for non-404 connection errors (unchanged from main).

## Intentional UX changes from shell conformance

- **Header link styling**: original "Wiki article →" / "Data →" inline arrow links are now bordered pills via `headerLinks`. Label normalized from "Wiki article" to "Wiki page" to match `/ai-models`, `/organizations`, etc.
- **Races metadata position**: original rendered level/district/state/election as a row below the title; the shell renders metadata to the right of the title (with `ml-auto`) on wide viewports, wrapping below on narrow ones. Same content, shell-conformant placement.
- **Container width**: races page now uses the shell's `max-w-[70rem]` instead of the original `max-w-4xl`.

## Acceptance criteria

- [x] Both pages use `<EntityProfileShell>`
- [x] No new per-type wrapper components introduced
- [x] `pnpm build` passes
- [x] Playwright e2e passes for both entity types

## Test plan

- [x] `pnpm build` — both pages compile, `events/[slug]` is SSG, `races/[id]` is dynamic (force-dynamic preserved for the wiki-server fetch)
- [x] `pnpm test` — 1912 tests pass
- [x] `pnpm crux w validate gate --fix` — 70 gate checks pass (3 pre-existing advisory warnings, unchanged)
- [x] Added `/events/cyber-incident-notpetya` to `e2e/render-audit.spec.ts` SIDEBAR_ONLY_PAGES — passes locally
- [x] Manual smoke test against prod data via local dev server: `/events/cyber-incident-notpetya`, `/events/ai-military-deployment-iran-2026`, `/events/anthropic-government-standoff`, `/events/cyber-incident-wannacry`, and `/races/LDge8ou24V` all render with the shell (correct h1, breadcrumb, header links, stat cards, candidates table, sidebar Tags) — no JS errors
- [x] Adversarial inputs: 404 paths for missing/path-traversal/XSS-style slugs and IDs all return 404 cleanly
- [x] `/agent-review-pr` hostile review pass — 6 LOW findings, all behavior-change observations now documented in this PR description; no CRITICAL/HIGH/MEDIUM findings
- Note: `/races/[id]` is PG-only and 404s in CI without `LONGTERMWIKI_SERVER_URL`, so it isn't in the e2e list — this matches the QUA-487 pattern for `investments/[id]`, `funding-rounds/[id]`, `funding-programs/[id]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-488
