### PR TITLE
fix(sourcing): recency tie-break in evidence aggregation (QUA-992)

### DIFF
--- a/apps/wiki-server/src/__tests__/sourcing-aggregation.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-aggregation.test.ts
@@ -17,8 +17,9 @@ function row(
   verdict: EvidenceRow["verdict"],
   relevanceScore: number | null = 1.0,
   confidence: number | null = null,
+  checkedAt: Date | null = null,
 ): EvidenceRow {
-  return { verdict, relevanceScore, confidence };
+  return { verdict, relevanceScore, confidence, checkedAt };
 }
 
 describe("aggregateEvidence — empty / degenerate input", () => {
@@ -150,6 +151,90 @@ describe("aggregateEvidence — tiebreaking by priority", () => {
     // more actionable than 'couldn't tell').
     const r = aggregateEvidence([row("outdated", 0.7), row("unverifiable", 0.7)]);
     expect(r.verdict).toBe("outdated");
+  });
+});
+
+describe("aggregateEvidence — tiebreaking by recency (QUA-992)", () => {
+  // Real-world scenario from QUA-979: re-verifying a personnel record finds
+  // a better source URL and writes a fresh `confirmed` evidence row, but the
+  // record still has stale `unverifiable` evidence from a generic homepage
+  // check. Without the recency tie-break, priority would pick `unverifiable`
+  // (3 < 4) and the fresh re-check would be silently overridden.
+  it("prefers the most-recent bucket on weight ties when both have checkedAt", () => {
+    const old = new Date("2026-04-09T00:00:00Z");
+    const fresh = new Date("2026-05-01T00:00:00Z");
+    const r = aggregateEvidence([
+      row("unverifiable", 1.0, 0.95, old),
+      row("confirmed", 1.0, 0.99, fresh),
+    ]);
+    expect(r.verdict).toBe("confirmed");
+    expect(r.contributing[0].verdict).toBe("confirmed");
+    expect(r.contributing[0].latestCheckedAt).toEqual(fresh);
+  });
+
+  it("recency tie-break works in either direction (newer unverifiable beats older confirmed)", () => {
+    const old = new Date("2026-01-01T00:00:00Z");
+    const fresh = new Date("2026-05-01T00:00:00Z");
+    const r = aggregateEvidence([
+      row("confirmed", 1.0, 0.9, old),
+      row("unverifiable", 1.0, 0.9, fresh),
+    ]);
+    // The fresher unverifiable wins — recency outweighs the priority order's
+    // preference for confirmed in this direction (confirmed has priority 4,
+    // unverifiable has priority 3; without recency the priority tie-break
+    // would still pick unverifiable because it's lower-numbered, so this case
+    // converges with the legacy behavior — but the intent is cleaner now).
+    expect(r.verdict).toBe("unverifiable");
+  });
+
+  it("falls back to priority tie-break when checkedAt is missing on both sides", () => {
+    // Unchanged from pre-QUA-992: tests that don't supply checkedAt still see
+    // the legacy "more-actionable wins" semantics so older callers and the
+    // existing test corpus aren't disturbed.
+    const r = aggregateEvidence([row("contradicted", 0.8), row("confirmed", 0.8)]);
+    expect(r.verdict).toBe("contradicted");
+  });
+
+  it("falls back to priority when only one bucket has checkedAt", () => {
+    // Mixed presence is treated as 'no recency signal' — neither side gets a
+    // recency-driven win. Legacy data has NULL checkedAt; we don't want a
+    // single-row legacy bucket to lose just because the new bucket has a
+    // timestamp. The priority tie-break stays as the safety net.
+    const fresh = new Date("2026-05-01T00:00:00Z");
+    const r = aggregateEvidence([
+      row("unverifiable", 1.0, 0.9, null),
+      row("confirmed", 1.0, 0.9, fresh),
+    ]);
+    expect(r.verdict).toBe("unverifiable");
+  });
+
+  it("recency tie-break does not override a true weight majority", () => {
+    // Weight desc still runs first. A heavier non-fresh bucket wins, even
+    // when a single fresh row dissents at lower weight.
+    const old = new Date("2026-01-01T00:00:00Z");
+    const fresh = new Date("2026-05-01T00:00:00Z");
+    const r = aggregateEvidence([
+      row("confirmed", 1.0, 0.9, old),
+      row("confirmed", 1.0, 0.9, old),
+      row("unverifiable", 1.0, 0.9, fresh),
+    ]);
+    expect(r.verdict).toBe("confirmed");
+  });
+
+  it("ContributingVerdict.latestCheckedAt surfaces the per-bucket max", () => {
+    const t1 = new Date("2026-04-01T00:00:00Z");
+    const t2 = new Date("2026-04-15T00:00:00Z");
+    const t3 = new Date("2026-05-01T00:00:00Z");
+    const r = aggregateEvidence([
+      row("confirmed", 1.0, 0.9, t1),
+      row("confirmed", 1.0, 0.9, t3),
+      row("partial", 0.5, 0.7, t2),
+    ]);
+    expect(r.verdict).toBe("confirmed");
+    const conf = r.contributing.find((c) => c.verdict === "confirmed");
+    const part = r.contributing.find((c) => c.verdict === "partial");
+    expect(conf?.latestCheckedAt).toEqual(t3);
+    expect(part?.latestCheckedAt).toEqual(t2);
   });
 });
 

--- a/apps/wiki-server/src/__tests__/sourcing-aggregation.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-aggregation.test.ts
@@ -221,6 +221,42 @@ describe("aggregateEvidence — tiebreaking by recency (QUA-992)", () => {
     expect(r.verdict).toBe("confirmed");
   });
 
+  it("treats float-epsilon weight differences as ties (QUA-992 hardening)", () => {
+    // Production relevance scores are `real` floats summed across rows, so
+    // values like 0.1 + 0.2 = 0.30000000000000004 are routine. Without an
+    // epsilon the strict `!==` would treat the 1-ULP gap as a real weight
+    // difference and silently skip the recency tie-break — which would
+    // re-introduce the QUA-979 stale-evidence-wins failure for any
+    // production records whose relevance scores don't sum bit-equal.
+    const old = new Date("2026-01-01T00:00:00Z");
+    const fresh = new Date("2026-05-01T00:00:00Z");
+    const r = aggregateEvidence([
+      // Two stale "confirmed" rows summing to 0.30000000000000004.
+      row("confirmed", 0.1, null, old),
+      row("confirmed", 0.2, null, old),
+      // One fresh "unverifiable" row at exactly 0.3 — mathematically equal
+      // but not bit-equal to 0.1 + 0.2.
+      row("unverifiable", 0.3, null, fresh),
+    ]);
+    // Without the epsilon, `confirmed` would win on a 1e-17 weight advantage
+    // and recency would never be consulted. With the epsilon, the buckets
+    // are equal-weight, so recency picks `unverifiable`.
+    expect(r.verdict).toBe("unverifiable");
+  });
+
+  it("falls back to priority when checkedAt is identical across buckets", () => {
+    // Two evidence rows written in the same checker batch (same millisecond)
+    // produce equal recency. Recency tie is silent — priority decides the
+    // winner. Documented here so a future refactor can't silently re-route
+    // same-ms writes through some new ordering rule.
+    const t = new Date("2026-05-01T12:00:00.000Z");
+    const r = aggregateEvidence([
+      row("confirmed", 1.0, 0.9, t),
+      row("contradicted", 1.0, 0.9, t),
+    ]);
+    expect(r.verdict).toBe("contradicted"); // priority 0 < 4
+  });
+
   it("ContributingVerdict.latestCheckedAt surfaces the per-bucket max", () => {
     const t1 = new Date("2026-04-01T00:00:00Z");
     const t2 = new Date("2026-04-15T00:00:00Z");

--- a/apps/wiki-server/src/routes/sourcing/recompute-verdict.ts
+++ b/apps/wiki-server/src/routes/sourcing/recompute-verdict.ts
@@ -91,6 +91,10 @@ async function loadEvidenceRows(
       verdict: recordSources.verdict,
       relevanceScore: recordSources.relevanceScore,
       confidence: recordSources.confidence,
+      // QUA-992: aggregation tie-breaker prefers the bucket whose latest
+      // evidence is most recent. Required so a fresh re-check supersedes
+      // stale evidence at equal weight.
+      checkedAt: recordSources.checkedAt,
     })
     .from(recordSources)
     .where(
@@ -104,6 +108,7 @@ async function loadEvidenceRows(
     verdict: r.verdict as EvidenceRow["verdict"],
     relevanceScore: r.relevanceScore,
     confidence: r.confidence,
+    checkedAt: r.checkedAt,
   }));
 }
 

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts
@@ -47,6 +47,13 @@ export interface EvidenceRow {
   relevanceScore: number | null;
   /** 0..1, NULL means "no confidence reported"; ignored in the average. */
   confidence: number | null;
+  /**
+   * QUA-992: when supplied, breaks ties between equal-weight verdict
+   * buckets in favor of the bucket whose latest evidence is most recent.
+   * NULL is treated as "no recency signal" — falls through to the
+   * priority tie-breaker below. Tests can omit it for back-compat.
+   */
+  checkedAt?: Date | null;
 }
 
 export interface ContributingVerdict {
@@ -55,6 +62,13 @@ export interface ContributingVerdict {
   weight: number;
   /** Number of evidence rows that voted for this verdict. */
   rowCount: number;
+  /**
+   * QUA-992: most-recent `checkedAt` across the rows that voted for this
+   * verdict. Used by the aggregation tie-breaker so a fresh re-check can
+   * supersede stale evidence at equal weight. NULL when none of the rows
+   * supplied a `checkedAt`.
+   */
+  latestCheckedAt?: Date | null;
 }
 
 export interface AggregationResult {

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
@@ -81,6 +81,11 @@ interface Bucket {
   confidenceWeightedSum: number;
   /** Sum of weights for the same rows (used as the denominator). */
   confidenceWeightSum: number;
+  /**
+   * QUA-992: max `checkedAt` across rows in this bucket. NULL when no row
+   * supplied a `checkedAt`. Drives the recency tie-breaker.
+   */
+  latestCheckedAt: Date | null;
 }
 
 /**
@@ -171,7 +176,13 @@ export function aggregateEvidence(
     const w = effectiveWeight(row);
     let bucket = buckets.get(verdict);
     if (!bucket) {
-      bucket = { weight: 0, rowCount: 0, confidenceWeightedSum: 0, confidenceWeightSum: 0 };
+      bucket = {
+        weight: 0,
+        rowCount: 0,
+        confidenceWeightedSum: 0,
+        confidenceWeightSum: 0,
+        latestCheckedAt: null,
+      };
       buckets.set(verdict, bucket);
     }
     bucket.weight += w;
@@ -179,6 +190,11 @@ export function aggregateEvidence(
     if (typeof row.confidence === "number") {
       bucket.confidenceWeightedSum += row.confidence * w;
       bucket.confidenceWeightSum += w;
+    }
+    if (row.checkedAt) {
+      if (!bucket.latestCheckedAt || row.checkedAt > bucket.latestCheckedAt) {
+        bucket.latestCheckedAt = row.checkedAt;
+      }
     }
   }
   if (buckets.size === 0) {
@@ -192,12 +208,13 @@ export function aggregateEvidence(
     };
   }
 
-  // Step 5: pick winner. Score desc, then priority asc.
+  // Step 5: pick winner. Score desc, then recency desc (QUA-992), then priority asc.
   const contributing = sortContributing(
     [...buckets.entries()].map(([verdict, b]) => ({
       verdict,
       weight: b.weight,
       rowCount: b.rowCount,
+      latestCheckedAt: b.latestCheckedAt,
     })),
   );
   const winningVerdict = contributing[0].verdict;
@@ -220,10 +237,19 @@ export function aggregateEvidence(
   };
 }
 
-/** Sort contributing buckets by weight desc, ties broken by priority. */
+/**
+ * Sort contributing buckets by weight desc, ties broken by recency desc
+ * (QUA-992) — a fresh re-check should supersede stale evidence at equal
+ * weight. Final tie-break is `SOURCE_CHECK_VERDICT_PRIORITY` (more-actionable
+ * wins) for callers that don't supply `checkedAt` (e.g. legacy tests, or
+ * legitimately concurrent checks).
+ */
 function sortContributing(items: ContributingVerdict[]): ContributingVerdict[] {
   return [...items].sort((a, b) => {
     if (a.weight !== b.weight) return b.weight - a.weight;
+    const at = a.latestCheckedAt?.getTime() ?? null;
+    const bt = b.latestCheckedAt?.getTime() ?? null;
+    if (at !== null && bt !== null && at !== bt) return bt - at;
     const aPri = SOURCE_CHECK_VERDICT_PRIORITY[a.verdict] ?? 99;
     const bPri = SOURCE_CHECK_VERDICT_PRIORITY[b.verdict] ?? 99;
     return aPri - bPri;

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
@@ -238,6 +238,18 @@ export function aggregateEvidence(
 }
 
 /**
+ * Float-tolerance for weight equality (QUA-992). Production weights come
+ * from the `relevance_score real` PG column and end up summed across rows,
+ * so values like `0.1 + 0.2 = 0.30000000000000004` are routine. Without an
+ * epsilon, a 1-ULP gap defeats `weight !== weight` and silently bypasses
+ * the recency tie-break — exactly the QUA-979 failure mode this fix is
+ * supposed to close. 1e-9 is well below any real relevance signal (`real`
+ * is single-precision, ~7 decimal digits) and well above representation
+ * noise from typical `0.x + 0.y` sums.
+ */
+const WEIGHT_EQUALITY_EPSILON = 1e-9;
+
+/**
  * Sort contributing buckets by weight desc, ties broken by recency desc
  * (QUA-992) — a fresh re-check should supersede stale evidence at equal
  * weight. Final tie-break is `SOURCE_CHECK_VERDICT_PRIORITY` (more-actionable
@@ -246,7 +258,8 @@ export function aggregateEvidence(
  */
 function sortContributing(items: ContributingVerdict[]): ContributingVerdict[] {
   return [...items].sort((a, b) => {
-    if (a.weight !== b.weight) return b.weight - a.weight;
+    const weightDiff = b.weight - a.weight;
+    if (Math.abs(weightDiff) > WEIGHT_EQUALITY_EPSILON) return weightDiff;
     const at = a.latestCheckedAt?.getTime() ?? null;
     const bt = b.latestCheckedAt?.getTime() ?? null;
     if (at !== null && bt !== null && at !== bt) return bt - at;

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -825,6 +825,9 @@ const sourcingApp = new Hono()
         verdict: e.verdict as EvidenceRow["verdict"],
         relevanceScore: e.relevanceScore,
         confidence: e.confidence,
+        // QUA-992: aggregation tie-breaker prefers the bucket whose latest
+        // evidence is most recent.
+        checkedAt: e.checkedAt,
       });
     }
     for (const [key, rows] of evidenceByFieldKey) {


### PR DESCRIPTION
## Summary

Fixes QUA-992 (a blocker for QUA-979): when aggregating `source_check_evidence` rows for a single record, equal-weight verdict buckets used to be tied-broken purely by `SOURCE_CHECK_VERDICT_PRIORITY`, so a stale `unverifiable` row from a generic homepage check could permanently override a fresh `confirmed` row from a better source.

## How it broke QUA-979

Discovered while running `crux tb verify personnel --entity=<sid>` for top non-green orgs. The verify orchestrator finds better URLs via OpenAlex / web research and writes fresh `confirmed` evidence — but the existing aggregate stayed at `unverifiable` because:

```
old: anthropic.com           → unverifiable (weight 1.0, NULL relevance)
new: sleepinyourhat.github.io → confirmed     (weight 1.0, NULL relevance)

aggregate: unverifiable    ← priority 3 < 4, ties go to "more actionable"
```

The reasoning field even narrates the dissent verbatim: `"1 → unverifiable; dissent: 1 → confirmed"`. This artificially capped how high we could push personnel green-rate via the verify path alone — Anthropic batch run got 16/25 → confirmed in evidence but only 5/25 in aggregate.

## Fix

When both buckets supply `checkedAt`, prefer the bucket whose latest evidence is most recent, falling back to the priority tie-breaker when recency is tied or missing on either side.

```
weight desc → recency desc (NEW) → priority asc
```

Changes:
- `EvidenceRow.checkedAt?: Date | null` (optional — back-compat for callers without a timestamp)
- `ContributingVerdict.latestCheckedAt?: Date | null` (per-bucket max, surfaced for diagnostics)
- New tie-break in `sortContributing` in `sourcing-aggregation.ts`
- `recompute-verdict.ts:loadEvidenceRows` and `sourcing.ts` (verdict-detail route) wired through the existing `checkedAt` column

### Float-tolerance for weight equality (review-driven)

Hostile-review pass found a HIGH-severity issue: strict `weight !== weight` skips the recency branch on 1-ULP float gaps. Production relevance scores come from PG `real` and end up summed across rows, so values like `0.1 + 0.2 = 0.30000000000000004` are routine. Without an epsilon, a 1-ULP "win" defeats recency and recreates the QUA-979 bug for any record whose relevance scores don't sum bit-equal — exactly the production case.

Use `Math.abs(weightDiff) > 1e-9` as the equality boundary. The threshold is well below any real relevance signal (`real` is single-precision, ~7 decimal digits) and well above representation noise from typical `0.x + 0.y` sums. Locked in by a regression test built from `0.1 + 0.2 vs 0.3`.

## Tests

7 new tests in `sourcing-aggregation.test.ts`:
- Recency tie-break flips fresh-confirmed over stale-unverifiable (the canonical QUA-979 case)
- Symmetry: fresh-unverifiable beats older-confirmed
- Fallback to priority when both lack `checkedAt`
- Fallback to priority when only one bucket has `checkedAt`
- Weight majority still wins regardless of recency
- `ContributingVerdict.latestCheckedAt` surfaces the per-bucket max
- **Float-eps**: 0.1 + 0.2 vs 0.3 doesn't bypass recency
- **Same-millisecond**: identical timestamps fall back to priority (locks behavior in)

All 31 aggregation tests pass; full wiki-server suite **1659/1659 pass** (57 unrelated skipped). `npx tsc --noEmit` clean. `pnpm crux w validate gate` passes.

## Review notes (deferred, not addressed here)

The hostile-reviewer pass surfaced two MEDIUMs that I judged out of scope:

- **"Mixed `checkedAt` presence":** schema has `checked_at NOT NULL DEFAULT now()` (`schema.ts:1799–1801`), so production rows always have a real timestamp. The mixed-presence path only fires in tests; documented and tested.
- **"Flaky LLM flips on recency":** evidence dedup unique index is on `(record_type, record_id, source_url, checker_model)` (migration 0135). Same-URL re-checks UPSERT, not append. The recency-vs-priority decision only fires across DIFFERENT source URLs, where "newer source disagrees" winning is the desired behavior — and it's the same behavior we already have at heavy weights.

## Deploy plan

After merge:
1. Wiki-server deploy picks up the new aggregation rule.
2. New evidence writes auto-call `recomputeVerdictBestEffort`, so any record that gets re-verified after the deploy uses the new tie-break automatically.
3. To pick up the fix on records that *already* have stale + fresh evidence (no future re-verify needed), a one-shot recompute sweep:
   ```
   for each personnel verdict in source_check_verdicts:
     POST /api/sourcing/verdicts/recompute { recordType, recordId, fieldName }
   ```
   Estimated: 1.5k requests, ~1 minute.

## QUA-979 status (parent ticket)

Verify-batch progress so far on personnel: **48.4% → 56.8% green** (544 → 862 confirmed, 1124 → 1518 checked). The aggregation fix will unlock more `confirmed` from records where fresh re-checks were silently overridden — final number gated on the recompute sweep above. Full status will be posted to QUA-979.

Closes QUA-992.


## Test plan

- [x] `npx vitest run src/__tests__/sourcing-aggregation.test.ts` — 31/31 pass (7 new)
- [x] Full wiki-server suite — 1659/1659 pass
- [x] `npx tsc --noEmit` (wiki-server) — clean
- [x] `pnpm crux w validate gate` — green (cached)
- [x] Hostile-reviewer pass — HIGH float-eps finding addressed; MEDIUMs rejected with rationale in PR body
- [x] Verified the QUA-979 reproduction: `aggregateEvidence([row("unverifiable",1,0.95,old), row("confirmed",1,0.99,fresh)])` → `confirmed` (was: `unverifiable`)

Fixes QUA-979
