### PR TITLE
feat(QUA-489): migrate /things/[id] to EntityProfileShell; defer /wiki/[id]

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -119,6 +119,11 @@ const SIMPLE_PAGES = [
   "/scorecards",  // QUA-688 scorecards directory
   "/scorecards/fli_index",  // QUA-837 per-scorecard detail route
   "/divisions",  // QUA-897 sourcing-summary header
+  // NOTE: /things/[id] was migrated to EntityProfileShell in QUA-489 but is
+  // not in this list — its records live only in PG, so the page 404s in the
+  // PR-CI build (LONGTERMWIKI_SERVER_URL unset). Validated locally with
+  // PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com, same pattern as
+  // investments/funding-rounds/funding-programs from QUA-487.
 ];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/app/things/[id]/page.tsx
+++ b/apps/web/src/app/things/[id]/page.tsx
@@ -5,19 +5,18 @@ import {
   Database,
   ShieldCheck,
   ExternalLink,
-  ArrowRight,
-  Layers,
 } from "lucide-react";
-import { Breadcrumbs } from "@/components/directory/Breadcrumbs";
 import { fetchDetailed } from "@/lib/wiki-server";
 import type { RpcSourcingDetailResult } from "@/lib/wiki-server";
 import { sanitizeRawLargeNumbers } from "@/lib/format-compact";
 import {
   VerdictBadge,
-  formatRecordType,
   getStoredVerdictHref,
 } from "../../sourcing/sourcing-shared";
 import { isAnySid } from "@longterm-wiki/id-utils";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
+import type { EntityProfileShellHeaderLink } from "@/components/entity/EntityProfileShell";
+import { SOURCE_CHECK_VERDICT_PRIORITY } from "@/components/shared/verdict-styles";
 
 export const revalidate = 300;
 export const dynamicParams = true;
@@ -81,6 +80,27 @@ function sourceTableToRecordType(sourceTable: string): string {
   return SOURCE_TABLE_TO_RECORD_TYPE[sourceTable] ?? sourceTable.replace(/_/g, "-");
 }
 
+/**
+ * Reduce a list of per-field verdicts to a single rollup verdict, preferring
+ * the most actionable (contradicted > outdated > partial > ...). Mirrors
+ * `rollupVerdictFromSummary` from `@/components/entity/entity-sourcing` but
+ * works on `RpcSourcingDetailResult.verdicts` directly so we don't need to
+ * round-trip through the entity-summary endpoint.
+ */
+function rollupRecordVerdict(verdicts: RpcSourcingDetailResult["verdicts"]): string | null {
+  if (verdicts.length === 0) return null;
+  let best: string | null = null;
+  let bestPriority = Infinity;
+  for (const v of verdicts) {
+    const p = SOURCE_CHECK_VERDICT_PRIORITY[v.verdict] ?? 99;
+    if (p < bestPriority) {
+      bestPriority = p;
+      best = v.verdict;
+    }
+  }
+  return best;
+}
+
 // ── Metadata ───────────────────────────────────────────────────────────
 
 interface PageProps {
@@ -111,7 +131,7 @@ export async function generateMetadata({
 // ── Helpers ────────────────────────────────────────────────────────────
 
 function formatTimestamp(ts: string | null): string {
-  if (!ts) return "\u2014";
+  if (!ts) return "—";
   try {
     return new Date(ts).toLocaleString("en-US", {
       dateStyle: "medium",
@@ -123,7 +143,7 @@ function formatTimestamp(ts: string | null): string {
 }
 
 function ChildrenSummary({ count, byType }: { count: number; byType: Record<string, number> }) {
-  if (count === 0) return <span className="text-muted-foreground">{"\u2014"}</span>;
+  if (count === 0) return <span className="text-muted-foreground">{"—"}</span>;
 
   const entries = Object.entries(byType).sort(([, a], [, b]) => b - a);
   return (
@@ -154,7 +174,7 @@ function RecordValue({
 }) {
   // Null / undefined
   if (value === null || value === undefined) {
-    return <span className="text-muted-foreground">{"\u2014"}</span>;
+    return <span className="text-muted-foreground">{"—"}</span>;
   }
 
   // Boolean
@@ -196,9 +216,9 @@ function RecordValue({
             try {
               const url = new URL(value);
               const display = url.hostname + url.pathname;
-              return display.length > 80 ? display.slice(0, 80) + "\u2026" : display;
+              return display.length > 80 ? display.slice(0, 80) + "…" : display;
             } catch {
-              return value.length > 80 ? value.slice(0, 80) + "\u2026" : value;
+              return value.length > 80 ? value.slice(0, 80) + "…" : value;
             }
           })()}
         </a>
@@ -212,7 +232,7 @@ function RecordValue({
 
     // Long string — truncate
     if (value.length > 300) {
-      return <span className="text-sm">{value.slice(0, 300)}{"\u2026"}</span>;
+      return <span className="text-sm">{value.slice(0, 300)}{"…"}</span>;
     }
 
     return <span className="text-sm">{value}</span>;
@@ -257,7 +277,7 @@ function RecordValue({
     } catch {
       json = "[Unable to serialize]";
     }
-    const display = json.length > 300 ? json.slice(0, 300) + "\u2026" : json;
+    const display = json.length > 300 ? json.slice(0, 300) + "…" : json;
     return (
       <pre className="text-xs bg-muted px-2 py-1 rounded overflow-x-auto max-w-full whitespace-pre-wrap">
         {display}
@@ -304,8 +324,9 @@ export default async function ThingDetailPage({ params }: PageProps) {
 
   // Fetch sourcing verdicts and record data in parallel
   const recordType = sourceTableToRecordType(thing.sourceTable);
+  const supportsVerdicts = VERDICT_SOURCE_TABLES.has(thing.sourceTable);
 
-  const verdictsPromise = VERDICT_SOURCE_TABLES.has(thing.sourceTable)
+  const verdictsPromise = supportsVerdicts
     ? fetchDetailed<RpcSourcingDetailResult>(
         `/api/sourcing/verdicts/${encodeURIComponent(recordType)}/${encodeURIComponent(thing.sourceId)}`,
         { revalidate: 300 }
@@ -333,6 +354,43 @@ export default async function ThingDetailPage({ params }: PageProps) {
   }
 
   const hasVerdicts = verdicts && verdicts.verdicts.length > 0;
+  const rollupVerdict = supportsVerdicts && verdicts ? rollupRecordVerdict(verdicts.verdicts) : null;
+  const sourcingHref = supportsVerdicts ? getStoredVerdictHref(recordType, thing.sourceId) : null;
+
+  // Header pieces -----------------------------------------------------------
+
+  const titlePills = (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-violet-500/10 px-2.5 py-0.5 text-[11px] font-semibold text-violet-600 dark:text-violet-400">
+      <Database className="h-3 w-3" />
+      {thing.thingType}
+    </span>
+  );
+
+  const subtitle = thing.parentTitle && thing.parentThingId ? (
+    <p className="text-sm text-muted-foreground">
+      Child of{" "}
+      <Link
+        href={`/things/${encodeURIComponent(thing.parentThingId)}`}
+        className="text-blue-600 hover:underline dark:text-blue-400"
+      >
+        {thing.parentTitle}
+      </Link>
+    </p>
+  ) : undefined;
+
+  const headerLinks: EntityProfileShellHeaderLink[] = [];
+  if (thing.href) {
+    headerLinks.push({ label: "Full page", href: thing.href });
+  }
+  if (thing.parentThingId) {
+    headerLinks.push({
+      label: "Entity profile",
+      href: `/wiki/E1929?entity=${encodeURIComponent(thing.parentThingId)}`,
+    });
+  }
+  if (sourcingHref) {
+    headerLinks.push({ label: "Source checks", href: sourcingHref });
+  }
 
   // Metadata rows for the key-value table
   const metadataRows: { label: string; value: React.ReactNode }[] = [
@@ -374,7 +432,7 @@ export default async function ThingDetailPage({ params }: PageProps) {
       value: (
         <span className="text-sm">
           {sanitized.length > 300
-            ? sanitized.slice(0, 300) + "\u2026"
+            ? sanitized.slice(0, 300) + "…"
             : sanitized}
         </span>
       ),
@@ -447,266 +505,201 @@ export default async function ThingDetailPage({ params }: PageProps) {
   );
 
   return (
-    <div className="max-w-4xl mx-auto px-6 py-8">
-      <Breadcrumbs
-        items={[
-          { label: "Things", href: "/things" },
-          { label: thing.title },
-        ]}
-      />
-
-      {/* Header */}
-      <div className="mb-6">
-        <div className="flex items-center gap-2 mb-3">
-          <span className="inline-flex items-center gap-1.5 rounded-full bg-violet-500/10 px-2.5 py-0.5 text-[11px] font-semibold text-violet-600 dark:text-violet-400">
-            <Database className="h-3 w-3" />
-            {thing.thingType}
-          </span>
-        </div>
-
-        <h1 className="text-2xl font-bold mb-1">{thing.title}</h1>
-
-        {thing.parentTitle && thing.parentThingId && (
-          <p className="text-sm text-muted-foreground mb-2">
-            Child of{" "}
-            <Link
-              href={`/things/${encodeURIComponent(thing.parentThingId)}`}
-              className="text-blue-600 hover:underline dark:text-blue-400"
-            >
-              {thing.parentTitle}
-            </Link>
-          </p>
-        )}
-      </div>
-
-      {/* Navigation links */}
-      <div className="flex flex-wrap gap-3 mb-8">
-        {thing.href && (
-          <Link
-            href={thing.href}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-3 py-1.5 text-sm hover:bg-muted/50 transition-colors"
-          >
-            <ArrowRight className="h-3.5 w-3.5" />
-            View full page
-          </Link>
-        )}
-        {thing.parentThingId && (
-          <Link
-            href={`/wiki/E1929?entity=${encodeURIComponent(thing.parentThingId)}`}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-3 py-1.5 text-sm hover:bg-muted/50 transition-colors"
-          >
-            <Layers className="h-3.5 w-3.5" />
-            View entity profile
-          </Link>
-        )}
-        {VERDICT_SOURCE_TABLES.has(thing.sourceTable) && (
-          <Link
-            href={getStoredVerdictHref(recordType, thing.sourceId)}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-3 py-1.5 text-sm hover:bg-muted/50 transition-colors"
-          >
-            <ShieldCheck className="h-3.5 w-3.5" />
-            Source checks
-          </Link>
-        )}
-      </div>
-
-      {/* Thing Metadata table */}
-      <section className="mb-8">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-          Metadata
-        </h2>
-        <div className="rounded-lg border border-border/60 overflow-hidden">
-          <table className="w-full text-sm">
-            <tbody className="divide-y divide-border/30">
-              {metadataRows.map((row) => (
-                <tr key={row.label}>
-                  <td className="px-4 py-2.5 text-muted-foreground font-medium whitespace-nowrap w-36 align-top">
-                    {row.label}
-                  </td>
-                  <td className="px-4 py-2.5">{row.value}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
-
-      {/* Record Data */}
-      <section className="mb-8">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-          <span className="inline-flex items-center gap-1.5">
-            <Database className="h-4 w-4" />
-            Record Data
-          </span>
-        </h2>
-        {recordData && Object.keys(recordData.record).length > 0 ? (
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "Things", href: "/things" },
+        { label: thing.title },
+      ]}
+      title={thing.title}
+      titlePills={titlePills}
+      subtitle={subtitle}
+      headerLinks={headerLinks}
+      verdict={supportsVerdicts ? rollupVerdict : undefined}
+      verdictHref={sourcingHref ?? undefined}
+    >
+      <div className="space-y-8">
+        {/* Thing Metadata table */}
+        <section>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+            Metadata
+          </h2>
           <div className="rounded-lg border border-border/60 overflow-hidden">
             <table className="w-full text-sm">
               <tbody className="divide-y divide-border/30">
-                {Object.entries(recordData.record)
-                  .filter(([key]) => !METADATA_FIELDS.has(key))
-                  .map(([key, value]) => (
-                    <tr key={key}>
-                      <td className="px-4 py-2.5 text-muted-foreground font-medium whitespace-nowrap w-48 align-top">
-                        <code className="text-[12px]">{key}</code>
-                      </td>
-                      <td className="px-4 py-2.5">
-                        <RecordValue
-                          fieldKey={key}
-                          value={value}
-                          displayNames={recordData!.displayNames}
-                        />
-                      </td>
-                    </tr>
-                  ))}
+                {metadataRows.map((row) => (
+                  <tr key={row.label}>
+                    <td className="px-4 py-2.5 text-muted-foreground font-medium whitespace-nowrap w-36 align-top">
+                      {row.label}
+                    </td>
+                    <td className="px-4 py-2.5">{row.value}</td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>
-        ) : (
-          <p className="text-sm text-muted-foreground">Record data unavailable</p>
-        )}
-      </section>
+        </section>
 
-      {/* Source Check Verdicts */}
-      {hasVerdicts ? (
-        <section className="mb-8">
+        {/* Record Data */}
+        <section>
           <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
             <span className="inline-flex items-center gap-1.5">
-              <ShieldCheck className="h-4 w-4" />
-              Source Check Verdicts
+              <Database className="h-4 w-4" />
+              Record Data
             </span>
           </h2>
-          <div className="space-y-3">
-            {verdicts!.verdicts.map((v, i) => (
-              <div
-                key={`${v.fieldName ?? "overall"}-${i}`}
-                className="rounded-lg border border-border/60 p-4"
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    {v.fieldName && (
-                      <p className="text-xs text-muted-foreground mb-1">
-                        Field:{" "}
-                        <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
-                          {v.fieldName}
-                        </code>
-                      </p>
-                    )}
-                    <div className="flex items-center gap-3">
-                      <VerdictBadge verdict={v.verdict} />
-                      {v.confidence != null && (
-                        <span className="text-sm tabular-nums font-medium">
-                          {Math.round(v.confidence * 100)}% confidence
-                        </span>
+          {recordData && Object.keys(recordData.record).length > 0 ? (
+            <div className="rounded-lg border border-border/60 overflow-hidden">
+              <table className="w-full text-sm">
+                <tbody className="divide-y divide-border/30">
+                  {Object.entries(recordData.record)
+                    .filter(([key]) => !METADATA_FIELDS.has(key))
+                    .map(([key, value]) => (
+                      <tr key={key}>
+                        <td className="px-4 py-2.5 text-muted-foreground font-medium whitespace-nowrap w-48 align-top">
+                          <code className="text-[12px]">{key}</code>
+                        </td>
+                        <td className="px-4 py-2.5">
+                          <RecordValue
+                            fieldKey={key}
+                            value={value}
+                            displayNames={recordData!.displayNames}
+                          />
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">Record data unavailable</p>
+          )}
+        </section>
+
+        {/* Source Check Verdicts */}
+        {hasVerdicts ? (
+          <section>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              <span className="inline-flex items-center gap-1.5">
+                <ShieldCheck className="h-4 w-4" />
+                Source Check Verdicts
+              </span>
+            </h2>
+            <div className="space-y-3">
+              {verdicts!.verdicts.map((v, i) => (
+                <div
+                  key={`${v.fieldName ?? "overall"}-${i}`}
+                  className="rounded-lg border border-border/60 p-4"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      {v.fieldName && (
+                        <p className="text-xs text-muted-foreground mb-1">
+                          Field:{" "}
+                          <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
+                            {v.fieldName}
+                          </code>
+                        </p>
+                      )}
+                      <div className="flex items-center gap-3">
+                        <VerdictBadge verdict={v.verdict} />
+                        {v.confidence != null && (
+                          <span className="text-sm tabular-nums font-medium">
+                            {Math.round(v.confidence * 100)}% confidence
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="text-right text-xs text-muted-foreground">
+                      {v.lastComputedAt && (
+                        <p>
+                          Last checked:{" "}
+                          {new Date(v.lastComputedAt).toLocaleDateString()}
+                        </p>
+                      )}
+                      {v.needsRecheck && (
+                        <p className="text-amber-500 font-medium mt-0.5">
+                          Needs recheck
+                        </p>
                       )}
                     </div>
                   </div>
-                  <div className="text-right text-xs text-muted-foreground">
-                    {v.lastComputedAt && (
-                      <p>
-                        Last checked:{" "}
-                        {new Date(v.lastComputedAt).toLocaleDateString()}
-                      </p>
-                    )}
-                    {v.needsRecheck && (
-                      <p className="text-amber-500 font-medium mt-0.5">
-                        Needs recheck
-                      </p>
-                    )}
-                  </div>
+
+                  {v.reasoning && (
+                    <p className="text-sm text-muted-foreground mt-2">
+                      {v.reasoning}
+                    </p>
+                  )}
                 </div>
+              ))}
+            </div>
+          </section>
+        ) : supportsVerdicts ? (
+          <section>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              <span className="inline-flex items-center gap-1.5">
+                <ShieldCheck className="h-4 w-4" />
+                Source Check
+              </span>
+            </h2>
+            <div className="rounded-lg border border-dashed border-border/60 p-4">
+              <p className="text-sm text-muted-foreground">
+                This record has not been sourced yet.
+              </p>
+            </div>
+          </section>
+        ) : null}
 
-                {v.reasoning && (
-                  <p className="text-sm text-muted-foreground mt-2">
-                    {v.reasoning}
-                  </p>
-                )}
-              </div>
-            ))}
-          </div>
-          <div className="mt-3">
-            <Link
-              href={getStoredVerdictHref(recordType, thing.sourceId)}
-              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              View full evidence
-              <ArrowRight className="h-3.5 w-3.5" />
-            </Link>
-          </div>
-        </section>
-      ) : VERDICT_SOURCE_TABLES.has(thing.sourceTable) ? (
-        <section className="mb-8">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-            <span className="inline-flex items-center gap-1.5">
-              <ShieldCheck className="h-4 w-4" />
-              Source Check
-            </span>
-          </h2>
-          <div className="rounded-lg border border-dashed border-border/60 p-4">
-            <p className="text-sm text-muted-foreground">
-              This record has not been sourced yet.
-            </p>
-            <Link
-              href={getStoredVerdictHref(recordType, thing.sourceId)}
-              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mt-2"
-            >
-              View source check page
-              <ArrowRight className="h-3.5 w-3.5" />
-            </Link>
-          </div>
-        </section>
-      ) : null}
-
-      {/* Debug footer */}
-      <details className="text-xs text-muted-foreground border-t border-border pt-4 mt-8">
-        <summary className="cursor-pointer hover:text-foreground transition-colors">
-          Debug info
-        </summary>
-        <div className="mt-2 space-y-0.5">
-          <p>
-            Thing ID:{" "}
-            <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
-              {thing.id}
-            </code>
-          </p>
-          <p>
-            Source Table:{" "}
-            <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
-              {thing.sourceTable}
-            </code>
-          </p>
-          <p>
-            Source ID:{" "}
-            <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
-              {thing.sourceId}
-            </code>
-          </p>
-          {thing.parentThingId && (
+        {/* Debug footer */}
+        <details className="text-xs text-muted-foreground border-t border-border pt-4">
+          <summary className="cursor-pointer hover:text-foreground transition-colors">
+            Debug info
+          </summary>
+          <div className="mt-2 space-y-0.5">
             <p>
-              Parent Thing ID:{" "}
+              Thing ID:{" "}
               <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
-                {thing.parentThingId}
+                {thing.id}
               </code>
             </p>
-          )}
-          {thing.wikiId && (
             <p>
-              Wiki ID:{" "}
+              Source Table:{" "}
               <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
-                {thing.wikiId}
+                {thing.sourceTable}
               </code>
             </p>
-          )}
-          {thing.entityType && (
             <p>
-              Entity Type:{" "}
+              Source ID:{" "}
               <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
-                {thing.entityType}
+                {thing.sourceId}
               </code>
             </p>
-          )}
-        </div>
-      </details>
-    </div>
+            {thing.parentThingId && (
+              <p>
+                Parent Thing ID:{" "}
+                <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
+                  {thing.parentThingId}
+                </code>
+              </p>
+            )}
+            {thing.wikiId && (
+              <p>
+                Wiki ID:{" "}
+                <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
+                  {thing.wikiId}
+                </code>
+              </p>
+            )}
+            {thing.entityType && (
+              <p>
+                Entity Type:{" "}
+                <code className="text-[11px] bg-muted px-1 py-0.5 rounded">
+                  {thing.entityType}
+                </code>
+              </p>
+            )}
+          </div>
+        </details>
+      </div>
+    </EntityProfileShell>
   );
 }

--- a/apps/web/src/app/things/[id]/page.tsx
+++ b/apps/web/src/app/things/[id]/page.tsx
@@ -16,10 +16,18 @@ import {
 import { isAnySid } from "@longterm-wiki/id-utils";
 import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
 import type { EntityProfileShellHeaderLink } from "@/components/entity/EntityProfileShell";
-import { SOURCE_CHECK_VERDICT_PRIORITY } from "@/components/shared/verdict-styles";
+import { rollupVerdictFromVerdictList } from "@/components/entity/entity-sourcing";
 
 export const revalidate = 300;
 export const dynamicParams = true;
+
+/**
+ * Wiki ID for the entity-profile dashboard route. The "View entity profile"
+ * header link routes through `/wiki/<id>?entity=<parent-thing-id>`. Hardcoded
+ * because there's no other lookup table for it; if the dashboard ever moves,
+ * grep for this constant.
+ */
+const ENTITY_PROFILE_WIKI_ID = "E1929";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -78,27 +86,6 @@ const VERDICT_SOURCE_TABLES = new Set(Object.keys(SOURCE_TABLE_TO_RECORD_TYPE));
 
 function sourceTableToRecordType(sourceTable: string): string {
   return SOURCE_TABLE_TO_RECORD_TYPE[sourceTable] ?? sourceTable.replace(/_/g, "-");
-}
-
-/**
- * Reduce a list of per-field verdicts to a single rollup verdict, preferring
- * the most actionable (contradicted > outdated > partial > ...). Mirrors
- * `rollupVerdictFromSummary` from `@/components/entity/entity-sourcing` but
- * works on `RpcSourcingDetailResult.verdicts` directly so we don't need to
- * round-trip through the entity-summary endpoint.
- */
-function rollupRecordVerdict(verdicts: RpcSourcingDetailResult["verdicts"]): string | null {
-  if (verdicts.length === 0) return null;
-  let best: string | null = null;
-  let bestPriority = Infinity;
-  for (const v of verdicts) {
-    const p = SOURCE_CHECK_VERDICT_PRIORITY[v.verdict] ?? 99;
-    if (p < bestPriority) {
-      bestPriority = p;
-      best = v.verdict;
-    }
-  }
-  return best;
 }
 
 // ── Metadata ───────────────────────────────────────────────────────────
@@ -343,19 +330,40 @@ export default async function ThingDetailPage({ params }: PageProps) {
     recordPromise,
   ]);
 
-  let verdicts: RpcSourcingDetailResult | null = null;
-  if (verdictsSettled.status === "fulfilled" && verdictsSettled.value && verdictsSettled.value.ok) {
+  // Distinguish "fetch failed" from "successfully fetched, no verdicts": only
+  // the latter should render an "unchecked" SourcingDot. A failed fetch leaves
+  // `verdicts === undefined` so the dot is hidden entirely.
+  let verdicts: RpcSourcingDetailResult | undefined;
+  if (
+    verdictsSettled.status === "fulfilled" &&
+    verdictsSettled.value &&
+    verdictsSettled.value.ok
+  ) {
     verdicts = verdictsSettled.value.data;
   }
 
   let recordData: RecordLookupResult | null = null;
-  if (recordSettled.status === "fulfilled" && recordSettled.value.ok) {
+  if (
+    recordSettled.status === "fulfilled" &&
+    recordSettled.value &&
+    recordSettled.value.ok
+  ) {
     recordData = recordSettled.value.data;
   }
 
-  const hasVerdicts = verdicts && verdicts.verdicts.length > 0;
-  const rollupVerdict = supportsVerdicts && verdicts ? rollupRecordVerdict(verdicts.verdicts) : null;
-  const sourcingHref = supportsVerdicts ? getStoredVerdictHref(recordType, thing.sourceId) : null;
+  const hasVerdicts = verdicts != null && verdicts.verdicts.length > 0;
+  // verdict prop semantics:
+  //   undefined → shell hides the SourcingDot entirely (record table doesn't
+  //               support verdicts, OR the verdicts fetch failed)
+  //   null      → SourcingDot renders "unchecked" (fetch succeeded with no rows)
+  //   "<verdict>" → SourcingDot renders the rollup state
+  const rollupVerdict =
+    !supportsVerdicts || verdicts === undefined
+      ? undefined
+      : rollupVerdictFromVerdictList(verdicts.verdicts);
+  const sourcingHref: string | undefined = supportsVerdicts
+    ? getStoredVerdictHref(recordType, thing.sourceId)
+    : undefined;
 
   // Header pieces -----------------------------------------------------------
 
@@ -385,7 +393,7 @@ export default async function ThingDetailPage({ params }: PageProps) {
   if (thing.parentThingId) {
     headerLinks.push({
       label: "Entity profile",
-      href: `/wiki/E1929?entity=${encodeURIComponent(thing.parentThingId)}`,
+      href: `/wiki/${ENTITY_PROFILE_WIKI_ID}?entity=${encodeURIComponent(thing.parentThingId)}`,
     });
   }
   if (sourcingHref) {
@@ -514,8 +522,8 @@ export default async function ThingDetailPage({ params }: PageProps) {
       titlePills={titlePills}
       subtitle={subtitle}
       headerLinks={headerLinks}
-      verdict={supportsVerdicts ? rollupVerdict : undefined}
-      verdictHref={sourcingHref ?? undefined}
+      verdict={rollupVerdict}
+      verdictHref={sourcingHref}
     >
       <div className="space-y-8">
         {/* Thing Metadata table */}

--- a/apps/web/src/components/entity/__tests__/entity-sourcing.test.ts
+++ b/apps/web/src/components/entity/__tests__/entity-sourcing.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { rollupVerdictFromSummary } from "../entity-sourcing";
+import {
+  rollupVerdictFromSummary,
+  rollupVerdictFromVerdictList,
+} from "../entity-sourcing";
 
 const zeroCounts = {
   confirmed: 0,
@@ -105,5 +108,97 @@ describe("rollupVerdictFromSummary", () => {
         totalRecords: 7,
       } as Parameters<typeof rollupVerdictFromSummary>[0]),
     ).toBe("confirmed");
+  });
+});
+
+describe("rollupVerdictFromVerdictList", () => {
+  it("returns null for an empty list", () => {
+    expect(rollupVerdictFromVerdictList([])).toBeNull();
+  });
+
+  it("returns the only verdict for a single-element list", () => {
+    expect(rollupVerdictFromVerdictList([{ verdict: "confirmed" }])).toBe("confirmed");
+    expect(rollupVerdictFromVerdictList([{ verdict: "contradicted" }])).toBe("contradicted");
+    expect(rollupVerdictFromVerdictList([{ verdict: "unchecked" }])).toBe("unchecked");
+  });
+
+  it("prefers contradicted over all other verdicts", () => {
+    expect(
+      rollupVerdictFromVerdictList([
+        { verdict: "confirmed" },
+        { verdict: "outdated" },
+        { verdict: "partial" },
+        { verdict: "unverifiable" },
+        { verdict: "contradicted" },
+        { verdict: "unchecked" },
+      ]),
+    ).toBe("contradicted");
+  });
+
+  it("prefers outdated over partial/unverifiable/confirmed/unchecked", () => {
+    expect(
+      rollupVerdictFromVerdictList([
+        { verdict: "confirmed" },
+        { verdict: "partial" },
+        { verdict: "outdated" },
+        { verdict: "unverifiable" },
+        { verdict: "unchecked" },
+      ]),
+    ).toBe("outdated");
+  });
+
+  it("prefers partial over unverifiable/confirmed/unchecked", () => {
+    expect(
+      rollupVerdictFromVerdictList([
+        { verdict: "confirmed" },
+        { verdict: "unverifiable" },
+        { verdict: "partial" },
+        { verdict: "unchecked" },
+      ]),
+    ).toBe("partial");
+  });
+
+  it("prefers unverifiable over confirmed/unchecked", () => {
+    expect(
+      rollupVerdictFromVerdictList([
+        { verdict: "confirmed" },
+        { verdict: "unverifiable" },
+        { verdict: "unchecked" },
+      ]),
+    ).toBe("unverifiable");
+  });
+
+  it("prefers confirmed over unchecked", () => {
+    expect(
+      rollupVerdictFromVerdictList([
+        { verdict: "confirmed" },
+        { verdict: "unchecked" },
+      ]),
+    ).toBe("confirmed");
+  });
+
+  it("treats unknown verdicts as priority 99 (lowest)", () => {
+    // Unknown verdict ranks below all known ones; confirmed should win.
+    expect(
+      rollupVerdictFromVerdictList([
+        { verdict: "totally-made-up-verdict" },
+        { verdict: "confirmed" },
+      ]),
+    ).toBe("confirmed");
+  });
+
+  it("returns the unknown verdict when it's the only one", () => {
+    expect(rollupVerdictFromVerdictList([{ verdict: "weird" }])).toBe("weird");
+  });
+
+  it("ignores extra fields on each verdict item", () => {
+    // The full `RpcSourcingDetailResult.verdicts` row has many fields;
+    // the rollup should only depend on `verdict`.
+    expect(
+      rollupVerdictFromVerdictList([
+        { verdict: "confirmed", fieldName: "amount", confidence: 0.9 } as { verdict: string },
+        { verdict: "contradicted", fieldName: "investor", confidence: 0.7 } as { verdict: string },
+      ]),
+    ).toBe("contradicted");
   });
 });

--- a/apps/web/src/components/entity/entity-sourcing.ts
+++ b/apps/web/src/components/entity/entity-sourcing.ts
@@ -47,6 +47,23 @@ export async function fetchEntitySourcingSummary(
 }
 
 /**
+ * Picks the most actionable verdict (lowest `SOURCE_CHECK_VERDICT_PRIORITY`)
+ * from a non-empty list. Used by both rollup helpers below.
+ */
+function pickHighestPriorityVerdict(verdicts: readonly string[]): string | null {
+  let best: string | null = null;
+  let bestPriority = Infinity;
+  for (const v of verdicts) {
+    const p = SOURCE_CHECK_VERDICT_PRIORITY[v] ?? 99;
+    if (p < bestPriority) {
+      bestPriority = p;
+      best = v;
+    }
+  }
+  return best;
+}
+
+/**
  * Reduces a per-entity verdict count row to a single rollup verdict, preferring
  * the most actionable verdict present (contradicted > outdated > partial > ...).
  * Returns null when no verdicts are recorded.
@@ -58,20 +75,31 @@ export function rollupVerdictFromSummary(
   > | null | undefined,
 ): string | null {
   if (!summary) return null;
-  const counts: Array<[string, number]> = [
-    ["contradicted", summary.contradicted],
-    ["outdated", summary.outdated],
-    ["partial", summary.partial],
-    ["unverifiable", summary.unverifiable],
-    ["confirmed", summary.confirmed],
-    ["unchecked", summary.unchecked],
-  ];
-  const present = counts.filter(([, n]) => n > 0);
-  if (present.length === 0) return null;
-  present.sort(
-    ([a], [b]) =>
-      (SOURCE_CHECK_VERDICT_PRIORITY[a] ?? 99) -
-      (SOURCE_CHECK_VERDICT_PRIORITY[b] ?? 99),
-  );
-  return present[0][0];
+  const present = (
+    [
+      ["contradicted", summary.contradicted],
+      ["outdated", summary.outdated],
+      ["partial", summary.partial],
+      ["unverifiable", summary.unverifiable],
+      ["confirmed", summary.confirmed],
+      ["unchecked", summary.unchecked],
+    ] as const
+  )
+    .filter(([, n]) => n > 0)
+    .map(([k]) => k);
+  return pickHighestPriorityVerdict(present);
+}
+
+/**
+ * Reduces a per-record verdict list (one row per field) to a single rollup
+ * verdict, using the same priority order as `rollupVerdictFromSummary`.
+ * Used by record-level inspector pages (e.g. `/things/[id]`) that fetch the
+ * `/api/sourcing/verdicts/<recordType>/<recordId>` endpoint directly instead
+ * of going through `entity-summary`.
+ */
+export function rollupVerdictFromVerdictList(
+  verdicts: ReadonlyArray<{ verdict: string }>,
+): string | null {
+  if (verdicts.length === 0) return null;
+  return pickHighestPriorityVerdict(verdicts.map((v) => v.verdict));
 }


### PR DESCRIPTION
## Summary

- Migrate `apps/web/src/app/things/[id]/page.tsx` (708 lines → ~480 lines) to `EntityProfileShell`. `thingType` violet badge → `titlePills`; "Child of …" → `subtitle`; "Full page" / "Entity profile" / "Source checks" → `headerLinks`; sourcing rollup verdict feeds the shell's `SourcingDot`, so things pages now show the same sourcing badge as other entity profiles.
- **`wiki/[id]` deliberately NOT migrated.** `entity-profile-pages.md` explicitly excludes wiki pages (`"Wiki pages (/wiki/E<N>) — MDX content uses its own article layout"`). The wiki page's left-hand `WikiSidebar`, 5 content formats, `prose`/`fullWidth`/`hideSidebar` variants, and wiki-only chrome (`PageStatus`, `ContentConfidenceBanner`, `CitationHealthBanner`, `JsonLd`, `DataInfoBox`, `TableOfContents`, `CitationOverlay`, `References`, `FBAutoFacts`, `SourcingStatus`, `RelatedPages`, plus provider chains) do not fit the shell without bloating it with wiki-only props. Full scope-review rationale posted to [QUA-489](https://linear.app/quantifieduncertainty/issue/QUA-489).
- **Shared rollup helper.** Extracted `rollupVerdictFromVerdictList` (consumes `RpcSourcingDetailResult.verdicts` directly) into `apps/web/src/components/entity/entity-sourcing.ts` alongside the existing `rollupVerdictFromSummary`, with a private `pickHighestPriorityVerdict()` doing the priority-order pick once. 10 new unit tests cover the new helper.
- **Verdict semantics fix.** A failed verdicts fetch now passes `verdict={undefined}` to the shell (dot hidden) instead of `verdict={null}` (which would render a misleading "unchecked" dot with a clickable href to an empty sourcing page). Successfully-fetched-but-empty still renders "unchecked".

## Verification

- `pnpm build` — passes (470 pages compiled, including `/things/[id]` dynamic route).
- `pnpm test` — apps/web: 1922 / 1922 (+10 new), full root suite green.
- `pnpm crux w validate gate --fix` — 70 / 70 checks green (2 advisory warnings unrelated to this PR — pre-existing TS crux baseline + orphan entity detection).
- Local Playwright render-audit against prod data (`WIKI_SERVER_ENV=prod next start`) for three thing types:
  - resource thing (`sid_aqtwMFcaYE`) — 200, no console errors, no `SourcingDot` (correct: resources don't support verdicts)
  - grant thing (`2wqQkcoDyy`, verdict-supporting, has verdicts) — 200, `SourcingDot` rendered linking to `/sourcing/grant/2wqQkcoDyy`, "Source checks" header link present
  - entity-resource composite-key id (`er:sid_gNsqAes7Dw:sid_74XgjQ1XA4`) — 200, no console errors
- Adversarial probes (path traversal, XSS, SQL injection, oversized id, null byte): all return clean 404 or graceful error fallback — no crashes, no injection.
- `/things/[id]` not added to the shared render-audit spec (records live only in PG → 404 in PR-CI without `LONGTERMWIKI_SERVER_URL`). Comment added inline matching the QUA-487 pattern.

## Test plan

- [x] Build passes
- [x] Unit tests pass (10 new)
- [x] Gate passes (70 / 70)
- [x] Local Playwright render-audit against prod data (resource, grant, entity-resource)
- [x] Adversarial input probes (404 / graceful error fallback)
- [ ] Post-merge: prod render-audit cron (`render-monitor.yml`) confirms no regressions

Fixes QUA-489
