### PR TITLE
data(people): add Chris Stewart, refresh Brad Carson with Public First Action role

### DIFF
--- a/data/entities/people.yaml
+++ b/data/entities/people.yaml
@@ -6668,12 +6668,32 @@
     - id: sid_IFjdCevnFg
       type: organization
       relationship: leads-to
-  description: Co-founder and President of Americans for Responsible Innovation (ARI). Former U.S. Congressman (OK-2, 2001-2005). Former Under Secretary of the Army and Acting Under Secretary of Defense for Personnel and Readiness. Former President of the University of Tulsa.
+    - id: sid_NeUHBH9hGa
+      type: organization
+      relationship: leads-to
+  description: Co-founder and President of Americans for Responsible Innovation (ARI). Co-founder of Public First Action (2025), a bipartisan AI-safety 501(c)(4) network supporting pro-regulation candidates in the 2026 U.S. elections. Former U.S. Congressman (OK-2, 2001-2005). Former Under Secretary of the Army and Acting Under Secretary of Defense for Personnel and Readiness. Former President of the University of Tulsa.
   customFields:
     - label: Role
       value: Co-founder and President
     - label: Organization
       value: Americans for Responsible Innovation
+  tags:
+    - ai-governance
+    - ai-policy
+- id: chris-stewart
+  stableId: sid_TkeOMpAV5w
+  type: person
+  title: Chris Stewart
+  relatedEntries:
+    - id: sid_NeUHBH9hGa
+      type: organization
+      relationship: leads-to
+  description: Co-founder of Public First Action (2025), a bipartisan AI-safety 501(c)(4) network supporting pro-regulation candidates in the 2026 U.S. elections. Former Republican U.S. Congressman from Utah (UT-2, 2013-2023), where he served on the House Permanent Select Committee on Intelligence and the Appropriations Committee. Resigned from Congress in September 2023 due to family health reasons.
+  customFields:
+    - label: Role
+      value: Co-founder
+    - label: Organization
+      value: Public First Action
   tags:
     - ai-governance
     - ai-policy


### PR DESCRIPTION
## Summary

Two narrow gaps noticed while auditing our Public First Action (PFA) coverage. PFA is the bipartisan AI-safety 501(c)(4) co-founded by Brad Carson (D) and Chris Stewart (R) in 2025; Anthropic's $20M donation to it is one of the larger publicly-disclosed AI-safety political contributions on record.

- **Brad Carson description was stale.** Mentioned only his Americans for Responsible Innovation role; omitted Public First Action entirely. Refreshed to add PFA as a parallel co-founder role (no claim he stepped down from ARI), and added PFA to `relatedEntries`.
- **Chris Stewart was missing from `people.yaml`.** Added as a lightweight TableBase reference record (stableId only; no wikiId / no wiki page). If the QUA-986 follow-up decides he warrants a full wiki page, allocate a wikiId then.

## Scope — precursor to QUA-986, do NOT auto-close parent

This is a **partial** of QUA-986. Out-of-scope items still tracked there:
- Dedicated MDX wiki page for Public First Action
- FactBase entity with structured Anthropic-$20M donation
- Individual-donor facts (Jan Leike, Peter Lofgren, Michael Cohen)
- Supported-candidates relationships

Reviewers / Linear: please leave QUA-986 in In Progress (or move back to Backlog) when this PR merges; do not let the auto-close trigger.

Refs QUA-986

## Test plan

- [x] `pnpm crux w validate gate --scope=content --fix` — all 5 checks pass (local)
- [x] Pre-push hook ran the full 63-check gate — all passed
- [x] Confirmed Chris Stewart's stableId `sid_TkeOMpAV5w` is unique across `data/entities/*.yaml`
- [x] Confirmed PFA org stableId `sid_NeUHBH9hGa` resolves to `public-first-action` in `organizations.yaml`
- [x] CI green (22 checks passed after one transient `resources-pg` timeout retry)
- [x] `/agent-review-pr` ran (adaptive — most phases legitimately N/A for a 21-line YAML diff; see below)

## Review Phases Skipped

- phase-3b-hostile: N/A: 21 lines under 30-line threshold
- phase-4-redteam: N/A: <100 lines and no security/API/data-pipeline changes (single YAML data file)
- phase-5-category: N/A: no UI/API/CLI/data-pipeline/infra files in diff

Full tracker: `.claude/review-phases-done` (gitignored, session-local).
