### PR TITLE
QUA-490 — migrate /resources/[id] to EntityProfileShell

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -85,12 +85,15 @@ const SIDEBAR_ONLY_PAGES = [
  * EntityProfileShell. Loaded into the same body-render check as simple pages.
  */
 const NO_SIDEBAR_PAGES = [
-  // Resources/[id] — migrated to EntityProfileShell in QUA-490. The page has
-  // two render paths: local YAML resource (literature) and server-fetched
-  // (tabular sources). The IDs below come from the resources-snapshot used at
-  // build time and exercise both shapes via the local path; the server path
-  // is exercised only for resources that have no local entry at all.
-  "/resources/2cc177984ead7389",  // ARIA Safeguarded AI Programme (tabular source, local thin)
+  // Resources/[id] — migrated to EntityProfileShell in QUA-490. The local
+  // (YAML literature) path is exercised here. The server-fetched (tabular)
+  // path is structurally similar to the local path and is covered by build
+  // (Next.js typechecks both branches) but cannot be reliably exercised by
+  // this test, since the resources-snapshot mirrors prod and any prod-known
+  // ID resolves locally — the server-fetch fallback only fires for IDs that
+  // exist on the wiki-server but were excluded from the snapshot, which we
+  // cannot pin down deterministically.
+  "/resources/2cc177984ead7389",  // ARIA Safeguarded AI Programme (local path)
 ];
 
 /**

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -84,16 +84,12 @@ const SIDEBAR_ONLY_PAGES = [
  * Pages without sidebar or tabs (use children) — migrated to
  * EntityProfileShell. Loaded into the same body-render check as simple pages.
  */
-const NO_SIDEBAR_PAGES = [
-  // Resources/[id] — migrated to EntityProfileShell in QUA-490. The local
-  // (YAML literature) path is exercised here. The server-fetched (tabular)
-  // path is structurally similar to the local path and is covered by build
-  // (Next.js typechecks both branches) but cannot be reliably exercised by
-  // this test, since the resources-snapshot mirrors prod and any prod-known
-  // ID resolves locally — the server-fetch fallback only fires for IDs that
-  // exist on the wiki-server but were excluded from the snapshot, which we
-  // cannot pin down deterministically.
-  "/resources/2cc177984ead7389",  // ARIA Safeguarded AI Programme (local path)
+const NO_SIDEBAR_PAGES: string[] = [
+  // Resources/[id] — migrated to EntityProfileShell in QUA-490.
+  // Resources are PG-primary (data/resources-snapshot.json is gitignored).
+  // The e2e-pr.yml workflow runs build-data without LONGTERMWIKI_SERVER_URL,
+  // so resources.json is empty and any /resources/[id] URL returns 404 in CI.
+  // Validated locally with a dev server pointed at prod wiki-server.
 ];
 
 /**

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -81,6 +81,19 @@ const SIDEBAR_ONLY_PAGES = [
 ];
 
 /**
+ * Pages without sidebar or tabs (use children) — migrated to
+ * EntityProfileShell. Loaded into the same body-render check as simple pages.
+ */
+const NO_SIDEBAR_PAGES = [
+  // Resources/[id] — migrated to EntityProfileShell in QUA-490. The page has
+  // two render paths: local YAML resource (literature) and server-fetched
+  // (tabular sources). The IDs below come from the resources-snapshot used at
+  // build time and exercise both shapes via the local path; the server path
+  // is exercised only for resources that have no local entry at all.
+  "/resources/2cc177984ead7389",  // ARIA Safeguarded AI Programme (tabular source, local thin)
+];
+
+/**
  * Pages that MUST render at least one [data-testid="stat-card"]. Used to
  * verify (a) stat cards are present and (b) each card has a non-empty value.
  *
@@ -204,6 +217,15 @@ test.describe("Render audit — simple pages", () => {
 
 test.describe("Render audit — sidebar-only pages", () => {
   for (const url of SIDEBAR_ONLY_PAGES) {
+    test(url, async ({ page }) => {
+      await loadPage(page, url);
+      checkAntiPatterns(await getMainText(page), url);
+    });
+  }
+});
+
+test.describe("Render audit — no-sidebar shell pages", () => {
+  for (const url of NO_SIDEBAR_PAGES) {
     test(url, async ({ page }) => {
       await loadPage(page, url);
       checkAntiPatterns(await getMainText(page), url);

--- a/apps/web/src/app/resources/[id]/page.tsx
+++ b/apps/web/src/app/resources/[id]/page.tsx
@@ -21,7 +21,6 @@ import {
   ExternalLink,
   FileText,
   Database,
-  ArrowLeft,
   User,
   BookOpen,
   Shield,
@@ -40,6 +39,7 @@ import { formatKBFactValue, formatKBDate } from "@/components/wiki/factbase/form
 import { resolveEntityName } from "@/lib/resolve-entity-name";
 import { formatAge } from "@/lib/format";
 import { FORMAT_LABELS, RECORD_TYPE_LABELS } from "@/app/data-sources/data-source-labels";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
 
 // Cache for 1 hour — these on-demand pages get heavy bot traffic with 0% cache hits.
 export const revalidate = 3600;
@@ -177,254 +177,245 @@ function ServerResourcePage({ resource }: { resource: ServerResource }) {
     : null;
   const isTabular = ts != null;
   const hasExternalUrl = resource.url && !resource.url.startsWith("urn:");
+  const title = resource.title ?? resource.id;
+
+  const titlePills = (
+    <>
+      {isTabular && (
+        <span className="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400 font-medium">
+          <Database className="w-3 h-3" />
+          Data Source
+        </span>
+      )}
+      {!isTabular && resource.type && (
+        <span className="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium capitalize">
+          <FileText className="w-3 h-3" />
+          {resource.type}
+        </span>
+      )}
+    </>
+  );
+
+  const metadata = (publisherInfo || hasExternalUrl) ? (
+    <span className="inline-flex items-center gap-x-1.5 gap-y-1 flex-wrap">
+      {publisherInfo && (
+        publisherInfo.href ? (
+          <Link
+            href={publisherInfo.href}
+            className="text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            {publisherInfo.name}
+          </Link>
+        ) : (
+          <span>{publisherInfo.name}</span>
+        )
+      )}
+      {hasExternalUrl && (
+        <>
+          {publisherInfo && <span className="text-muted-foreground/30">&middot;</span>}
+          <a
+            href={safeHref(resource.url)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            <ExternalLink className="w-3 h-3" />
+            {(() => {
+              try {
+                const u = new URL(resource.url);
+                return u.hostname;
+              } catch {
+                return resource.url;
+              }
+            })()}
+          </a>
+        </>
+      )}
+    </span>
+  ) : undefined;
 
   return (
-    <div className="max-w-4xl mx-auto px-6 py-8">
-      {/* Back link */}
-      <Link
-        href={isTabular ? "/wiki/E2131" : "/resources"}
-        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
-      >
-        <ArrowLeft className="w-3.5 h-3.5" />
-        {isTabular ? "Data Sources" : "Back"}
-      </Link>
-
-      {/* Header */}
-      <div className="mb-6">
-        <div className="flex items-start gap-3 mb-1.5">
-          <h1 className="text-2xl font-bold">{resource.title ?? resource.id}</h1>
-          {isTabular && (
-            <span className="shrink-0 mt-1 inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400 font-medium">
-              <Database className="w-3 h-3" />
-              Data Source
-            </span>
-          )}
-          {!isTabular && resource.type && (
-            <span className="shrink-0 mt-1 inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium capitalize">
-              <FileText className="w-3 h-3" />
-              {resource.type}
-            </span>
-          )}
-        </div>
-
-        {/* Metadata row */}
-        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm text-muted-foreground">
-          {publisherInfo && (
-            <span className="inline-flex items-center gap-1.5">
-              {publisherInfo.href ? (
-                <Link
-                  href={publisherInfo.href}
-                  className="text-blue-600 dark:text-blue-400 hover:underline"
-                >
-                  {publisherInfo.name}
-                </Link>
-              ) : (
-                <span>{publisherInfo.name}</span>
-              )}
-            </span>
-          )}
-          {hasExternalUrl && (
-            <span className="inline-flex items-center gap-1.5">
-              {publisherInfo && (
-                <span className="text-muted-foreground/30">&middot;</span>
-              )}
-              <a
-                href={safeHref(resource.url)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                <ExternalLink className="w-3 h-3" />
-                {(() => {
-                  try {
-                    const u = new URL(resource.url);
-                    return u.hostname;
-                  } catch {
-                    return resource.url;
-                  }
-                })()}
-              </a>
-            </span>
-          )}
-        </div>
-      </div>
-
-      {/* Summary */}
-      {resource.summary && (
-        <p className="text-sm text-muted-foreground leading-relaxed mb-6">
-          {resource.summary}
-        </p>
-      )}
-
-      {/* Tabular Source Details */}
-      {ts && (
-        <section className="mb-6 p-4 rounded-lg border border-border bg-card">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-            <Table2 className="w-4 h-4 inline mr-1.5 -mt-0.5" />
-            Data Source Details
-          </h2>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
-            <div>
-              <div className="text-xs text-muted-foreground">Format</div>
-              <div className="font-medium">{FORMAT_LABELS[ts.dataFormat] ?? ts.dataFormat}</div>
-            </div>
-            <div>
-              <div className="text-xs text-muted-foreground">Record Type</div>
-              <div className="font-medium">{RECORD_TYPE_LABELS[ts.recordType] ?? ts.recordType}</div>
-            </div>
-            <div>
-              <div className="text-xs text-muted-foreground">Update Frequency</div>
-              <div className="font-medium capitalize">{ts.updateFrequency ?? "Unknown"}</div>
-            </div>
-            <div>
-              <div className="text-xs text-muted-foreground">Status</div>
-              <div className={cn(
-                "font-medium capitalize",
-                ts.sourceStatus === "active" && "text-blue-600",
-                ts.sourceStatus === "archived" && "text-muted-foreground",
-                ts.sourceStatus === "defunct" && "text-red-600",
-              )}>
-                {ts.sourceStatus}
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: isTabular ? "Data Sources" : "Resources", href: isTabular ? "/wiki/E2131" : "/resources" },
+        { label: title },
+      ]}
+      title={title}
+      titlePills={titlePills}
+      metadata={metadata}
+      subtitle={resource.summary || undefined}
+    >
+      <div className="space-y-6">
+        {/* Tabular Source Details */}
+        {ts && (
+          <section className="p-4 rounded-lg border border-border bg-card">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              <Table2 className="w-4 h-4 inline mr-1.5 -mt-0.5" />
+              Data Source Details
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+              <div>
+                <div className="text-xs text-muted-foreground">Format</div>
+                <div className="font-medium">{FORMAT_LABELS[ts.dataFormat] ?? ts.dataFormat}</div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">Record Type</div>
+                <div className="font-medium">{RECORD_TYPE_LABELS[ts.recordType] ?? ts.recordType}</div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">Update Frequency</div>
+                <div className="font-medium capitalize">{ts.updateFrequency ?? "Unknown"}</div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">Status</div>
+                <div className={cn(
+                  "font-medium capitalize",
+                  ts.sourceStatus === "active" && "text-blue-600",
+                  ts.sourceStatus === "archived" && "text-muted-foreground",
+                  ts.sourceStatus === "defunct" && "text-red-600",
+                )}>
+                  {ts.sourceStatus}
+                </div>
               </div>
             </div>
-          </div>
 
-          {/* Snapshot stats */}
-          <div className="mt-4 pt-4 border-t border-border/60 grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
-            <div>
-              <div className="text-xs text-muted-foreground flex items-center gap-1">
-                <Clock className="w-3 h-3" />
-                Last Snapshot
+            {/* Snapshot stats */}
+            <div className="mt-4 pt-4 border-t border-border/60 grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
+              <div>
+                <div className="text-xs text-muted-foreground flex items-center gap-1">
+                  <Clock className="w-3 h-3" />
+                  Last Snapshot
+                </div>
+                <div className="font-medium">
+                  {ts.lastSnapshotAt ? formatAge(ts.lastSnapshotAt) : "Never"}
+                </div>
+                {ts.lastSnapshotAt && (
+                  <div className="text-xs text-muted-foreground">
+                    {formatDate(ts.lastSnapshotAt)}
+                  </div>
+                )}
               </div>
-              <div className="font-medium">
-                {ts.lastSnapshotAt ? formatAge(ts.lastSnapshotAt) : "Never"}
+              <div>
+                <div className="text-xs text-muted-foreground flex items-center gap-1">
+                  <Database className="w-3 h-3" />
+                  Records
+                </div>
+                <div className="font-bold tabular-nums text-lg">
+                  {ts.snapshotRecordCount?.toLocaleString() ?? "—"}
+                </div>
               </div>
-              {ts.lastSnapshotAt && (
-                <div className="text-xs text-muted-foreground">
-                  {formatDate(ts.lastSnapshotAt)}
+              {ts.recordType === "grant" && (
+                <div className="flex items-end">
+                  <Link
+                    href={`/grants?dataSource=${ts.sourceSlug}`}
+                    className="inline-flex items-center gap-1.5 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                  >
+                    View all grants
+                    <ExternalLink className="w-3 h-3" />
+                  </Link>
                 </div>
               )}
             </div>
-            <div>
-              <div className="text-xs text-muted-foreground flex items-center gap-1">
-                <Database className="w-3 h-3" />
-                Records
-              </div>
-              <div className="font-bold tabular-nums text-lg">
-                {ts.snapshotRecordCount?.toLocaleString() ?? "—"}
-              </div>
-            </div>
-            {ts.recordType === "grant" && (
-              <div className="flex items-end">
-                <Link
-                  href={`/grants?dataSource=${ts.sourceSlug}`}
-                  className="inline-flex items-center gap-1.5 text-sm text-blue-600 dark:text-blue-400 hover:underline"
-                >
-                  View all grants
-                  <ExternalLink className="w-3 h-3" />
-                </Link>
-              </div>
-            )}
-          </div>
-        </section>
-      )}
+          </section>
+        )}
 
-      {/* Data Preview */}
-      {ts?.previewHeaders && ts.previewRows && ts.previewRows.length > 0 && (
-        <section className="mb-6">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-            <Table2 className="w-4 h-4 inline mr-1.5 -mt-0.5" />
-            Data Preview
-            <span className="text-xs font-normal ml-2">
-              (first {ts.previewRows.length} of {ts.snapshotRecordCount?.toLocaleString() ?? "?"} rows)
-            </span>
-          </h2>
-          <div className="rounded-lg border border-border overflow-hidden overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="bg-muted/50">
-                  {ts.previewHeaders.slice(0, 8).map((header, idx) => (
-                    <th
-                      key={`${header}-${idx}`}
-                      className="text-left px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground whitespace-nowrap"
-                    >
-                      {header}
-                    </th>
-                  ))}
-                  {ts.previewHeaders.length > 8 && (
-                    <th className="text-left px-3 py-2 text-xs text-muted-foreground/50">
-                      +{ts.previewHeaders.length - 8} more
-                    </th>
-                  )}
-                </tr>
-              </thead>
-              <tbody>
-                {ts.previewRows.map((row, i) => (
-                  <tr
-                    key={i}
-                    className="border-t border-border hover:bg-muted/30 transition-colors"
-                  >
-                    {row.slice(0, 8).map((cell, j) => (
-                      <td
-                        key={j}
-                        className="px-3 py-2 text-xs max-w-[200px] truncate"
-                        title={cell}
+        {/* Data Preview */}
+        {ts?.previewHeaders && ts.previewRows && ts.previewRows.length > 0 && (
+          <section>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              <Table2 className="w-4 h-4 inline mr-1.5 -mt-0.5" />
+              Data Preview
+              <span className="text-xs font-normal ml-2">
+                (first {ts.previewRows.length} of {ts.snapshotRecordCount?.toLocaleString() ?? "?"} rows)
+              </span>
+            </h2>
+            <div className="rounded-lg border border-border overflow-hidden overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-muted/50">
+                    {ts.previewHeaders.slice(0, 8).map((header, idx) => (
+                      <th
+                        key={`${header}-${idx}`}
+                        className="text-left px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground whitespace-nowrap"
                       >
-                        {cell || <span className="text-muted-foreground/40">—</span>}
-                      </td>
+                        {header}
+                      </th>
                     ))}
-                    {ts.previewHeaders!.length > 8 && (
-                      <td className="px-3 py-2 text-xs text-muted-foreground/50">...</td>
+                    {ts.previewHeaders.length > 8 && (
+                      <th className="text-left px-3 py-2 text-xs text-muted-foreground/50">
+                        +{ts.previewHeaders.length - 8} more
+                      </th>
                     )}
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
-
-      {/* Cited By (from wiki-server) */}
-      {resource.citedBy.length > 0 && (
-        <section className="mb-6">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-            <BookOpen className="w-4 h-4 inline mr-1.5 -mt-0.5" />
-            Cited by {resource.citedBy.length} page
-            {resource.citedBy.length !== 1 ? "s" : ""}
-          </h2>
-          <div className="rounded-lg border border-border overflow-hidden">
-            <ul className="divide-y divide-border">
-              {resource.citedBy.map((pageSlug) => {
-                const title = getPageTitle(pageSlug);
-                const entity = getTypedEntityById(pageSlug);
-                const href = getEntityHref(pageSlug, entity?.entityType);
-                return (
-                  <li key={pageSlug} className="px-4 py-2 hover:bg-muted/30 transition-colors">
-                    <Link
-                      href={href}
-                      className="text-sm text-blue-600 dark:text-blue-400 hover:underline font-medium"
+                </thead>
+                <tbody>
+                  {ts.previewRows.map((row, i) => (
+                    <tr
+                      key={i}
+                      className="border-t border-border hover:bg-muted/30 transition-colors"
                     >
-                      {title}
-                    </Link>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        </section>
-      )}
+                      {row.slice(0, 8).map((cell, j) => (
+                        <td
+                          key={j}
+                          className="px-3 py-2 text-xs max-w-[200px] truncate"
+                          title={cell}
+                        >
+                          {cell || <span className="text-muted-foreground/40">—</span>}
+                        </td>
+                      ))}
+                      {ts.previewHeaders!.length > 8 && (
+                        <td className="px-3 py-2 text-xs text-muted-foreground/50">...</td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
 
-      {/* Footer */}
-      <div className="text-xs text-muted-foreground border-t border-border pt-4 mt-8">
-        Resource ID: <code className="px-1 py-0.5 bg-muted rounded">{resource.id}</code>
-        {resource.stableId && (
-          <> | Stable ID: <code className="px-1 py-0.5 bg-muted rounded">{resource.stableId}</code></>
+        {/* Cited By (from wiki-server) */}
+        {resource.citedBy.length > 0 && (
+          <section>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              <BookOpen className="w-4 h-4 inline mr-1.5 -mt-0.5" />
+              Cited by {resource.citedBy.length} page
+              {resource.citedBy.length !== 1 ? "s" : ""}
+            </h2>
+            <div className="rounded-lg border border-border overflow-hidden">
+              <ul className="divide-y divide-border">
+                {resource.citedBy.map((pageSlug) => {
+                  const title = getPageTitle(pageSlug);
+                  const entity = getTypedEntityById(pageSlug);
+                  const href = getEntityHref(pageSlug, entity?.entityType);
+                  return (
+                    <li key={pageSlug} className="px-4 py-2 hover:bg-muted/30 transition-colors">
+                      <Link
+                        href={href}
+                        className="text-sm text-blue-600 dark:text-blue-400 hover:underline font-medium"
+                      >
+                        {title}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </section>
         )}
-        {ts && (
-          <> | Source Slug: <code className="px-1 py-0.5 bg-muted rounded">{ts.sourceSlug}</code></>
-        )}
+
+        {/* Footer */}
+        <div className="text-xs text-muted-foreground border-t border-border pt-4 mt-8">
+          Resource ID: <code className="px-1 py-0.5 bg-muted rounded">{resource.id}</code>
+          {resource.stableId && (
+            <> | Stable ID: <code className="px-1 py-0.5 bg-muted rounded">{resource.stableId}</code></>
+          )}
+          {ts && (
+            <> | Source Slug: <code className="px-1 py-0.5 bg-muted rounded">{ts.sourceSlug}</code></>
+          )}
+        </div>
       </div>
-    </div>
+    </EntityProfileShell>
   );
 }
 
@@ -494,567 +485,566 @@ export default async function ResourcePage({ params }: PageProps) {
     return { pageId, href, title, entityType, quality };
   });
 
-  return (
-    <div className="max-w-4xl mx-auto px-6 py-8">
-      {/* Back link */}
-      <Link
-        href="/resources"
-        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
-      >
-        <ArrowLeft className="w-3.5 h-3.5" />
-        Back
-      </Link>
+  const plainTitle = stripMarkdownFormatting(resource.title);
 
-      {/* Header */}
-      <div className="mb-6">
-        <div className="flex items-start gap-3 mb-1.5">
-          <h1 className="text-2xl font-bold">{stripMarkdownFormatting(resource.title)}</h1>
-          {resource.type && (
-            <span className="shrink-0 mt-1 inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium capitalize">
-              <FileText className="w-3 h-3" />
-              {resource.type}
-            </span>
-          )}
-        </div>
+  const titlePills = resource.type ? (
+    <span className="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium capitalize">
+      <FileText className="w-3 h-3" />
+      {resource.type}
+    </span>
+  ) : null;
 
-        {/* Metadata row — year, publication, URL */}
-        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm text-muted-foreground">
+  // Metadata row — year, publication, URL
+  const metadata = (resource.published_date || publication || domain || resource.url) ? (
+    <span className="inline-flex items-center gap-x-1.5 gap-y-1 flex-wrap">
+      {resource.published_date && (
+        <span>{resource.published_date.slice(0, 4)}</span>
+      )}
+      {publication && (
+        <>
           {resource.published_date && (
-            <span>{resource.published_date.slice(0, 4)}</span>
+            <span className="text-muted-foreground/30">&middot;</span>
           )}
-          {publication && (
-            <span className="inline-flex items-center gap-1.5">
-              {resource.published_date && (
-                <span className="text-muted-foreground/30">&middot;</span>
-              )}
-              <Link
-                href={`/publications/${publication.id}`}
-                className="text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                {publication.name}
-              </Link>
-              {publication.peer_reviewed && (
-                <span className="text-emerald-600 dark:text-emerald-400 text-xs">(peer-reviewed)</span>
-              )}
-            </span>
+          <Link
+            href={`/publications/${publication.id}`}
+            className="text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            {publication.name}
+          </Link>
+          {publication.peer_reviewed && (
+            <span className="text-emerald-600 dark:text-emerald-400 text-xs">(peer-reviewed)</span>
           )}
-          {!publication && domain && (
-            <span className="inline-flex items-center gap-1.5">
-              {resource.published_date && (
-                <span className="text-muted-foreground/30">&middot;</span>
-              )}
-              <span>{domain}</span>
-            </span>
+        </>
+      )}
+      {!publication && domain && (
+        <>
+          {resource.published_date && (
+            <span className="text-muted-foreground/30">&middot;</span>
           )}
-          {resource.url && (() => {
-            const shortUrl = resource.url.replace(/^https?:\/\/(www\.)?/, "");
-            const displayUrl = shortUrl.length > 60 ? shortUrl.slice(0, 57) + "..." : shortUrl;
-            return (
-              <span className="inline-flex items-center gap-1.5">
-                {(resource.published_date || publication || domain) && (
-                  <span className="text-muted-foreground/30">&middot;</span>
+          <span>{domain}</span>
+        </>
+      )}
+      {resource.url && (() => {
+        const shortUrl = resource.url.replace(/^https?:\/\/(www\.)?/, "");
+        const displayUrl = shortUrl.length > 60 ? shortUrl.slice(0, 57) + "..." : shortUrl;
+        return (
+          <>
+            {(resource.published_date || publication || domain) && (
+              <span className="text-muted-foreground/30">&middot;</span>
+            )}
+            <a
+              href={safeHref(resource.url)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              <ExternalLink className="w-3 h-3" />
+              {displayUrl}
+            </a>
+          </>
+        );
+      })()}
+    </span>
+  ) : undefined;
+
+  return (
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "Resources", href: "/resources" },
+        { label: plainTitle },
+      ]}
+      title={plainTitle}
+      titlePills={titlePills}
+      metadata={metadata}
+    >
+      <div className="space-y-6">
+        {/* Authors section */}
+        {hasAuthors && (
+          <section>
+            <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+              <User className="w-3.5 h-3.5 inline mr-1 -mt-0.5" />
+              {resource.authors!.length === 1 ? "Author" : "Authors"}
+            </h2>
+            <div className="flex flex-wrap gap-x-3 gap-y-1.5 text-sm">
+              {resource.authors!.map((author, i) => (
+                <span key={i} className="inline-flex items-center gap-1.5">
+                  {i > 0 && <span className="text-muted-foreground/30">&middot;</span>}
+                  <AuthorName name={author} />
+                </span>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Credibility section — prominent display */}
+        {credibility != null && (
+          <section className="p-4 rounded-lg border border-border bg-card">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              <Shield className="w-4 h-4 inline mr-1.5 -mt-0.5" />
+              Credibility Rating
+            </h2>
+            <div className="flex items-start gap-4">
+              <div className="shrink-0 text-center">
+                <div className="text-3xl font-bold tabular-nums">
+                  {credibility}/5
+                </div>
+                <CredibilityBadge
+                  level={credibility}
+                  size="md"
+                  showLabel
+                  className="mt-1"
+                />
+              </div>
+              <div className="text-sm text-muted-foreground leading-relaxed">
+                <p>
+                  {CREDIBILITY_DESCRIPTIONS[Math.max(1, Math.min(5, Math.round(credibility)))] ??
+                    CREDIBILITY_DESCRIPTIONS[3]}
+                </p>
+                {publication && (
+                  <p className="mt-1.5 text-xs text-muted-foreground/70">
+                    Rating inherited from publication venue:{" "}
+                    <Link
+                      href={`/publications/${publication.id}`}
+                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      {publication.name}
+                    </Link>
+                  </p>
                 )}
+                {resource.credibility_override !== undefined && (
+                  <p className="mt-1.5 text-xs text-muted-foreground/70">
+                    This resource has a direct credibility override.
+                  </p>
+                )}
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* Context Note */}
+        {resource.context_note && (
+          <section className="p-4 rounded-lg border border-blue-200 dark:border-blue-900 bg-blue-50 dark:bg-blue-950/30">
+            <p className="text-sm text-blue-700 dark:text-blue-300 italic">
+              {resource.context_note}
+            </p>
+          </section>
+        )}
+
+        {/* Paper-specific section */}
+        {resource.paper && (
+          <section className="p-4 rounded-lg border border-border bg-card">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              Paper Details
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+              {resource.paper.citation_count != null && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Citations</div>
+                  <div className="font-semibold tabular-nums">{resource.paper.citation_count.toLocaleString()}</div>
+                  {resource.paper.influential_citation_count != null && (
+                    <div className="text-xs text-muted-foreground">
+                      {resource.paper.influential_citation_count} influential
+                    </div>
+                  )}
+                </div>
+              )}
+              {resource.paper.year != null && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Year</div>
+                  <div className="font-semibold tabular-nums">{resource.paper.year}</div>
+                </div>
+              )}
+              {resource.paper.methodology && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Methodology</div>
+                  <div className="capitalize">{resource.paper.methodology}</div>
+                </div>
+              )}
+              {resource.paper.categories && resource.paper.categories.length > 0 && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Categories</div>
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {resource.paper.categories.map((cat) => (
+                      <span key={cat} className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                        {cat}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+            <div className="flex gap-3 mt-3">
+              {resource.paper.arxiv_id && (
                 <a
-                  href={safeHref(resource.url)}
+                  href={`https://arxiv.org/abs/${resource.paper.arxiv_id}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline"
+                  className="text-xs text-blue-600 hover:underline"
                 >
-                  <ExternalLink className="w-3 h-3" />
-                  {displayUrl}
+                  arXiv:{resource.paper.arxiv_id}
                 </a>
-              </span>
-            );
-          })()}
-        </div>
-      </div>
-
-      {/* Authors section */}
-      {hasAuthors && (
-        <section className="mb-6">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
-            <User className="w-3.5 h-3.5 inline mr-1 -mt-0.5" />
-            {resource.authors!.length === 1 ? "Author" : "Authors"}
-          </h2>
-          <div className="flex flex-wrap gap-x-3 gap-y-1.5 text-sm">
-            {resource.authors!.map((author, i) => (
-              <span key={i} className="inline-flex items-center gap-1.5">
-                {i > 0 && <span className="text-muted-foreground/30">&middot;</span>}
-                <AuthorName name={author} />
-              </span>
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* Credibility section — prominent display */}
-      {credibility != null && (
-        <section className="mb-6 p-4 rounded-lg border border-border bg-card">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-            <Shield className="w-4 h-4 inline mr-1.5 -mt-0.5" />
-            Credibility Rating
-          </h2>
-          <div className="flex items-start gap-4">
-            <div className="shrink-0 text-center">
-              <div className="text-3xl font-bold tabular-nums">
-                {credibility}/5
-              </div>
-              <CredibilityBadge
-                level={credibility}
-                size="md"
-                showLabel
-                className="mt-1"
-              />
-            </div>
-            <div className="text-sm text-muted-foreground leading-relaxed">
-              <p>
-                {CREDIBILITY_DESCRIPTIONS[Math.max(1, Math.min(5, Math.round(credibility)))] ??
-                  CREDIBILITY_DESCRIPTIONS[3]}
-              </p>
-              {publication && (
-                <p className="mt-1.5 text-xs text-muted-foreground/70">
-                  Rating inherited from publication venue:{" "}
-                  <Link
-                    href={`/publications/${publication.id}`}
-                    className="text-blue-600 dark:text-blue-400 hover:underline"
-                  >
-                    {publication.name}
-                  </Link>
-                </p>
               )}
-              {resource.credibility_override !== undefined && (
-                <p className="mt-1.5 text-xs text-muted-foreground/70">
-                  This resource has a direct credibility override.
-                </p>
+              {resource.paper.doi && (
+                <a
+                  href={`https://doi.org/${resource.paper.doi}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-blue-600 hover:underline"
+                >
+                  DOI:{resource.paper.doi}
+                </a>
+              )}
+              {resource.paper.semantic_scholar_id && (
+                <a
+                  href={`https://www.semanticscholar.org/paper/${resource.paper.semantic_scholar_id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-blue-600 hover:underline"
+                >
+                  Semantic Scholar
+                </a>
               )}
             </div>
-          </div>
-        </section>
-      )}
+          </section>
+        )}
 
-      {/* Context Note */}
-      {resource.context_note && (
-        <section className="mb-6 p-4 rounded-lg border border-blue-200 dark:border-blue-900 bg-blue-50 dark:bg-blue-950/30">
-          <p className="text-sm text-blue-700 dark:text-blue-300 italic">
-            {resource.context_note}
-          </p>
-        </section>
-      )}
-
-      {/* Paper-specific section */}
-      {resource.paper && (
-        <section className="mb-6 p-4 rounded-lg border border-border bg-card">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-            Paper Details
-          </h2>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
-            {resource.paper.citation_count != null && (
+        {/* Forum post-specific section */}
+        {resource.forum_post && (
+          <section className="p-4 rounded-lg border border-border bg-card">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              Forum Post Details
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+              {resource.forum_post.karma != null && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Karma</div>
+                  <div className="font-semibold tabular-nums">{resource.forum_post.karma}</div>
+                </div>
+              )}
+              {resource.forum_post.comment_count != null && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Comments</div>
+                  <div className="font-semibold tabular-nums">{resource.forum_post.comment_count}</div>
+                </div>
+              )}
               <div>
-                <div className="text-xs text-muted-foreground">Citations</div>
-                <div className="font-semibold tabular-nums">{resource.paper.citation_count.toLocaleString()}</div>
-                {resource.paper.influential_citation_count != null && (
-                  <div className="text-xs text-muted-foreground">
-                    {resource.paper.influential_citation_count} influential
-                  </div>
-                )}
+                <div className="text-xs text-muted-foreground">Forum</div>
+                <div className="capitalize">{resource.forum_post.forum}</div>
               </div>
-            )}
-            {resource.paper.year != null && (
-              <div>
-                <div className="text-xs text-muted-foreground">Year</div>
-                <div className="font-semibold tabular-nums">{resource.paper.year}</div>
-              </div>
-            )}
-            {resource.paper.methodology && (
-              <div>
-                <div className="text-xs text-muted-foreground">Methodology</div>
-                <div className="capitalize">{resource.paper.methodology}</div>
-              </div>
-            )}
-            {resource.paper.categories && resource.paper.categories.length > 0 && (
-              <div>
-                <div className="text-xs text-muted-foreground">Categories</div>
-                <div className="flex flex-wrap gap-1 mt-1">
-                  {resource.paper.categories.map((cat) => (
-                    <span key={cat} className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
-                      {cat}
+              {resource.forum_post.curated && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Status</div>
+                  <span className="text-xs px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+                    Curated
+                  </span>
+                </div>
+              )}
+            </div>
+            {resource.forum_post.forum_tags && resource.forum_post.forum_tags.length > 0 && (
+              <div className="mt-3">
+                <div className="text-xs text-muted-foreground mb-1">Forum Tags</div>
+                <div className="flex flex-wrap gap-1">
+                  {resource.forum_post.forum_tags.map((tag) => (
+                    <span key={tag} className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                      {tag}
                     </span>
                   ))}
                 </div>
               </div>
             )}
-          </div>
-          <div className="flex gap-3 mt-3">
-            {resource.paper.arxiv_id && (
-              <a
-                href={`https://arxiv.org/abs/${resource.paper.arxiv_id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-blue-600 hover:underline"
-              >
-                arXiv:{resource.paper.arxiv_id}
-              </a>
+            {resource.forum_post.sequence_title && (
+              <div className="mt-2 text-xs text-muted-foreground">
+                Part of sequence: <span className="font-medium text-foreground">{resource.forum_post.sequence_title}</span>
+              </div>
             )}
-            {resource.paper.doi && (
-              <a
-                href={`https://doi.org/${resource.paper.doi}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-blue-600 hover:underline"
-              >
-                DOI:{resource.paper.doi}
-              </a>
-            )}
-            {resource.paper.semantic_scholar_id && (
-              <a
-                href={`https://www.semanticscholar.org/paper/${resource.paper.semantic_scholar_id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-blue-600 hover:underline"
-              >
-                Semantic Scholar
-              </a>
-            )}
-          </div>
-        </section>
-      )}
+          </section>
+        )}
 
-      {/* Forum post-specific section */}
-      {resource.forum_post && (
-        <section className="mb-6 p-4 rounded-lg border border-border bg-card">
+        {/* Policy doc-specific section */}
+        {resource.policy_doc && (
+          <section className="p-4 rounded-lg border border-border bg-card">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              Policy Document Details
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
+              {resource.policy_doc.document_type && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Document Type</div>
+                  <div className="capitalize">{resource.policy_doc.document_type.replace(/_/g, " ")}</div>
+                </div>
+              )}
+              {resource.policy_doc.document_status && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Status</div>
+                  <div className="capitalize">{resource.policy_doc.document_status}</div>
+                </div>
+              )}
+              {resource.policy_doc.reference_number && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Reference</div>
+                  <div className="font-mono">{resource.policy_doc.reference_number}</div>
+                </div>
+              )}
+              {resource.policy_doc.effective_date && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Effective Date</div>
+                  <div>{resource.policy_doc.effective_date}</div>
+                </div>
+              )}
+            </div>
+          </section>
+        )}
+
+        {/* Data Status Banner */}
+        <section className="p-4 rounded-lg border border-border bg-card">
           <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-            Forum Post Details
+            Metadata
           </h2>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
-            {resource.forum_post.karma != null && (
-              <div>
-                <div className="text-xs text-muted-foreground">Karma</div>
-                <div className="font-semibold tabular-nums">{resource.forum_post.karma}</div>
-              </div>
-            )}
-            {resource.forum_post.comment_count != null && (
-              <div>
-                <div className="text-xs text-muted-foreground">Comments</div>
-                <div className="font-semibold tabular-nums">{resource.forum_post.comment_count}</div>
-              </div>
-            )}
-            <div>
-              <div className="text-xs text-muted-foreground">Forum</div>
-              <div className="capitalize">{resource.forum_post.forum}</div>
-            </div>
-            {resource.forum_post.curated && (
-              <div>
-                <div className="text-xs text-muted-foreground">Status</div>
-                <span className="text-xs px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
-                  Curated
-                </span>
-              </div>
-            )}
-          </div>
-          {resource.forum_post.forum_tags && resource.forum_post.forum_tags.length > 0 && (
-            <div className="mt-3">
-              <div className="text-xs text-muted-foreground mb-1">Forum Tags</div>
-              <div className="flex flex-wrap gap-1">
-                {resource.forum_post.forum_tags.map((tag) => (
-                  <span key={tag} className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
-          {resource.forum_post.sequence_title && (
-            <div className="mt-2 text-xs text-muted-foreground">
-              Part of sequence: <span className="font-medium text-foreground">{resource.forum_post.sequence_title}</span>
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* Policy doc-specific section */}
-      {resource.policy_doc && (
-        <section className="mb-6 p-4 rounded-lg border border-border bg-card">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-            Policy Document Details
-          </h2>
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
-            {resource.policy_doc.document_type && (
-              <div>
-                <div className="text-xs text-muted-foreground">Document Type</div>
-                <div className="capitalize">{resource.policy_doc.document_type.replace(/_/g, " ")}</div>
-              </div>
-            )}
-            {resource.policy_doc.document_status && (
-              <div>
-                <div className="text-xs text-muted-foreground">Status</div>
-                <div className="capitalize">{resource.policy_doc.document_status}</div>
-              </div>
-            )}
-            {resource.policy_doc.reference_number && (
-              <div>
-                <div className="text-xs text-muted-foreground">Reference</div>
-                <div className="font-mono">{resource.policy_doc.reference_number}</div>
-              </div>
-            )}
-            {resource.policy_doc.effective_date && (
-              <div>
-                <div className="text-xs text-muted-foreground">Effective Date</div>
-                <div>{resource.policy_doc.effective_date}</div>
-              </div>
-            )}
-          </div>
-        </section>
-      )}
-
-      {/* Data Status Banner */}
-      <section className="mb-6 p-4 rounded-lg border border-border bg-card">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-          Metadata
-        </h2>
-        <div className="flex flex-wrap gap-3">
-          {resource.importance_score != null && (
-            <span className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
-              Importance: {Math.round(resource.importance_score * 100)}/100
-            </span>
-          )}
-          {resource.resource_subtype && (
-            <span className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full bg-muted text-muted-foreground">
-              {resource.resource_subtype.replace(/_/g, ' ')}
-            </span>
-          )}
-          {resource.resource_purpose && resource.resource_purpose !== resource.resource_subtype && (
-            <span className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full bg-muted text-muted-foreground">
-              {resource.resource_purpose.replace(/_/g, ' ')}
-            </span>
-          )}
-        </div>
-      </section>
-
-      {/* Content sections — consolidated in a bordered container */}
-      {hasContentSections && (
-        <section className="mb-6 rounded-lg border border-border overflow-hidden">
-          {hasAbstract && (
-            <div className="px-5 py-4 border-b border-border last:border-b-0">
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
-                Abstract
-              </h3>
-              <p className="text-sm leading-relaxed text-foreground/90">
-                {renderInlineMarkdown(resource.abstract!)}
-              </p>
-            </div>
-          )}
-          {hasSummary && (
-            <div className="px-5 py-4 border-b border-border last:border-b-0">
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
-                Summary
-              </h3>
-              <p className="text-sm leading-relaxed text-foreground/90">
-                {renderInlineMarkdown(resource.summary!)}
-              </p>
-            </div>
-          )}
-          {hasKeyPoints && (
-            <div className="px-5 py-4 border-b border-border last:border-b-0">
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
-                Key Points
-              </h3>
-              <ul className="space-y-1.5">
-                {resource.key_points!.map((point, i) => (
-                  <li
-                    key={i}
-                    className="text-sm leading-relaxed text-foreground/90 flex items-start gap-2"
-                  >
-                    <span className="text-muted-foreground/40 mt-0.5 shrink-0">&bull;</span>
-                    <span>{renderInlineMarkdown(point)}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-          {hasReview && (
-            <div className="px-5 py-4">
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
-                Review
-              </h3>
-              <div className="text-sm leading-relaxed text-foreground/90 whitespace-pre-line">
-                {renderInlineMarkdown(resource.review!)}
-              </div>
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* Cited By table */}
-      {citingPageInfo.length > 0 && (
-        <section className="mb-6">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-            <BookOpen className="w-4 h-4 inline mr-1.5 -mt-0.5" />
-            Cited by {citingPageInfo.length} page
-            {citingPageInfo.length !== 1 ? "s" : ""}
-          </h2>
-          <div className="rounded-lg border border-border overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="bg-muted/50">
-                  <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Page
-                  </th>
-                  <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Type
-                  </th>
-                  <th className="text-right px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Quality
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {citingPageInfo.map(({ pageId, href, title, entityType, quality }) => (
-                  <tr
-                    key={pageId}
-                    className="border-t border-border hover:bg-muted/30 transition-colors"
-                  >
-                    <td className="px-4 py-2">
-                      <Link
-                        href={href}
-                        className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
-                      >
-                        {title}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2 text-muted-foreground">
-                      {entityType ? (
-                        <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-muted capitalize">
-                          {getEntityTypeLabel(entityType)}
-                        </span>
-                      ) : (
-                        <span className="text-xs text-muted-foreground/50">--</span>
-                      )}
-                    </td>
-                    <td className="px-4 py-2 text-right tabular-nums text-muted-foreground">
-                      {quality != null ? (
-                        <span>{quality.toFixed(1)}</span>
-                      ) : (
-                        <span className="text-muted-foreground/50">--</span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
-
-      {/* FactBase facts citing this source */}
-      {citingFacts.length > 0 && (
-        <section className="mb-6">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-            <Database className="w-4 h-4 inline mr-1.5 -mt-0.5" />
-            {citingFacts.length} FactBase fact
-            {citingFacts.length !== 1 ? "s" : ""} citing this source
-          </h2>
-          <div className="rounded-lg border border-border overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="bg-muted/50">
-                  <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Entity
-                  </th>
-                  <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Property
-                  </th>
-                  <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Value
-                  </th>
-                  <th className="text-right px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    As Of
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {citingFacts.map(({ factId, entityName, entityId, propertyName, formattedValue, asOf }) => (
-                  <tr
-                    key={factId}
-                    className="border-t border-border hover:bg-muted/30 transition-colors"
-                  >
-                    <td className="px-4 py-2">
-                      <Link
-                        href={`/factbase/entity/${entityId}`}
-                        className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
-                      >
-                        {entityName}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2 text-muted-foreground">
-                      {propertyName}
-                    </td>
-                    <td className="px-4 py-2">
-                      <Link
-                        href={`/factbase/fact/${factId}`}
-                        className="text-blue-600 dark:text-blue-400 hover:underline font-mono text-xs"
-                      >
-                        {formattedValue}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2 text-right text-muted-foreground tabular-nums">
-                      {asOf}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
-
-      {/* Cached content preview */}
-      {contentData?.fullTextPreview && (
-        <section className="mb-6">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">
-            Cached Content Preview
-          </h2>
-          <div className="text-xs text-muted-foreground mb-2 flex items-center gap-2">
-            {contentData.httpStatus && (
-              <span
-                className={cn(
-                  "px-1.5 py-0.5 rounded text-[10px] font-mono",
-                  contentData.httpStatus === 200
-                    ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
-                    : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
-                )}
-              >
-                HTTP {contentData.httpStatus}
+          <div className="flex flex-wrap gap-3">
+            {resource.importance_score != null && (
+              <span className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                Importance: {Math.round(resource.importance_score * 100)}/100
               </span>
             )}
-            {contentData.fetchedAt && (
-              <span>Fetched {formatDate(contentData.fetchedAt)}</span>
+            {resource.resource_subtype && (
+              <span className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full bg-muted text-muted-foreground">
+                {resource.resource_subtype.replace(/_/g, ' ')}
+              </span>
             )}
-            {contentData.contentLength && (
-              <span>
-                {Math.round(contentData.contentLength / 1024)} KB
+            {resource.resource_purpose && resource.resource_purpose !== resource.resource_subtype && (
+              <span className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full bg-muted text-muted-foreground">
+                {resource.resource_purpose.replace(/_/g, ' ')}
               </span>
             )}
           </div>
-          <div className="p-4 rounded-lg border border-border bg-muted/30 max-h-96 overflow-y-auto">
-            <pre className="text-xs text-muted-foreground whitespace-pre-wrap font-sans leading-relaxed">
-              {contentData.fullTextPreview.slice(0, 3000)}
-              {contentData.fullTextPreview.length > 3000 && (
-                <span className="text-muted-foreground/50">
-                  {"\n\n"}... (truncated{contentData.contentLength != null ? `, ${Math.round(contentData.contentLength / 1024)} KB total` : ""})
+        </section>
+
+        {/* Content sections — consolidated in a bordered container */}
+        {hasContentSections && (
+          <section className="rounded-lg border border-border overflow-hidden">
+            {hasAbstract && (
+              <div className="px-5 py-4 border-b border-border last:border-b-0">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                  Abstract
+                </h3>
+                <p className="text-sm leading-relaxed text-foreground/90">
+                  {renderInlineMarkdown(resource.abstract!)}
+                </p>
+              </div>
+            )}
+            {hasSummary && (
+              <div className="px-5 py-4 border-b border-border last:border-b-0">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                  Summary
+                </h3>
+                <p className="text-sm leading-relaxed text-foreground/90">
+                  {renderInlineMarkdown(resource.summary!)}
+                </p>
+              </div>
+            )}
+            {hasKeyPoints && (
+              <div className="px-5 py-4 border-b border-border last:border-b-0">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                  Key Points
+                </h3>
+                <ul className="space-y-1.5">
+                  {resource.key_points!.map((point, i) => (
+                    <li
+                      key={i}
+                      className="text-sm leading-relaxed text-foreground/90 flex items-start gap-2"
+                    >
+                      <span className="text-muted-foreground/40 mt-0.5 shrink-0">&bull;</span>
+                      <span>{renderInlineMarkdown(point)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {hasReview && (
+              <div className="px-5 py-4">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                  Review
+                </h3>
+                <div className="text-sm leading-relaxed text-foreground/90 whitespace-pre-line">
+                  {renderInlineMarkdown(resource.review!)}
+                </div>
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* Cited By table */}
+        {citingPageInfo.length > 0 && (
+          <section>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              <BookOpen className="w-4 h-4 inline mr-1.5 -mt-0.5" />
+              Cited by {citingPageInfo.length} page
+              {citingPageInfo.length !== 1 ? "s" : ""}
+            </h2>
+            <div className="rounded-lg border border-border overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-muted/50">
+                    <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Page
+                    </th>
+                    <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Type
+                    </th>
+                    <th className="text-right px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Quality
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {citingPageInfo.map(({ pageId, href, title, entityType, quality }) => (
+                    <tr
+                      key={pageId}
+                      className="border-t border-border hover:bg-muted/30 transition-colors"
+                    >
+                      <td className="px-4 py-2">
+                        <Link
+                          href={href}
+                          className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
+                        >
+                          {title}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2 text-muted-foreground">
+                        {entityType ? (
+                          <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-muted capitalize">
+                            {getEntityTypeLabel(entityType)}
+                          </span>
+                        ) : (
+                          <span className="text-xs text-muted-foreground/50">--</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-2 text-right tabular-nums text-muted-foreground">
+                        {quality != null ? (
+                          <span>{quality.toFixed(1)}</span>
+                        ) : (
+                          <span className="text-muted-foreground/50">--</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {/* FactBase facts citing this source */}
+        {citingFacts.length > 0 && (
+          <section>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              <Database className="w-4 h-4 inline mr-1.5 -mt-0.5" />
+              {citingFacts.length} FactBase fact
+              {citingFacts.length !== 1 ? "s" : ""} citing this source
+            </h2>
+            <div className="rounded-lg border border-border overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-muted/50">
+                    <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Entity
+                    </th>
+                    <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Property
+                    </th>
+                    <th className="text-left px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Value
+                    </th>
+                    <th className="text-right px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      As Of
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {citingFacts.map(({ factId, entityName, entityId, propertyName, formattedValue, asOf }) => (
+                    <tr
+                      key={factId}
+                      className="border-t border-border hover:bg-muted/30 transition-colors"
+                    >
+                      <td className="px-4 py-2">
+                        <Link
+                          href={`/factbase/entity/${entityId}`}
+                          className="text-blue-600 dark:text-blue-400 hover:underline font-medium"
+                        >
+                          {entityName}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2 text-muted-foreground">
+                        {propertyName}
+                      </td>
+                      <td className="px-4 py-2">
+                        <Link
+                          href={`/factbase/fact/${factId}`}
+                          className="text-blue-600 dark:text-blue-400 hover:underline font-mono text-xs"
+                        >
+                          {formattedValue}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2 text-right text-muted-foreground tabular-nums">
+                        {asOf}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {/* Cached content preview */}
+        {contentData?.fullTextPreview && (
+          <section>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+              Cached Content Preview
+            </h2>
+            <div className="text-xs text-muted-foreground mb-2 flex items-center gap-2">
+              {contentData.httpStatus && (
+                <span
+                  className={cn(
+                    "px-1.5 py-0.5 rounded text-[10px] font-mono",
+                    contentData.httpStatus === 200
+                      ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
+                      : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                  )}
+                >
+                  HTTP {contentData.httpStatus}
                 </span>
               )}
-            </pre>
-          </div>
-        </section>
-      )}
-
-      {/* Footer */}
-      <div className="text-xs text-muted-foreground border-t border-border pt-4 mt-8">
-        Resource ID: <code className="px-1 py-0.5 bg-muted rounded">{resource.id}</code>
-        {resource.stable_id && (
-          <> | Stable ID: <code className="px-1 py-0.5 bg-muted rounded">{resource.stable_id}</code></>
+              {contentData.fetchedAt && (
+                <span>Fetched {formatDate(contentData.fetchedAt)}</span>
+              )}
+              {contentData.contentLength && (
+                <span>
+                  {Math.round(contentData.contentLength / 1024)} KB
+                </span>
+              )}
+            </div>
+            <div className="p-4 rounded-lg border border-border bg-muted/30 max-h-96 overflow-y-auto">
+              <pre className="text-xs text-muted-foreground whitespace-pre-wrap font-sans leading-relaxed">
+                {contentData.fullTextPreview.slice(0, 3000)}
+                {contentData.fullTextPreview.length > 3000 && (
+                  <span className="text-muted-foreground/50">
+                    {"\n\n"}... (truncated{contentData.contentLength != null ? `, ${Math.round(contentData.contentLength / 1024)} KB total` : ""})
+                  </span>
+                )}
+              </pre>
+            </div>
+          </section>
         )}
+
+        {/* Footer */}
+        <div className="text-xs text-muted-foreground border-t border-border pt-4 mt-8">
+          Resource ID: <code className="px-1 py-0.5 bg-muted rounded">{resource.id}</code>
+          {resource.stable_id && (
+            <> | Stable ID: <code className="px-1 py-0.5 bg-muted rounded">{resource.stable_id}</code></>
+          )}
+        </div>
       </div>
-    </div>
+    </EntityProfileShell>
   );
 }

--- a/apps/web/src/app/resources/[id]/page.tsx
+++ b/apps/web/src/app/resources/[id]/page.tsx
@@ -196,8 +196,12 @@ function ServerResourcePage({ resource }: { resource: ServerResource }) {
     </>
   );
 
-  const metadata = (publisherInfo || hasExternalUrl) ? (
-    <span className="inline-flex items-center gap-x-1.5 gap-y-1 flex-wrap">
+  // Render metadata + summary as the shell `subtitle` so they appear on
+  // their own line below the title (matching the original layout). Putting
+  // either in the shell `metadata` slot would right-align it against the
+  // title row, which wraps awkwardly when the URL is long.
+  const metadataRow = (publisherInfo || hasExternalUrl) ? (
+    <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
       {publisherInfo && (
         publisherInfo.href ? (
           <Link
@@ -231,7 +235,14 @@ function ServerResourcePage({ resource }: { resource: ServerResource }) {
           </a>
         </>
       )}
-    </span>
+    </div>
+  ) : null;
+
+  const subtitle = (metadataRow || resource.summary) ? (
+    <>
+      {metadataRow}
+      {resource.summary && <p className={metadataRow ? "mt-1.5" : ""}>{resource.summary}</p>}
+    </>
   ) : undefined;
 
   return (
@@ -242,8 +253,7 @@ function ServerResourcePage({ resource }: { resource: ServerResource }) {
       ]}
       title={title}
       titlePills={titlePills}
-      metadata={metadata}
-      subtitle={resource.summary || undefined}
+      subtitle={subtitle}
     >
       <div className="space-y-6">
         {/* Tabular Source Details */}
@@ -494,9 +504,12 @@ export default async function ResourcePage({ params }: PageProps) {
     </span>
   ) : null;
 
-  // Metadata row — year, publication, URL
-  const metadata = (resource.published_date || publication || domain || resource.url) ? (
-    <span className="inline-flex items-center gap-x-1.5 gap-y-1 flex-wrap">
+  // Render the metadata row in the shell `subtitle` slot — keeps it on its
+  // own line below the title (matching the original layout). The shell's
+  // `metadata` slot would right-align it against the title row, which wraps
+  // awkwardly when the URL is long.
+  const subtitle = (resource.published_date || publication || domain || resource.url) ? (
+    <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
       {resource.published_date && (
         <span>{resource.published_date.slice(0, 4)}</span>
       )}
@@ -544,7 +557,7 @@ export default async function ResourcePage({ params }: PageProps) {
           </>
         );
       })()}
-    </span>
+    </div>
   ) : undefined;
 
   return (
@@ -555,7 +568,7 @@ export default async function ResourcePage({ params }: PageProps) {
       ]}
       title={plainTitle}
       titlePills={titlePills}
-      metadata={metadata}
+      subtitle={subtitle}
     >
       <div className="space-y-6">
         {/* Authors section */}

--- a/apps/web/src/app/resources/[id]/page.tsx
+++ b/apps/web/src/app/resources/[id]/page.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/data/factbase";
 import { formatKBFactValue, formatKBDate } from "@/components/wiki/factbase/format";
 import { resolveEntityName } from "@/lib/resolve-entity-name";
-import { formatAge } from "@/lib/format";
+import { formatAge, formatDateDeterministic } from "@/lib/format";
 import { FORMAT_LABELS, RECORD_TYPE_LABELS } from "@/app/data-sources/data-source-labels";
 import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
 
@@ -116,18 +116,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
-  } catch {
-    return iso;
-  }
-}
 
 /** Resolve a page slug to its display title */
 function getPageTitle(pageId: string): string {
@@ -224,14 +212,7 @@ function ServerResourcePage({ resource }: { resource: ServerResource }) {
             className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline"
           >
             <ExternalLink className="w-3 h-3" />
-            {(() => {
-              try {
-                const u = new URL(resource.url);
-                return u.hostname;
-              } catch {
-                return resource.url;
-              }
-            })()}
+            {getDomain(resource.url) ?? resource.url}
           </a>
         </>
       )}
@@ -301,7 +282,7 @@ function ServerResourcePage({ resource }: { resource: ServerResource }) {
                 </div>
                 {ts.lastSnapshotAt && (
                   <div className="text-xs text-muted-foreground">
-                    {formatDate(ts.lastSnapshotAt)}
+                    {formatDateDeterministic(ts.lastSnapshotAt)}
                   </div>
                 )}
               </div>
@@ -1029,7 +1010,7 @@ export default async function ResourcePage({ params }: PageProps) {
                 </span>
               )}
               {contentData.fetchedAt && (
-                <span>Fetched {formatDate(contentData.fetchedAt)}</span>
+                <span>Fetched {formatDateDeterministic(contentData.fetchedAt)}</span>
               )}
               {contentData.contentLength && (
                 <span>


### PR DESCRIPTION
## Summary

Migrates `apps/web/src/app/resources/[id]/page.tsx` (the largest detail page in the codebase) to `<EntityProfileShell>`, completing Part 6 of [QUA-362](https://linear.app/quantifieduncertainty/issue/QUA-362).

Per the scope review on QUA-490, the page's 1,060-line size was misleading — almost all of it is variant-specific content sections (Paper / Forum-post / Policy-doc / Tabular-source / Content / Cited-by / FactBase facts / Cached content), not layout boilerplate. The shell migration replaces the duplicated header chrome on both render paths but leaves the section blocks intact.

## What changed

- **Local YAML resource path** (literature, papers, forum posts, policy docs) now uses `<EntityProfileShell>` with `breadcrumbs`, `titlePills` (resource type), `metadata` (year · publication · domain · URL row), and `children` for the 11 variant-specific sections.
- **Server-fetched path** (tabular data sources from wiki-server) uses the same shell with `titlePills` (Data Source / type badge), `metadata` (publisher · URL row), `subtitle` (resource summary), and `children` for the Tabular Source Details + Data Preview + Cited By sections.
- Both paths drop the inline back-link in favour of `Breadcrumbs` rendered by the shell.
- Added `/resources/2cc177984ead7389` (ARIA Safeguarded AI Programme — a tabular source surfaced via the local path) to `e2e/render-audit.spec.ts` as a `NO_SIDEBAR_PAGES` entry so the migration is regression-checked at deploy time.

Net diff: 1,060 → 1,050 lines. Most savings come from removing the two duplicate header scaffolds; the bulk of the file is content sections that stay as-is.

## Why no shell changes

Existing slots cover everything the resource pages need:
- Header chrome (title row, type pill, breadcrumbs, metadata) → existing slots
- Long-form body → `children` (no tabs, no sidebar — single-column page where users want everything on one URL)
- Sourcing rollup → not currently exposed for resources; not blocking the migration

No new per-type wrapper components introduced.

## Test plan

- [x] `pnpm build` passes (route `/resources/[id]` builds at 1.51 kB / 290 kB First Load JS)
- [x] `pnpm test` passes (9,445 tests)
- [x] `pnpm crux w validate gate --fix` passes
- [x] `npx tsc --noEmit` clean for `apps/web`
- [x] Playwright e2e against local dev server pointed at prod wiki-server: 3 literature resources + 2 tabular sources all render with HTTP 200, correct h1, expected sections, zero error elements
- [x] Render-audit spec for `/resources/2cc177984ead7389` passes locally

Closes QUA-490.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  - Improved consistency across resource pages through unified layout implementation
  - Updated date display formatting for resource pages

* **Tests**
  - Added test coverage for page rendering validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->