### PR TITLE
fix(sourcing): bind non-verifiable property list as text[] param (QUA-985)

### DIFF
--- a/apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts
@@ -366,9 +366,71 @@ describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
     // (postgres-js then serialises it as `text[]`), not the spread elements.
     const arrayParams = checkableParams.filter((p) => Array.isArray(p));
     expect(arrayParams).toHaveLength(1);
-    // Sanity: properties.yaml has at least one verifiable:false entry, so the
-    // bound array isn't empty in prod-shaped runs.
+    // Content check, not just shape: the bound array must equal the spread
+    // of `getNonVerifiablePropertyIds()`. Without this, a future refactor
+    // that introduces a second array param to the same SELECT would silently
+    // pass the shape check while binding the wrong array.
+    const { getNonVerifiablePropertyIds } = await import("../property-metadata.js");
+    expect(arrayParams[0]).toEqual([...getNonVerifiablePropertyIds()]);
+    // Sanity: properties.yaml has at least one verifiable:false entry.
     expect((arrayParams[0] as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it("survives an empty non-verifiable property list (QUA-985 red-team)", async () => {
+    // Adversarial input: if properties.yaml has zero `verifiable: false`
+    // entries, `[...emptySet]` is `[]` and `sql.param([])` should bind as
+    // `'{}'::text[]`. The query `ANY('{}')` matches nothing, so the
+    // `NOT (measure = ANY(...))` clause is true for every row — every
+    // sourced fact counts as checkable. Verify the query still binds as
+    // a single text[] param (no row-constructor regression on empty input)
+    // and the endpoint still returns 200.
+    const { _resetPropertyMetadataCache } = await import("../property-metadata.js");
+    const propertyMetadata = await import("../property-metadata.js");
+    _resetPropertyMetadataCache();
+    const spy = vi
+      .spyOn(propertyMetadata, "getNonVerifiablePropertyIds")
+      .mockReturnValue(new Set<string>());
+
+    try {
+      tableTotals = [{ table_name: "fact", total: 100 }];
+      verifiedCounts = [];
+
+      const res = await app.request("/api/sourcing/coverage");
+      expect(res.status).toBe(200);
+
+      const idx = capturedQueries.findIndex(
+        (q) => /FROM\s+facts/i.test(q) && /AS\s+checkable/i.test(q),
+      );
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(capturedQueries[idx]).toMatch(/ANY\(\s*\$\d+::text\[\]\s*\)/);
+      const arrayParams = capturedParams[idx].filter((p) => Array.isArray(p));
+      expect(arrayParams).toHaveLength(1);
+      expect(arrayParams[0]).toEqual([]);
+    } finally {
+      spy.mockRestore();
+      _resetPropertyMetadataCache();
+    }
+  });
+
+  it("/coverage-matrix shares the fix via countCheckableFacts (QUA-985)", async () => {
+    // /coverage-matrix and /coverage both call countCheckableFacts(db). The
+    // QUA-985 prod 500 affected both endpoints. This is a smoke test that
+    // /coverage-matrix also issues the checkable query in the fixed shape,
+    // so a future refactor that inlines the helper into one endpoint can't
+    // re-introduce the bug on the other.
+    tableTotals = [{ record_type: "fact", total: 100 }];
+    checkedCounts = [];
+    verdictRows = [];
+
+    const res = await app.request("/api/sourcing/coverage-matrix");
+    expect(res.status).toBe(200);
+
+    const idx = capturedQueries.findIndex(
+      (q) => /FROM\s+facts/i.test(q) && /AS\s+checkable/i.test(q),
+    );
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(capturedQueries[idx]).not.toMatch(/ANY\(\s*\(\s*\$\d+\s*,/);
+    expect(capturedQueries[idx]).toMatch(/ANY\(\s*\$\d+::text\[\]\s*\)/);
   });
 });
 

--- a/apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts
@@ -20,6 +20,7 @@ import { Hono } from "hono";
 import { type SqlDispatcher, mockDbModule } from "./test-utils";
 
 let capturedQueries: string[] = [];
+let capturedParams: unknown[][] = [];
 
 let tableTotals: Array<{ table_name?: string; record_type?: string; total: number }> = [];
 let verifiedCounts: Array<{ record_type: string; verified: number }> = [];
@@ -27,8 +28,9 @@ let checkedCounts: Array<{ record_type: string; checked_records: number }> = [];
 let verdictRows: Array<{ record_type: string; verdict: string; cnt: number }> = [];
 let checkableFacts = 0;
 
-const dispatch: SqlDispatcher = (query, _params) => {
+const dispatch: SqlDispatcher = (query, params) => {
   capturedQueries.push(query);
+  capturedParams.push(params);
 
   // Order matters: the LIVE_RECORDS_CTE for the matrix queries also contains
   // `AS record_type` inside its CTE body, so the union-totals patterns must
@@ -117,6 +119,7 @@ describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
 
   beforeEach(() => {
     capturedQueries = [];
+    capturedParams = [];
     tableTotals = [];
     verifiedCounts = [];
     checkedCounts = [];
@@ -327,6 +330,46 @@ describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
     expect(/source\s*<>\s*''/i.test(checkableQuery!)).toBe(true);
     expect(/measure\s*=\s*ANY/i.test(checkableQuery!)).toBe(true);
   });
+
+  it("binds the non-verifiable property list as a single text[] param (QUA-985)", async () => {
+    // Regression for QUA-985 prod 500.
+    //
+    // Drizzle's `sql` template tag spreads JS arrays as a row constructor
+    // `($1, $2, ..., $N)` rather than binding them as a postgres array
+    // parameter. With the broken binding the ANY clause renders as
+    // `ANY(($1, ..., $12)::text[])` — Postgres rejects the cast because a
+    // record is not an array, returning HTTP 500 to /coverage and
+    // /coverage-matrix on prod once properties.yaml grew to 12+ entries.
+    //
+    // The fix wraps the array in `sql.param(arr)` so it binds as a single
+    // `text[]` parameter, rendering as `ANY($1::text[])`.
+    tableTotals = [{ table_name: "fact", total: 100 }];
+    verifiedCounts = [];
+
+    const res = await app.request("/api/sourcing/coverage");
+    expect(res.status).toBe(200);
+
+    const idx = capturedQueries.findIndex(
+      (q) => /FROM\s+facts/i.test(q) && /AS\s+checkable/i.test(q),
+    );
+    expect(idx, "expected the checkable-facts query to be issued").toBeGreaterThanOrEqual(0);
+
+    const checkableQuery = capturedQueries[idx];
+    const checkableParams = capturedParams[idx];
+
+    // Must NOT spread the array as a row constructor (the QUA-985 prod bug).
+    expect(checkableQuery).not.toMatch(/ANY\(\s*\(\s*\$\d+\s*,/);
+    // Must bind as a single ::text[] parameter.
+    expect(checkableQuery).toMatch(/ANY\(\s*\$\d+::text\[\]\s*\)/);
+
+    // The params slot for the array binding must contain a single JS array
+    // (postgres-js then serialises it as `text[]`), not the spread elements.
+    const arrayParams = checkableParams.filter((p) => Array.isArray(p));
+    expect(arrayParams).toHaveLength(1);
+    // Sanity: properties.yaml has at least one verifiable:false entry, so the
+    // bound array isn't empty in prod-shaped runs.
+    expect((arrayParams[0] as unknown[]).length).toBeGreaterThan(0);
+  });
 });
 
 describe("QUA-928: GET /api/sourcing/coverage-matrix — checkability split", () => {
@@ -334,6 +377,7 @@ describe("QUA-928: GET /api/sourcing/coverage-matrix — checkability split", ()
 
   beforeEach(() => {
     capturedQueries = [];
+    capturedParams = [];
     tableTotals = [];
     verifiedCounts = [];
     checkedCounts = [];

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -159,9 +159,13 @@ async function countCheckableFacts(
 ): Promise<number> {
   const nonVerifiable = [...getNonVerifiablePropertyIds()];
   // `sql.param(arr)` binds the JS array as a single `text[]` parameter.
-  // Plain `${nonVerifiable}` would expand into a row constructor
+  // Drizzle's `sql` template tag (used here via `db.execute(sql`...`)`)
+  // would otherwise expand `${nonVerifiable}` into a row constructor
   // `($1, $2, ..., $N)` which Postgres can't cast to `text[]` and which
-  // 500'd both /coverage and /coverage-matrix on prod (QUA-985).
+  // 500'd both /coverage and /coverage-matrix on prod (QUA-985). The
+  // postgres-js raw tagged template (`getDb()` callsites) handles JS
+  // arrays natively and does NOT need this wrapper — see
+  // `routes/shared/query-helpers.ts` for the canonical write-up.
   const rows = (await db.execute(sql`
     SELECT count(DISTINCT fact_id)::int AS checkable
     FROM facts

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -158,11 +158,15 @@ async function countCheckableFacts(
   db: ReturnType<typeof getDrizzleDb>,
 ): Promise<number> {
   const nonVerifiable = [...getNonVerifiablePropertyIds()];
+  // `sql.param(arr)` binds the JS array as a single `text[]` parameter.
+  // Plain `${nonVerifiable}` would expand into a row constructor
+  // `($1, $2, ..., $N)` which Postgres can't cast to `text[]` and which
+  // 500'd both /coverage and /coverage-matrix on prod (QUA-985).
   const rows = (await db.execute(sql`
     SELECT count(DISTINCT fact_id)::int AS checkable
     FROM facts
     WHERE source IS NOT NULL AND source <> ''
-      AND (measure IS NULL OR NOT (measure = ANY(${nonVerifiable}::text[])))
+      AND (measure IS NULL OR NOT (measure = ANY(${sql.param(nonVerifiable)}::text[])))
   `)) as Array<{ checkable: number | null }>;
   return rows[0]?.checkable ?? 0;
 }


### PR DESCRIPTION
## Summary

Prod 500: `/api/sourcing/coverage` and `/api/sourcing/coverage-matrix` were returning HTTP 500 with `Failed query: ... measure = ANY(($1, $2, ..., $12)::text[])`. The `/internal/source-check-coverage` dashboard and the source-check coverage bars on `EntityProfileShell` were silently broken.

**Root cause.** Drizzle's `sql` template tag spreads JS arrays as a row constructor `($1, $2, ..., $N)` rather than binding them as a postgres array. With `${nonVerifiable}::text[]`, the rendered SQL was `ANY(($1, ..., $12)::text[])` — Postgres rejects the cast because a record can't be cast to `text[]`. The bug was latent until `properties.yaml` reached 12 `verifiable: false` entries; the params list in the prod 500 message confirms 12 was the trigger. The postgres-js raw tagged template (other `getDb()` callsites) handles JS arrays natively and is unaffected.

**Fix.** Wrap the array in `sql.param(arr)` so it binds as a single `text[]` parameter — renders as `ANY($1::text[])`. One-line change in `apps/wiki-server/src/routes/sourcing/sourcing.ts:countCheckableFacts`.

The footgun is already documented in `apps/wiki-server/src/routes/shared/query-helpers.ts:159-167` ("Drizzle's `sql` tag expands JS arrays as row constructors which is valid for `IN` but not for ANY()") but the comment didn't prevent the regression. Filed [QUA-990](https://linear.app/quantifieduncertainty/issue/QUA-990) to (a) audit the remaining `ANY(${arr})` Drizzle call sites — likely several in `tablebase/scanner-results.ts:431`, `tablebase/ai-incidents.ts:450`, `wikibase/resource-dedup.ts`, `wikibase/resources.ts` — and (b) add a gate validator that flags `ANY(\${...})` patterns inside Drizzle `sql` tag context.

## Test plan

- [x] Regression test in `sourcing-coverage-checkability.test.ts` captures both the rendered SQL and bound params, asserts the checkable query renders as `ANY($N::text[])` with a single JS-array param. Verified the test fails on the broken binding — failure output is byte-identical to the prod 500 message (`ANY(($1, ..., $12)::text[])`).
- [x] Content-equality assertion: bound array deep-equals `[...getNonVerifiablePropertyIds()]` so a future refactor that adds a second array param can't silently pass a shape-only check.
- [x] `/coverage-matrix` smoke test so a future inline of `countCheckableFacts` into `/coverage` can't reintroduce the bug on the matrix endpoint.
- [x] Empty-array red-team: when `properties.yaml` has zero `verifiable: false` entries, the binding still renders as `ANY($N::text[])` (not a row constructor) and the endpoint returns 200.
- [x] All 1656 wiki-server tests pass.
- [x] `pnpm crux w validate gate --fix` — 70/70 checks green.
- [x] `/agent-review-pr` — 7/7 phases. Hostile reviewer found 1 MEDIUM (filed as QUA-990) and 3 LOWs (all addressed in this PR with defensive tests + comment improvement).
- [ ] **Post-merge**: confirm `/api/sourcing/coverage` and `/api/sourcing/coverage-matrix` return 200 on prod, and `/internal/source-check-coverage` renders.

Closes QUA-985.
