### PR TITLE
QUA-977 — funding-program source-check triage (22% → 46%, blocked from 80% by QUA-992)

### DIFF
--- a/crux/commands/import-funding-programs.ts
+++ b/crux/commands/import-funding-programs.ts
@@ -130,13 +130,13 @@ const PROGRAMS: FundingProgramDef[] = [
     divisionIdSeed: "div|coefficient-giving|lead-exposure",
     name: "Lead Exposure Action Fund (LEAF)",
     description:
-      "Multi-donor pooled fund addressing lead exposure globally. $100-125M raised with Gates Foundation, UNICEF, and others.",
+      "Multi-donor pooled fund addressing lead exposure globally. $60M+ given across 20+ grants per Coefficient Giving.",
     programType: "grant-round",
-    totalBudget: 125_000_000,
+    totalBudget: 60_000_000,
     status: "open",
     deadline: "Rolling",
     source: "https://coefficientgiving.org/funds/lead-exposure-action-fund",
-    notes: "20+ grants. Launched 2024. Partners include Gates Foundation, UNICEF.",
+    notes: "$60M+ given across 20+ grants. Launched 2024. Partners include Gates Foundation, UNICEF.",
   },
   {
     idSeed: "prog|coefficient-giving|abundance-growth-grants",
@@ -201,10 +201,9 @@ const PROGRAMS: FundingProgramDef[] = [
       "Grantmaking for forecasting infrastructure, prediction markets, and forecasting research. 30+ grants totaling ~$50M.",
     programType: "grant-round",
     totalBudget: 50_000_000,
-    status: "open",
-    deadline: "Rolling",
+    status: "closed",
     source: "https://coefficientgiving.org/funds/forecasting",
-    notes: "Led by Benjamin Tereick.",
+    notes: "Led by Benjamin Tereick. Fund closed 2026-03-30.",
   },
   {
     idSeed: "prog|coefficient-giving|effective-giving-careers",
@@ -334,14 +333,14 @@ const PROGRAMS: FundingProgramDef[] = [
     divisionIdSeed: "div|sff|sff-main",
     name: "Speculation Grants",
     description:
-      "Faster-turnaround grants from SFF using novel donor coordination with ~35 grantors",
+      "Faster-turnaround grants from SFF using novel donor coordination with ~40 grantors",
     programType: "grant-round",
     status: "open",
     deadline: "Rolling",
     source: "https://survivalandflourishing.fund/speculation-grants",
     notes:
-      "Budget grown from $4M to $16M. Complementary to S-Process; allows faster funding decisions.",
-    totalBudget: 16_000_000,
+      "~40 Speculators with combined $20M budget (up from $4M initially). Complementary to S-Process; allows faster funding decisions.",
+    totalBudget: 20_000_000,
   },
   {
     idSeed: "prog|sff|matching-pledges",
@@ -401,12 +400,12 @@ const PROGRAMS: FundingProgramDef[] = [
     divisionIdSeed: "div|fli|grants-program",
     name: "2023 Grants",
     description:
-      "16 grants for AI safety research, policy, and governance",
+      "16 grants distributed in 2023 for AI safety research, policy, and governance",
     programType: "grant-round",
-    totalBudget: 8_438_000,
+    totalBudget: 8_638_000,
     status: "awarded",
     source: "https://futureoflife.org/grant-program/2023-grants/",
-    notes: "Largest to FAR AI ($1.86M) and ARC ($1.4M).",
+    notes: "16 grants distributed totaling $8.64M. Largest to FAR AI ($1.86M) and ARC ($1.4M).",
   },
   {
     idSeed: "prog|fli|2024-grants",
@@ -442,10 +441,10 @@ const PROGRAMS: FundingProgramDef[] = [
     description:
       "13 projects addressing AI-driven power concentration. Largest $1.66M to OpenMined Foundation.",
     programType: "rfp",
-    totalBudget: 5_637_000,
-    status: "open",
+    totalBudget: 4_000_000,
+    status: "awarded",
     source: "https://futureoflife.org/grant-program/mitigate-ai-driven-power-concentration/",
-    notes: "Two review rounds (July and October 2024).",
+    notes: "Two review rounds (July and October 2024). Up-to-$4M cap; 13 projects awarded totaling $5.64M (exceeded cap). Funds allocated.",
   },
   {
     idSeed: "prog|fli|global-institutions-ai",
@@ -479,9 +478,9 @@ const PROGRAMS: FundingProgramDef[] = [
     description:
       "5-year tuition + $40K/year stipend + $10K research fund. 14 fellows at UC Berkeley, Stanford, MIT, Cambridge.",
     programType: "fellowship",
-    status: "open",
+    status: "closed",
     source: "https://futureoflife.org/grant-program/phd-fellowships/",
-    notes: "Run with BAIF (Berkeley AI Foundation). Funded by Vitalik Buterin's $665.8M donation.",
+    notes: "Run with BAIF (Berkeley AI Foundation). Funded by Vitalik Buterin's $665.8M donation. Closed for submissions; deadline was 2025-11-21.",
   },
   {
     idSeed: "prog|fli|postdoc-fellowships",
@@ -491,9 +490,9 @@ const PROGRAMS: FundingProgramDef[] = [
     description:
       "$80K/year stipend + $10K research fund. Fellows at Berkeley/CHAI, MIT, Oxford.",
     programType: "fellowship",
-    status: "open",
+    status: "closed",
     source: "https://futureoflife.org/grant-program/postdoctoral-fellowships/",
-    notes: "Run with BAIF. Fellows include Nisan Stiennon (Berkeley), Peter S. Park (MIT).",
+    notes: "Run with BAIF. Fellows include Nisan Stiennon (Berkeley), Peter S. Park (MIT). Closed for submissions.",
   },
   {
     idSeed: "prog|fli|us-china-fellowships",
@@ -503,9 +502,9 @@ const PROGRAMS: FundingProgramDef[] = [
     description:
       "Same structure as technical PhD fellowship. Focused on US-China AI governance.",
     programType: "fellowship",
-    status: "open",
+    status: "closed",
     source: "https://futureoflife.org/grant-program/us-china-ai-governance-phd-fellowship/",
-    notes: "2025 class: Ruofei Wang, John Ferguson, Kayla Blomquist.",
+    notes: "2025 class: Ruofei Wang, John Ferguson, Kayla Blomquist. Closed for submissions; deadline was 2025-11-21.",
   },
   {
     idSeed: "prog|fli|multistakeholder-engagement",
@@ -516,8 +515,9 @@ const PROGRAMS: FundingProgramDef[] = [
       "Up to $5M for multi-stakeholder engagement projects. Individual grants $100K-$500K, multi-year up to 3 years.",
     programType: "rfp",
     totalBudget: 5_000_000,
-    status: "open",
+    status: "closed",
     source: "https://futureoflife.org/grant-program/multistakeholder-engagement-for-safe-and-prosperous-ai/",
+    notes: "Closed for submissions; LOI deadline was 2025-02-04.",
   },
   {
     idSeed: "prog|fli|religious-projects",
@@ -528,9 +528,9 @@ const PROGRAMS: FundingProgramDef[] = [
       "Up to $1.5M total; individual grants $30K-$300K. Faith community engagement with AI risks.",
     programType: "rfp",
     totalBudget: 1_500_000,
-    status: "open",
+    status: "closed",
     source: "https://futureoflife.org/grant-program/rfp-on-religious-projects/",
-    notes: "Launched 2026.",
+    notes: "Launched 2026. Closed for submissions; deadline was 2026-02-02.",
   },
 
   // ---- Schmidt Futures / Schmidt Sciences ----
@@ -687,9 +687,10 @@ const PROGRAMS: FundingProgramDef[] = [
     description:
       "Regranting program funded primarily by Coefficient Giving; multiple regrantors.",
     programType: "grant-round",
-    totalBudget: 1_400_000,
+    totalBudget: 1_550_000,
     status: "awarded",
     source: "https://manifund.org/about/regranting",
+    notes: "13 regrantors with combined ~$1.55M budget across cohort.",
   },
   {
     idSeed: "prog|manifund|impact-certificates",

--- a/crux/commands/import-funding-programs.ts
+++ b/crux/commands/import-funding-programs.ts
@@ -441,10 +441,10 @@ const PROGRAMS: FundingProgramDef[] = [
     description:
       "13 projects addressing AI-driven power concentration. Largest $1.66M to OpenMined Foundation.",
     programType: "rfp",
-    totalBudget: 4_000_000,
+    totalBudget: 5_637_000,
     status: "awarded",
     source: "https://futureoflife.org/grant-program/mitigate-ai-driven-power-concentration/",
-    notes: "Two review rounds (July and October 2024). Up-to-$4M cap; 13 projects awarded totaling $5.64M (exceeded cap). Funds allocated.",
+    notes: "Two review rounds (July and October 2024). Source page lists 'up to $4M' cap; 13 awarded projects total $5,637,429 (Funds allocated, exceeded cap). totalBudget records actual disbursed.",
   },
   {
     idSeed: "prog|fli|global-institutions-ai",


### PR DESCRIPTION
## Summary

Triage QUA-977 (`funding-program` source-check sweep). Got green rate from 13/59 (22%) to 28/61 (46%) — +15 confirmed, +24 pp.

Did not hit the 80% target. The blocker is QUA-992 (already filed): 8 funding-program records have a fresh `confirmed` evidence row but a stale QUA-650 retro-scan `partial` row, and the stale partial wins the priority tie. Resolving QUA-992 would lift this to 36/61 = 59% with no per-record edits. The remaining 25 records have legitimate per-record source-quality issues out of scope for one triage session (Safeguarded AI TA1.x sub-programs not broken out by source, dead FTX/ACX archives, LLM `subject_matches_claim` downgrades on parent-fund pages).

Full receipts in the [QUA-977 progress comment](https://linear.app/quantifieduncertainty/issue/QUA-977/source-check-bring-funding-program-to-80percent-green-currently).

## Changes

- 5 status updates on FLI / Coefficient Giving programs whose deadline has passed (open → closed): postdoc/PhD/US-China fellowships, Religious Projects RFP, Multistakeholder Engagement, Forecasting Fund.
- 4 budget corrections grounded in source-check evidence: Speculation Grants (16M → 20M), AI Safety Regranting 2024 (1.4M → 1.55M), 2023 Grants (8.438M → 8.638M), LEAF (125M → 60M).
- 2 missing records inserted in DB (PhD Fellowship `ynRLt8yjaF`, Forecasting Grantmaking `pzaZuaBSxG`) to clear orphan verdicts that pointed to deleted rows.
- 1 record's notes clarified after review feedback: AI Power Concentration kept at 5.637M (actual disbursed) per column convention, with notes calling out that the source page lists "up to $4M" cap that was exceeded — accepts the LLM contradiction in service of column-meaning consistency.
- Code change: `crux/commands/import-funding-programs.ts` — keeps the import-file source-of-truth consistent with the DB so future migrations don't reintroduce stale data.

DB updates went through `POST /api/funding-programs/sync?forceSkipSourcing=true&reason=QUA-977…` using the existing IDs, *not* via `crux tb import-funding-programs sync`. The latter would currently fail the unique-(orgId,name) constraint because the active records use legacy `_`/`-` IDs (`K48_8DelBG`, `F_suf8h8-I`, `_8cmBpVO23`) while `generateId(...)` now strips both. Filed as QUA-993 for follow-up.

## Test plan

- [x] `pnpm crux w validate gate --scope=content --fix` passes (5 checks)
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — no new errors in `import-funding-programs.ts`
- [x] `npx tsc --noEmit` on `apps/web` and `apps/wiki-server` — exit 0
- [x] Verified all 5 corrected DB records have updated status / budget via `GET /api/funding-programs/:id`
- [x] Verified the 2 inserted orphan-target records exist and are reachable
- [x] Re-ran `pnpm crux verify-orchestrate funding-programs --budget=2`: aggregate verdict matrix is `confirmed: 28, contradicted: 1, partial: 18, unverifiable: 14` (one record will revert to contradicted on next periodic re-verify after the AI Power Concentration totalBudget revert — `confirmed: 27, contradicted: 2` is the steady-state expected post-merge)
- [x] `/agent-review-pr` ran: 1 MEDIUM finding fixed (column-semantics regression), 3 LOW documented

## Follow-ups filed

- **QUA-992** (existing) — commented with the 8 stale-dragged funding-program record IDs so personnel/QUA-979 work and any other percentage-target triages share the same receipts.
- **QUA-993** (new) — `funding-programs` ID drift: `import-funding-programs sync` rejects legacy `_`/`-`-IDed rows due to unique-(orgId,name) collision with regenerated IDs.

Closes QUA-977 partially (does not meet 80% acceptance — see comment for path to 80%).
