### PR TITLE
test(sourcing): apply LOW review-cleanups missed before QUA-985 merged

### DIFF
--- a/apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts
@@ -384,9 +384,7 @@ describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
     // sourced fact counts as checkable. Verify the query still binds as
     // a single text[] param (no row-constructor regression on empty input)
     // and the endpoint still returns 200.
-    const { _resetPropertyMetadataCache } = await import("../property-metadata.js");
     const propertyMetadata = await import("../property-metadata.js");
-    _resetPropertyMetadataCache();
     const spy = vi
       .spyOn(propertyMetadata, "getNonVerifiablePropertyIds")
       .mockReturnValue(new Set<string>());
@@ -401,14 +399,13 @@ describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
       const idx = capturedQueries.findIndex(
         (q) => /FROM\s+facts/i.test(q) && /AS\s+checkable/i.test(q),
       );
-      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx, "expected the checkable-facts query to be issued").toBeGreaterThanOrEqual(0);
       expect(capturedQueries[idx]).toMatch(/ANY\(\s*\$\d+::text\[\]\s*\)/);
       const arrayParams = capturedParams[idx].filter((p) => Array.isArray(p));
       expect(arrayParams).toHaveLength(1);
       expect(arrayParams[0]).toEqual([]);
     } finally {
       spy.mockRestore();
-      _resetPropertyMetadataCache();
     }
   });
 
@@ -428,7 +425,7 @@ describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
     const idx = capturedQueries.findIndex(
       (q) => /FROM\s+facts/i.test(q) && /AS\s+checkable/i.test(q),
     );
-    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(idx, "expected the checkable-facts query to be issued").toBeGreaterThanOrEqual(0);
     expect(capturedQueries[idx]).not.toMatch(/ANY\(\s*\(\s*\$\d+\s*,/);
     expect(capturedQueries[idx]).toMatch(/ANY\(\s*\$\d+::text\[\]\s*\)/);
   });


### PR DESCRIPTION
## Summary

Trivial test cleanup — three LOW-severity findings from the second `/agent-review-pr` pass on PR #4785 that didn't make it into the original PR before merge.

- Drop dead `_resetPropertyMetadataCache` import + reset calls in the empty-array test. `vi.spyOn` replaces the function on the module namespace, so the cached-Set early-return inside the original body never executes — the cache reset was defensive dead code.
- Combine two adjacent `await import("../property-metadata.js")` calls into one.
- Add `"expected the checkable-facts query to be issued"` assertion message to the `/coverage-matrix` smoke test for parity with the other two `findIndex(...)` checks, so a future regex miss yields a useful error message instead of `Cannot read properties of undefined`.

No production logic changed. The 16 sourcing-coverage-checkability tests still pass.

## Test plan

- [x] `pnpm test` (wiki-server) — 1656/1656 pass
- [x] `pnpm test sourcing-coverage-checkability` — 16/16 pass
- [x] No source code changes; test-only diff (5 line delta in one file)

Follow-up to QUA-985 (PR #4785, merged in 70ff0bd98).

Fixes QUA-985
