### PR TITLE
QUA-988: drizzle-journal merge driver — auto-resolve _journal.json conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Drizzle migration journal — auto-resolve idx-collision conflicts on rebase.
+#
+# Two PRs that both add a migration grab the next sequential idx (e.g. both
+# 221) and conflict on `_journal.json`. The drizzle-journal merge driver
+# (crux/git/drizzle-journal-merge.mjs) resolves these mechanically: union the
+# `entries` arrays, give the migration with the earlier `when` the lower idx,
+# and rename the loser's .sql file to match its new prefix.
+#
+# Activated by the `merge.drizzle-journal.driver` git config (set by
+# scripts/setup.sh). On fresh clones, run `pnpm setup` once to register the
+# driver. Until then, git falls back to the standard 3-way merge — which
+# leaves conflict markers in `_journal.json` exactly as before, so this is
+# additive: no regression for users who haven't run setup.
+apps/wiki-server/drizzle/meta/_journal.json merge=drizzle-journal

--- a/.githooks/apply-migration-renames.sh
+++ b/.githooks/apply-migration-renames.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Apply migration .sql renames recorded by the drizzle-journal merge driver.
+#
+# The merge driver (crux/git/drizzle-journal-merge.mjs) resolves
+# _journal.json conflicts on rebase by renumbering the loser of an idx
+# collision. The .sql file rename can't always happen during the merge
+# itself — git holds the index lock and the source .sql may not yet be in
+# the worktree (mid-rebase). So the driver writes a marker file at
+# .git/MIGRATION_RENAMES_PENDING, and this script applies the renames once
+# the rebase / merge completes (post-rewrite / post-merge).
+#
+# Behavior:
+#   - Reads .git/MIGRATION_RENAMES_PENDING (JSON: { drizzleDir, renames }).
+#   - For each rename, `git mv` the .sql file (and snapshot.json sibling).
+#   - If any rename succeeded, amend HEAD to fold them into the just-made
+#     commit. This keeps the rebase / merge result a single clean commit.
+#   - Always removes the marker file so it doesn't carry over.
+#
+# Exits 0 on success or no-op. Failures are warned but never block the user
+# (it's only ever called from non-blocking hooks). Worst case the user runs
+# `pnpm crux migrations renumber` to clean up.
+
+set -uo pipefail
+
+REPO="$(git rev-parse --show-toplevel 2>/dev/null || echo '')"
+if [ -z "$REPO" ]; then exit 0; fi
+
+PENDING="$REPO/.git/MIGRATION_RENAMES_PENDING"
+if [ ! -f "$PENDING" ]; then exit 0; fi
+
+# Parse the marker JSON. We rely on Node being available — same prerequisite
+# as the merge driver itself.
+DRIZZLE_DIR="$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(process.argv[1],"utf-8")).drizzleDir)' "$PENDING" 2>/dev/null || echo '')"
+if [ -z "$DRIZZLE_DIR" ]; then
+  echo "drizzle-journal-merge: pending marker is corrupt — removing $PENDING" >&2
+  rm -f "$PENDING"
+  exit 0
+fi
+
+RENAMES_TSV="$(node -e '
+  const j = JSON.parse(require("fs").readFileSync(process.argv[1],"utf-8"));
+  for (const r of j.renames || []) console.log(r.oldTag + "\t" + r.newTag);
+' "$PENDING" 2>/dev/null || echo '')"
+
+cd "$REPO"
+
+ANY_RENAMED=0
+while IFS=$'\t' read -r OLD_TAG NEW_TAG; do
+  [ -z "$OLD_TAG" ] && continue
+
+  OLD_SQL="$DRIZZLE_DIR/${OLD_TAG}.sql"
+  NEW_SQL="$DRIZZLE_DIR/${NEW_TAG}.sql"
+
+  if [ -f "$OLD_SQL" ] && [ ! -f "$NEW_SQL" ]; then
+    if git mv "$OLD_SQL" "$NEW_SQL" 2>/dev/null; then
+      ANY_RENAMED=1
+    else
+      # File might be untracked — fall back to fs rename + git add.
+      mv "$OLD_SQL" "$NEW_SQL" 2>/dev/null && git add "$NEW_SQL" 2>/dev/null && ANY_RENAMED=1
+    fi
+  elif [ ! -f "$OLD_SQL" ] && [ -f "$NEW_SQL" ]; then
+    # Already in the desired state (idempotent re-run).
+    :
+  fi
+
+  # Snapshot.json sibling — same pattern, optional.
+  OLD_PREFIX="$(echo "$OLD_TAG" | grep -oE '^[0-9]+' || true)"
+  NEW_PREFIX="$(echo "$NEW_TAG" | grep -oE '^[0-9]+' || true)"
+  if [ -n "$OLD_PREFIX" ] && [ -n "$NEW_PREFIX" ] && [ "$OLD_PREFIX" != "$NEW_PREFIX" ]; then
+    OLD_SNAP="$DRIZZLE_DIR/meta/${OLD_PREFIX}_snapshot.json"
+    NEW_SNAP="$DRIZZLE_DIR/meta/${NEW_PREFIX}_snapshot.json"
+    if [ -f "$OLD_SNAP" ] && [ ! -f "$NEW_SNAP" ]; then
+      git mv "$OLD_SNAP" "$NEW_SNAP" 2>/dev/null || true
+    fi
+  fi
+done <<<"$RENAMES_TSV"
+
+rm -f "$PENDING"
+
+if [ "$ANY_RENAMED" = "1" ]; then
+  # Try to fold renames into HEAD. The amend re-fires post-rewrite /
+  # post-merge but the marker file was deleted above, so the recursive call
+  # is a no-op.
+  #
+  # During the post-merge hook, git may still consider itself "in the middle
+  # of a merge" — `git commit --amend` fails with exit 128 in that case.
+  # That's fine: we leave the rename as a staged change. The user will see
+  # it in `git status` and can commit it manually (or it'll go into their
+  # next commit on the branch).
+  if [ -e "$REPO/.git/MERGE_HEAD" ] || [ -e "$REPO/.git/MERGE_MSG" ]; then
+    echo "drizzle-journal-merge: .sql rename staged (still mid-merge — run 'git commit --amend --no-edit' after the merge completes to fold it in)"
+  elif git commit --amend --no-edit >/dev/null 2>&1; then
+    echo "drizzle-journal-merge: applied deferred .sql renames and amended HEAD"
+  else
+    # The merge state can persist briefly into the post-merge hook on some
+    # git versions. Stage-only fallback: rename is in the index, user
+    # commits later.
+    echo "drizzle-journal-merge: .sql rename staged — run 'git commit --amend --no-edit' to fold it in"
+  fi
+fi
+
+exit 0

--- a/.githooks/apply-migration-renames.sh
+++ b/.githooks/apply-migration-renames.sh
@@ -29,19 +29,38 @@ if [ -z "$REPO" ]; then exit 0; fi
 PENDING="$REPO/.git/MIGRATION_RENAMES_PENDING"
 if [ ! -f "$PENDING" ]; then exit 0; fi
 
-# Parse the marker JSON. We rely on Node being available — same prerequisite
-# as the merge driver itself.
-DRIZZLE_DIR="$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(process.argv[1],"utf-8")).drizzleDir)' "$PENDING" 2>/dev/null || echo '')"
-if [ -z "$DRIZZLE_DIR" ]; then
-  echo "drizzle-journal-merge: pending marker is corrupt — removing $PENDING" >&2
+# Parse the marker JSON in a single Node invocation (drizzleDir on the first
+# line, then one tab-separated `oldTag\tnewTag` per rename). We rely on Node
+# being available — same prerequisite as the merge driver itself. Tags are
+# validated against the same regex as the merge driver to defeat path
+# traversal via attacker-controlled journal content.
+PARSED="$(node -e '
+  const path = process.argv[1];
+  const j = JSON.parse(require("fs").readFileSync(path, "utf-8"));
+  if (typeof j.drizzleDir !== "string" || !j.drizzleDir) process.exit(2);
+  const SAFE = /^\d+_[A-Za-z0-9_]+$/;
+  console.log(j.drizzleDir);
+  for (const r of j.renames || []) {
+    if (typeof r?.oldTag !== "string" || typeof r?.newTag !== "string") continue;
+    if (!SAFE.test(r.oldTag) || !SAFE.test(r.newTag)) continue;
+    console.log(r.oldTag + "\t" + r.newTag);
+  }
+' "$PENDING" 2>/dev/null || true)"
+
+if [ -z "$PARSED" ]; then
+  echo "drizzle-journal-merge: pending marker is corrupt or empty — removing $PENDING" >&2
   rm -f "$PENDING"
   exit 0
 fi
 
-RENAMES_TSV="$(node -e '
-  const j = JSON.parse(require("fs").readFileSync(process.argv[1],"utf-8"));
-  for (const r of j.renames || []) console.log(r.oldTag + "\t" + r.newTag);
-' "$PENDING" 2>/dev/null || echo '')"
+DRIZZLE_DIR="$(printf '%s\n' "$PARSED" | head -n 1)"
+RENAMES_TSV="$(printf '%s\n' "$PARSED" | tail -n +2)"
+
+if [ -z "$DRIZZLE_DIR" ]; then
+  echo "drizzle-journal-merge: pending marker missing drizzleDir — removing $PENDING" >&2
+  rm -f "$PENDING"
+  exit 0
+fi
 
 cd "$REPO"
 

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -6,6 +6,11 @@
 # This prevents stale-data bugs after git pull.
 #
 
+# Apply any deferred migration .sql renames recorded by the drizzle-journal
+# merge driver (QUA-988). No-op if no marker file is present.
+DIR="$(dirname "$0")"
+[ -x "$DIR/apply-migration-renames.sh" ] && "$DIR/apply-migration-renames.sh"
+
 # Check if any data-relevant files changed in the merge
 CHANGED_FILES=$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD 2>/dev/null || echo "")
 

--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Post-rewrite hook — fires after `git rebase` (and `git commit --amend`).
+#
+# Currently only used to apply deferred migration .sql renames written by
+# the drizzle-journal merge driver (QUA-988). See the helper for details.
+
+DIR="$(dirname "$0")"
+[ -x "$DIR/apply-migration-renames.sh" ] && "$DIR/apply-migration-renames.sh"
+
+exit 0

--- a/crux/commands/migrations.ts
+++ b/crux/commands/migrations.ts
@@ -1,0 +1,200 @@
+/**
+ * Migrations command — utilities for managing Drizzle migration files.
+ *
+ * Currently exposes a single subcommand:
+ *
+ *   crux migrations renumber [--dry-run]
+ *
+ *     Detect duplicate idx values, mismatched filename prefixes, or non-
+ *     strictly-increasing `when` timestamps in `apps/wiki-server/drizzle/`
+ *     and resolve them by renumbering migrations into a clean sequence.
+ *
+ *     This is the manual fallback when the `drizzle-journal` git merge
+ *     driver (crux/git/drizzle-journal-merge.ts) failed mid-rebase or when
+ *     someone hand-edited migration files and got them out of sync.
+ *
+ * Usage:
+ *
+ *     # Detect-only — show what would change, exit 1 if anything is out of order
+ *     crux migrations renumber --dry-run
+ *
+ *     # Apply — rewrite the journal and `git mv` the .sql files
+ *     crux migrations renumber
+ */
+
+import { execSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
+import { getColors } from '../lib/output.ts';
+import {
+  applyRenames,
+  renumberJournal,
+  serializeJournal,
+} from '../git/drizzle-journal-merge.mjs';
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+interface RenumberOptions extends CommandOptions {
+  dryRun?: boolean;
+  drizzleDir?: string;
+}
+
+const DEFAULT_DRIZZLE_DIR = 'apps/wiki-server/drizzle';
+
+async function renumberCommand(
+  _args: string[],
+  options: RenumberOptions,
+): Promise<CommandResult> {
+  const c = getColors();
+  const drizzleDir = options.drizzleDir ?? DEFAULT_DRIZZLE_DIR;
+  const journalPath = join(drizzleDir, 'meta', '_journal.json');
+
+  if (!existsSync(journalPath)) {
+    return {
+      output: `${c.red}Journal not found at ${journalPath}${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  let journal: Journal;
+  try {
+    journal = JSON.parse(readFileSync(journalPath, 'utf-8')) as Journal;
+  } catch (err) {
+    return {
+      output: `${c.red}Failed to parse ${journalPath}: ${err instanceof Error ? err.message : String(err)}${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  // Compute the renumbered journal. The shared helper handles idx
+  // reassignment, tag rewriting, and `when` monotonicity.
+  const result = renumberJournal(journal);
+
+  if (result.renames.length === 0) {
+    // Nothing to rename — but we still need to check whether any other
+    // attribute changed (e.g., a `when` bump for monotonicity). Compare the
+    // serialized forms to detect that.
+    const before = JSON.stringify(journal);
+    const after = JSON.stringify(result.resolved);
+    if (before === after) {
+      return {
+        output: `${c.green}Journal is already in canonical form (${journal.entries.length} entries, no renumbering needed).${c.reset}\n`,
+        exitCode: 0,
+      };
+    }
+  }
+
+  let output = `${c.blue}Renumbering ${journal.entries.length} migration entries...${c.reset}\n\n`;
+
+  if (result.renames.length > 0) {
+    output += `${c.yellow}${result.renames.length} migration${result.renames.length === 1 ? '' : 's'} need renaming:${c.reset}\n`;
+    for (const { oldTag, newTag } of result.renames) {
+      output += `  ${c.dim}${oldTag}.sql${c.reset} → ${c.green}${newTag}.sql${c.reset}\n`;
+    }
+    output += '\n';
+  }
+
+  // Detect any `when` adjustments — useful diagnostic when the journal had
+  // duplicate timestamps before this run (which silently breaks production).
+  const whenChanges: Array<{ tag: string; oldWhen: number; newWhen: number }> = [];
+  const oldByTag = new Map(journal.entries.map((e) => [e.tag, e.when]));
+  // Note: after renumberJournal, the entry's `tag` may have changed. Match
+  // by the original tag via the rename map.
+  const renameMap = new Map(result.renames.map((r) => [r.newTag, r.oldTag]));
+  for (const e of result.resolved.entries) {
+    const originalTag = renameMap.get(e.tag) ?? e.tag;
+    const oldWhen = oldByTag.get(originalTag);
+    if (oldWhen !== undefined && oldWhen !== e.when) {
+      whenChanges.push({ tag: e.tag, oldWhen, newWhen: e.when });
+    }
+  }
+  if (whenChanges.length > 0) {
+    output += `${c.yellow}${whenChanges.length} 'when' timestamp${whenChanges.length === 1 ? '' : 's'} bumped for strict monotonicity:${c.reset}\n`;
+    for (const { tag, oldWhen, newWhen } of whenChanges) {
+      output += `  ${c.dim}${tag}: ${oldWhen} → ${newWhen}${c.reset}\n`;
+    }
+    output += '\n';
+  }
+
+  if (options.dryRun) {
+    output += `${c.dim}--dry-run: no files modified.${c.reset}\n`;
+    return { output, exitCode: result.renames.length > 0 || whenChanges.length > 0 ? 1 : 0 };
+  }
+
+  // Apply renames to the worktree.
+  const repoRoot = findRepoRoot();
+  try {
+    const { renamed, skipped } = applyRenames(result.renames, drizzleDir, repoRoot);
+    if (renamed > 0) {
+      output += `${c.green}Renamed ${renamed} file${renamed === 1 ? '' : 's'}.${c.reset}\n`;
+    }
+    for (const note of skipped) {
+      output += `  ${c.dim}skipped: ${note}${c.reset}\n`;
+    }
+  } catch (err) {
+    return {
+      output: output + `${c.red}Failed to rename migration files: ${err instanceof Error ? err.message : String(err)}${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  // Write the rewritten journal.
+  try {
+    writeFileSync(journalPath, serializeJournal(result.resolved));
+  } catch (err) {
+    return {
+      output: output + `${c.red}Failed to write ${journalPath}: ${err instanceof Error ? err.message : String(err)}${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  output += `\n${c.green}Done. Stage the journal change with:${c.reset} ${c.dim}git add ${journalPath}${c.reset}\n`;
+  return { output, exitCode: 0 };
+}
+
+function findRepoRoot(): string {
+  try {
+    return execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+export const commands: Record<
+  string,
+  (args: string[], options: CommandOptions) => Promise<CommandResult>
+> = {
+  renumber: renumberCommand,
+};
+
+export function getHelp(): string {
+  return `
+Migrations — Drizzle migration file utilities
+
+Subcommands:
+  renumber [--dry-run]   Renumber migration files into a clean sequence.
+                          Detects duplicate idx values, mismatched filename
+                          prefixes, or non-monotonic 'when' timestamps.
+
+This is the manual fallback when the drizzle-journal git merge driver
+couldn't auto-resolve a conflict, or when migration files were hand-edited
+and got out of sync with the journal.
+
+Examples:
+  pnpm crux migrations renumber --dry-run    # Detect issues
+  pnpm crux migrations renumber              # Fix in place
+`;
+}

--- a/crux/commands/migrations.ts
+++ b/crux/commands/migrations.ts
@@ -137,9 +137,12 @@ async function renumberCommand(
   // Apply renames to the worktree.
   const repoRoot = findRepoRoot();
   try {
-    const { renamed, skipped } = applyRenames(result.renames, drizzleDir, repoRoot);
+    const { renamed, alreadyRenamed, skipped } = applyRenames(result.renames, drizzleDir, repoRoot);
     if (renamed > 0) {
       output += `${c.green}Renamed ${renamed} file${renamed === 1 ? '' : 's'}.${c.reset}\n`;
+    }
+    if (alreadyRenamed > 0) {
+      output += `${c.dim}${alreadyRenamed} file${alreadyRenamed === 1 ? '' : 's'} already at the new path (idempotent re-run).${c.reset}\n`;
     }
     for (const note of skipped) {
       output += `  ${c.dim}skipped: ${note}${c.reset}\n`;

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -143,6 +143,7 @@ import * as auditCommands from './commands/audit.ts';
 import { primeAuditSessionId } from './lib/wiki-server/audit-context.ts';
 import * as aiidCommands from './commands/ingest-aiid.ts';
 import * as oecdAimCommands from './commands/ingest-oecd-aim.ts';
+import * as migrationsCommands from './commands/migrations.ts';
 
 const domains = {
   validate: validateCommands,
@@ -249,6 +250,7 @@ const domains = {
   audit: auditCommands,
   aiid: aiidCommands,
   'oecd-aim': oecdAimCommands,
+  migrations: migrationsCommands,
 };
 
 const shortcutMap = buildShortcutMap();

--- a/crux/git/__tests__/drizzle-journal-merge.test.ts
+++ b/crux/git/__tests__/drizzle-journal-merge.test.ts
@@ -310,6 +310,18 @@ describe('renumberJournal — single-journal fixup', () => {
     expect(result.renames).toEqual([{ oldTag: '0005_dup', newTag: '0007_dup' }]);
   });
 
+  it('refuses to rename tags containing path-traversal segments', () => {
+    // Defense in depth: a malicious branch could craft a journal entry
+    // like `{tag: "../../../../etc/passwd"}`. The merge driver renumbers
+    // and would emit a rename — without validation, that flows into
+    // `git mv` / `mv` and writes outside the migrations directory.
+    const j = journal([
+      entry(0, 100, '0000_a'),
+      entry(0, 200, '0000_../../../etc/passwd'), // duplicate idx forces renumber
+    ]);
+    expect(() => renumberJournal(j)).toThrow(/Refusing to rename unsafe tag/);
+  });
+
   it('does not mutate input', () => {
     const j = journal([
       entry(1, 200, '0001_a'),
@@ -466,6 +478,33 @@ describe('runMergeDriver — end to end', () => {
     expect(existsSync(join(metaDir, '0001_snapshot.json'))).toBe(false);
   });
 
+  it('reports alreadyRenamed (not renamed) when the source .sql is missing but destination exists', () => {
+    // Idempotent re-run scenario: the apply-migration-renames hook already
+    // moved the file, then something re-invokes applyRenames. We must not
+    // double-count it as a rename — the user-facing "Renamed N files"
+    // output would mislead.
+    const { repo, drizzleDir } = setupRepo('e2e-idempotent');
+
+    // Pre-stage the destination file.
+    writeFileSync(join(drizzleDir, '0002_b.sql'), '-- already moved\n');
+    execFileSync('git', ['add', '-A'], { cwd: repo });
+    commit(repo, 'pre-rename');
+
+    // applyRenames is called as if we tried to rename 0001_b → 0002_b
+    // again. Source missing, destination present.
+    // Use a dynamic import so we exercise the real exported function.
+    return import('../drizzle-journal-merge.mjs').then((mod) => {
+      const result = mod.applyRenames(
+        [{ oldTag: '0001_b', newTag: '0002_b' }],
+        'drizzle',
+        repo,
+      );
+      expect(result.renamed).toBe(0);
+      expect(result.alreadyRenamed).toBe(1);
+      expect(result.skipped[0]).toMatch(/already renamed/);
+    });
+  });
+
   it('writes a pending-renames marker when the source .sql is not in the worktree', () => {
     // This is the canonical mid-rebase scenario: git invokes the merge
     // driver before the rebase commit's tree has been written to the
@@ -507,6 +546,88 @@ describe('runMergeDriver — end to end', () => {
     const marker = JSON.parse(readFileSync(markerPath, 'utf-8'));
     expect(marker.renames).toEqual([{ oldTag: '0001_b', newTag: '0002_b' }]);
     expect(marker.drizzleDir).toBe('drizzle');
+  });
+
+  it('merges deferred renames across multiple invocations (multi-commit rebase)', () => {
+    // A multi-commit rebase invokes the merge driver once per conflicting
+    // commit. The marker file MUST accumulate renames across invocations,
+    // not overwrite — otherwise renames from earlier commits in the chain
+    // are silently lost and their .sql files keep their old prefix.
+    const { repo, drizzleDir, metaDir } = setupRepo('e2e-multi-defer');
+
+    const baseJournal = journal([entry(0, 100, '0000_base')]);
+    writeFileSync(join(metaDir, '_journal.json'), serializeJournal(baseJournal));
+    writeFileSync(join(drizzleDir, '0000_base.sql'), '-- base\n');
+    commit(repo, 'base');
+
+    // First invocation: ours adds 0001_alpha, theirs adds 0001_beta.
+    // No worktree files (mid-rebase), so the rename for the loser defers.
+    const firstOurs = journal([...baseJournal.entries, entry(1, 200, '0001_alpha')]);
+    const firstTheirs = journal([...baseJournal.entries, entry(1, 300, '0001_beta')]);
+    const pathBase1 = join(tmpRoot, 'mdefer1-base.json');
+    const pathOurs1 = join(tmpRoot, 'mdefer1-ours.json');
+    const pathTheirs1 = join(tmpRoot, 'mdefer1-theirs.json');
+    writeFileSync(pathBase1, serializeJournal(baseJournal));
+    writeFileSync(pathOurs1, serializeJournal(firstOurs));
+    writeFileSync(pathTheirs1, serializeJournal(firstTheirs));
+
+    const r1 = runMergeDriver(pathBase1, pathOurs1, pathTheirs1, 'drizzle/meta/_journal.json', repo);
+    expect(r1.exitCode).toBe(0);
+
+    const markerPath = join(repo, '.git', 'MIGRATION_RENAMES_PENDING');
+    let marker = JSON.parse(readFileSync(markerPath, 'utf-8'));
+    expect(marker.renames).toEqual([{ oldTag: '0001_beta', newTag: '0002_beta' }]);
+
+    // Second invocation: simulate a second conflicting commit with a
+    // different addition. Read what main looks like AFTER the first merge
+    // resolved, then simulate the next commit in the chain conflicting.
+    const afterFirstResolution = JSON.parse(readFileSync(pathOurs1, 'utf-8'));
+    const secondOurs = journal([
+      ...afterFirstResolution.entries,
+      entry(3, 400, '0003_gamma'),
+    ]);
+    const secondTheirs = journal([
+      ...afterFirstResolution.entries,
+      entry(3, 500, '0003_delta'),
+    ]);
+    const pathBase2 = join(tmpRoot, 'mdefer2-base.json');
+    const pathOurs2 = join(tmpRoot, 'mdefer2-ours.json');
+    const pathTheirs2 = join(tmpRoot, 'mdefer2-theirs.json');
+    writeFileSync(pathBase2, serializeJournal(afterFirstResolution));
+    writeFileSync(pathOurs2, serializeJournal(secondOurs));
+    writeFileSync(pathTheirs2, serializeJournal(secondTheirs));
+
+    const r2 = runMergeDriver(pathBase2, pathOurs2, pathTheirs2, 'drizzle/meta/_journal.json', repo);
+    expect(r2.exitCode).toBe(0);
+
+    // Marker now contains BOTH renames — neither is lost.
+    marker = JSON.parse(readFileSync(markerPath, 'utf-8'));
+    expect(marker.renames).toContainEqual({ oldTag: '0001_beta', newTag: '0002_beta' });
+    expect(marker.renames).toContainEqual({ oldTag: '0003_delta', newTag: '0004_delta' });
+    expect(marker.renames).toHaveLength(2);
+  });
+
+  it('refuses to operate when workingPath does not end in meta/_journal.json', () => {
+    const { repo } = setupRepo('e2e-bad-path');
+
+    const baseJournal = journal([entry(0, 100, '0000_a')]);
+    const pathBase = join(tmpRoot, 'badpath-base.json');
+    const pathOurs = join(tmpRoot, 'badpath-ours.json');
+    const pathTheirs = join(tmpRoot, 'badpath-theirs.json');
+    writeFileSync(pathBase, serializeJournal(baseJournal));
+    writeFileSync(pathOurs, serializeJournal(baseJournal));
+    writeFileSync(pathTheirs, serializeJournal(baseJournal));
+
+    const result = runMergeDriver(
+      pathBase,
+      pathOurs,
+      pathTheirs,
+      'some/other/file.json', // not the journal!
+      repo,
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toMatch(/refusing to operate on unexpected path/);
   });
 
   it('exits 1 with helpful message when journal JSON is malformed', () => {

--- a/crux/git/__tests__/drizzle-journal-merge.test.ts
+++ b/crux/git/__tests__/drizzle-journal-merge.test.ts
@@ -1,0 +1,535 @@
+/**
+ * Tests for the Drizzle journal merge driver.
+ *
+ * Three layers:
+ *
+ *   1. Pure merge logic — `mergeJournals` and `renumberJournal` operate on
+ *      JSON in / JSON out. These are the most important tests because they
+ *      cover the canonical conflict shape (two PRs both add `idx=221`).
+ *   2. End-to-end driver — `runMergeDriver` writes the resolved journal to
+ *      disk and renames .sql files via `git mv`. Tested against a fixture
+ *      git repo set up in tmpfs.
+ *   3. Integration — runs `git rebase` against fixture branches with idx
+ *      collisions and asserts the merge driver resolves cleanly.
+ *
+ * The pure logic tests are the regression-blocker: if they pass, the conflict
+ * shape from PR #4763 (qua-954: 0221 vs 0221 with main's qua-956) cannot
+ * recur as a hand-resolved-by-LLM round-trip.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  mergeJournals,
+  renumberJournal,
+  runMergeDriver,
+  serializeJournal,
+} from '../drizzle-journal-merge.mjs';
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function entry(idx: number, when: number, tag: string): JournalEntry {
+  return { idx, version: '7', when, tag, breakpoints: true };
+}
+
+function journal(entries: JournalEntry[]): Journal {
+  return { version: '7', dialect: 'postgresql', entries };
+}
+
+// ---------------------------------------------------------------------------
+// Pure merge logic — mergeJournals
+// ---------------------------------------------------------------------------
+
+describe('mergeJournals — canonical idx-collision conflict', () => {
+  it('two branches both adding idx=221 → resolves with renumber', () => {
+    // Base: idx 0..220 (the state when both branches were cut)
+    const baseEntries: JournalEntry[] = [];
+    for (let i = 0; i <= 220; i++) {
+      baseEntries.push(entry(i, 1_000_000 + i, `${String(i).padStart(4, '0')}_base_${i}`));
+    }
+    const base = journal(baseEntries);
+
+    // Ours adds idx=221, tag `0221_qua_956_*` with when=1_000_300
+    const ours = journal([
+      ...baseEntries.map((e) => ({ ...e })),
+      entry(221, 1_000_300, '0221_qua_956_policy_stakeholders_natural_key'),
+    ]);
+
+    // Theirs adds idx=221, tag `0221_qua_954_*` with when=1_000_400 (later)
+    const theirs = journal([
+      ...baseEntries.map((e) => ({ ...e })),
+      entry(221, 1_000_400, '0221_qua_954_pipeline_runs'),
+    ]);
+
+    const result = mergeJournals(base, ours, theirs);
+
+    // Should produce 223 entries: 221 base (idx 0..220) + 2 additions
+    expect(result.resolved.entries).toHaveLength(223);
+
+    // The earlier `when` (qua_956) wins the lower idx (221).
+    const e221 = result.resolved.entries.find((e) => e.idx === 221);
+    expect(e221?.tag).toBe('0221_qua_956_policy_stakeholders_natural_key');
+
+    // The later one gets idx=222 and is renamed.
+    const e222 = result.resolved.entries.find((e) => e.idx === 222);
+    expect(e222?.tag).toBe('0222_qua_954_pipeline_runs');
+
+    // The rename list reports the qua_954 file relocation.
+    expect(result.renames).toEqual([
+      { oldTag: '0221_qua_954_pipeline_runs', newTag: '0222_qua_954_pipeline_runs' },
+    ]);
+
+    // Base entries are untouched.
+    for (let i = 0; i <= 220; i++) {
+      const baseEntry = result.resolved.entries.find((e) => e.idx === i);
+      expect(baseEntry).toEqual(baseEntries[i]);
+    }
+  });
+
+  it('reverses winner if theirs has the earlier `when`', () => {
+    const baseEntries: JournalEntry[] = [
+      entry(0, 1_000_000, '0000_base'),
+    ];
+    const base = journal(baseEntries);
+
+    // Ours has the LATER when=1_000_400
+    const ours = journal([
+      ...baseEntries,
+      entry(1, 1_000_400, '0001_qua_a_later'),
+    ]);
+
+    // Theirs has the EARLIER when=1_000_300
+    const theirs = journal([
+      ...baseEntries,
+      entry(1, 1_000_300, '0001_qua_b_earlier'),
+    ]);
+
+    const result = mergeJournals(base, ours, theirs);
+
+    // The earlier `when` (theirs / qua_b) keeps idx=1.
+    const e1 = result.resolved.entries.find((e) => e.idx === 1);
+    expect(e1?.tag).toBe('0001_qua_b_earlier');
+
+    const e2 = result.resolved.entries.find((e) => e.idx === 2);
+    expect(e2?.tag).toBe('0002_qua_a_later');
+
+    expect(result.renames).toEqual([
+      { oldTag: '0001_qua_a_later', newTag: '0002_qua_a_later' },
+    ]);
+  });
+
+  it('three colliding additions all renumber correctly', () => {
+    // Edge case: three branches all adding idx=5
+    const base = journal([
+      entry(0, 100, '0000_base_0'),
+      entry(1, 200, '0001_base_1'),
+      entry(2, 300, '0002_base_2'),
+      entry(3, 400, '0003_base_3'),
+      entry(4, 500, '0004_base_4'),
+    ]);
+    const ours = journal([
+      ...base.entries,
+      entry(5, 600, '0005_a'),
+      entry(5, 700, '0005_b'),
+    ]);
+    const theirs = journal([
+      ...base.entries,
+      entry(5, 650, '0005_c'),
+    ]);
+
+    const result = mergeJournals(base, ours, theirs);
+
+    // 5 base + 3 additions = 8 entries
+    expect(result.resolved.entries).toHaveLength(8);
+    // Sorted by `when`: a (600) < c (650) < b (700)
+    const idxByTag = new Map(result.resolved.entries.map((e) => [e.tag, e.idx]));
+    expect(idxByTag.get('0005_a')).toBe(5);
+    expect(idxByTag.get('0006_c')).toBe(6);
+    expect(idxByTag.get('0007_b')).toBe(7);
+  });
+
+  it('preserves base entries with non-canonical idx ordering', () => {
+    // Real-world journals have idx gaps (e.g. idx 207, 209 with no 208) and
+    // tag prefixes that don't match idx. The merge driver MUST NOT touch
+    // those — they refer to migrations already applied in production.
+    const baseEntries: JournalEntry[] = [
+      entry(0, 100, '0000_a'),
+      entry(207, 200, '0207_b'),
+      entry(209, 300, '0210_c'), // idx=209 but tag prefix is 0210 (legacy mismatch)
+      entry(220, 400, '0220_d'),
+    ];
+    const base = journal(baseEntries);
+    const ours = journal([...baseEntries, entry(221, 500, '0221_new_a')]);
+    const theirs = journal([...baseEntries, entry(221, 600, '0221_new_b')]);
+
+    const result = mergeJournals(base, ours, theirs);
+
+    // Base entries unchanged — same idx, same when, same tag
+    for (const baseEntry of baseEntries) {
+      const matched = result.resolved.entries.find((e) => e.tag === baseEntry.tag);
+      expect(matched).toEqual(baseEntry);
+    }
+
+    // The two additions get fresh idx values above max(existing idx, existing prefix)
+    // existing idx max = 220, existing prefix max = 220 → next free = 221
+    const newA = result.resolved.entries.find((e) => e.tag === '0221_new_a');
+    const newB = result.resolved.entries.find((e) => e.tag === '0222_new_b');
+    expect(newA?.idx).toBe(221);
+    expect(newB?.idx).toBe(222);
+  });
+
+  it('handles same tag added on both branches (cherry-pick scenario)', () => {
+    const base = journal([entry(0, 100, '0000_a')]);
+    // Both branches independently add the SAME migration (tag identical)
+    const ours = journal([...base.entries, entry(1, 200, '0001_dup')]);
+    const theirs = journal([...base.entries, entry(1, 200, '0001_dup')]);
+
+    const result = mergeJournals(base, ours, theirs);
+
+    // Should dedup — only one entry for `0001_dup`.
+    expect(result.resolved.entries).toHaveLength(2);
+    expect(result.renames).toEqual([]);
+  });
+
+  it('bumps `when` to keep strict monotonicity when timestamps would collide', () => {
+    const base = journal([entry(0, 100, '0000_a'), entry(1, 200, '0001_b')]);
+    // Both branches add at the SAME `when`=300. The renamed loser must get
+    // a `when` strictly above the previous max.
+    const ours = journal([...base.entries, entry(2, 300, '0002_qua_a')]);
+    const theirs = journal([...base.entries, entry(2, 300, '0002_qua_b')]);
+
+    const result = mergeJournals(base, ours, theirs);
+
+    expect(result.resolved.entries).toHaveLength(4);
+    const e2 = result.resolved.entries.find((e) => e.idx === 2);
+    const e3 = result.resolved.entries.find((e) => e.idx === 3);
+    expect(e2?.when).toBe(300);
+    // The renumbered entry's `when` was bumped above the previous max.
+    expect(e3!.when).toBeGreaterThan(e2!.when);
+  });
+
+  it('produces the same result regardless of which branch is "ours" vs "theirs"', () => {
+    // The driver should be symmetric — the underlying conflict has no
+    // notion of "which side initiated the merge" beyond `when` ordering.
+    const base = journal([entry(0, 100, '0000_a')]);
+    const branch1 = journal([...base.entries, entry(1, 200, '0001_first')]);
+    const branch2 = journal([...base.entries, entry(1, 300, '0001_second')]);
+
+    const r1 = mergeJournals(base, branch1, branch2);
+    const r2 = mergeJournals(base, branch2, branch1);
+
+    // Tags + idx + when should be identical regardless of side.
+    const summary = (r: typeof r1) => r.resolved.entries.map((e) => `${e.idx}:${e.tag}:${e.when}`).sort();
+    expect(summary(r1)).toEqual(summary(r2));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure renumber logic — renumberJournal (fallback fixup)
+// ---------------------------------------------------------------------------
+
+describe('renumberJournal — single-journal fixup', () => {
+  it('returns canonical journal unchanged (no renames)', () => {
+    const j = journal([
+      entry(0, 100, '0000_a'),
+      entry(1, 200, '0001_b'),
+      entry(2, 300, '0002_c'),
+    ]);
+    const result = renumberJournal(j);
+    expect(result.renames).toEqual([]);
+    expect(result.resolved.entries).toEqual(j.entries);
+  });
+
+  it('preserves idx gaps when there are no conflicts', () => {
+    // Real-world journals have gaps. Don't churn historical state.
+    const j = journal([
+      entry(0, 100, '0000_a'),
+      entry(207, 200, '0207_b'),
+      entry(209, 300, '0210_c'), // idx=209, prefix=0210 — historical mismatch
+    ]);
+    const result = renumberJournal(j);
+    expect(result.renames).toEqual([]);
+    expect(result.resolved.entries).toEqual(j.entries);
+  });
+
+  it('resolves duplicate idx by renumbering the LATER `when`', () => {
+    const j = journal([
+      entry(0, 100, '0000_a'),
+      entry(1, 200, '0001_first'),
+      entry(1, 300, '0001_second'), // duplicate idx, later when
+    ]);
+    const result = renumberJournal(j);
+    // Earlier wins — keeps idx=1
+    const first = result.resolved.entries.find((e) => e.tag === '0001_first');
+    expect(first?.idx).toBe(1);
+    // Later gets renumbered to idx=2 (next free above max = 1)
+    const second = result.resolved.entries.find((e) => e.tag === '0002_second');
+    expect(second?.idx).toBe(2);
+    expect(result.renames).toEqual([{ oldTag: '0001_second', newTag: '0002_second' }]);
+  });
+
+  it('resolves duplicate prefix even when idx differs', () => {
+    // Two entries with idx 5 and 6 but BOTH have tag prefix `0005_*`.
+    // This shouldn't happen via drizzle-kit but can happen via manual edits.
+    const j = journal([
+      entry(0, 100, '0000_a'),
+      entry(5, 200, '0005_first'),
+      entry(6, 300, '0005_dup'),
+    ]);
+    const result = renumberJournal(j);
+    // The later `when` (0005_dup) gets renumbered to next free idx (7) and
+    // its prefix rewritten to match.
+    const dup = result.resolved.entries.find((e) => e.tag === '0007_dup');
+    expect(dup?.idx).toBe(7);
+    expect(result.renames).toEqual([{ oldTag: '0005_dup', newTag: '0007_dup' }]);
+  });
+
+  it('does not mutate input', () => {
+    const j = journal([
+      entry(1, 200, '0001_a'),
+      entry(1, 300, '0001_b'),
+    ]);
+    const snapshot = JSON.stringify(j);
+    renumberJournal(j);
+    expect(JSON.stringify(j)).toBe(snapshot);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+describe('serializeJournal', () => {
+  it('matches drizzle-kit format: 2-space indent + two trailing newlines', () => {
+    const j = journal([entry(0, 100, '0000_a')]);
+    const out = serializeJournal(j);
+    expect(out.endsWith('\n\n')).toBe(true);
+    expect(out).toMatch(/  "version": "7",\n  "dialect": "postgresql"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end driver — writes %A, runs `git mv`
+// ---------------------------------------------------------------------------
+
+describe('runMergeDriver — end to end', () => {
+  let tmpRoot: string;
+
+  beforeAll(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'drizzle-merge-test-'));
+  });
+
+  afterAll(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function setupRepo(testName: string): {
+    repo: string;
+    drizzleDir: string;
+    metaDir: string;
+  } {
+    const repo = join(tmpRoot, testName);
+    const drizzleDir = join(repo, 'drizzle');
+    const metaDir = join(drizzleDir, 'meta');
+    mkdirSync(metaDir, { recursive: true });
+
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+    return { repo, drizzleDir, metaDir };
+  }
+
+  function commit(repo: string, msg: string): void {
+    execFileSync('git', ['add', '-A'], { cwd: repo });
+    execFileSync('git', ['commit', '-q', '-m', msg], { cwd: repo });
+  }
+
+  it('writes resolved journal and renames .sql file via git mv', () => {
+    const { repo, drizzleDir, metaDir } = setupRepo('e2e-rename');
+
+    // Base state: idx 0
+    const baseJournal = journal([entry(0, 100, '0000_base')]);
+    writeFileSync(join(metaDir, '_journal.json'), serializeJournal(baseJournal));
+    writeFileSync(join(drizzleDir, '0000_base.sql'), '-- base\n');
+    commit(repo, 'base');
+
+    // Set up the three temp files git would pass to the merge driver:
+    // - %O = base
+    // - %A = ours (current branch with one addition, also output target)
+    // - %B = theirs (other branch with conflicting addition)
+    const oursJournal = journal([
+      ...baseJournal.entries,
+      entry(1, 200, '0001_qua_a'),
+    ]);
+    const theirsJournal = journal([
+      ...baseJournal.entries,
+      entry(1, 300, '0001_qua_b'), // conflicting idx
+    ]);
+
+    // Place ours's .sql file in the worktree as if the rebase has applied it.
+    writeFileSync(join(drizzleDir, '0001_qua_a.sql'), '-- qua_a\n');
+    writeFileSync(join(drizzleDir, '0001_qua_b.sql'), '-- qua_b\n');
+    // Both .sql files staged so `git mv` works.
+    execFileSync('git', ['add', '-A'], { cwd: repo });
+
+    const pathBase = join(tmpRoot, 'e2e-rename-base.json');
+    const pathOurs = join(tmpRoot, 'e2e-rename-ours.json');
+    const pathTheirs = join(tmpRoot, 'e2e-rename-theirs.json');
+    writeFileSync(pathBase, serializeJournal(baseJournal));
+    writeFileSync(pathOurs, serializeJournal(oursJournal));
+    writeFileSync(pathTheirs, serializeJournal(theirsJournal));
+
+    const workingPath = 'drizzle/meta/_journal.json';
+    const result = runMergeDriver(pathBase, pathOurs, pathTheirs, workingPath, repo);
+
+    expect(result.exitCode).toBe(0);
+
+    // Output journal at %A reflects the resolved state.
+    const out = JSON.parse(readFileSync(pathOurs, 'utf-8')) as Journal;
+    expect(out.entries).toHaveLength(3);
+    const tags = out.entries.map((e) => e.tag).sort();
+    expect(tags).toEqual(['0000_base', '0001_qua_a', '0002_qua_b']);
+
+    // The .sql rename happened via git mv.
+    expect(existsSync(join(drizzleDir, '0001_qua_a.sql'))).toBe(true);
+    expect(existsSync(join(drizzleDir, '0001_qua_b.sql'))).toBe(false);
+    expect(existsSync(join(drizzleDir, '0002_qua_b.sql'))).toBe(true);
+  });
+
+  it('renames matching snapshot.json sibling when present', () => {
+    const { repo, drizzleDir, metaDir } = setupRepo('e2e-snapshot');
+
+    const baseJournal = journal([entry(0, 100, '0000_base')]);
+    writeFileSync(join(metaDir, '_journal.json'), serializeJournal(baseJournal));
+    writeFileSync(join(drizzleDir, '0000_base.sql'), '-- base\n');
+    commit(repo, 'base');
+
+    // Theirs adds an entry with a snapshot.json sibling
+    writeFileSync(join(drizzleDir, '0001_a.sql'), '-- a\n');
+    writeFileSync(join(drizzleDir, '0001_b.sql'), '-- b\n');
+    writeFileSync(join(metaDir, '0001_snapshot.json'), '{"prevId":"x"}\n');
+    execFileSync('git', ['add', '-A'], { cwd: repo });
+
+    const oursJournal = journal([...baseJournal.entries, entry(1, 200, '0001_a')]);
+    const theirsJournal = journal([...baseJournal.entries, entry(1, 300, '0001_b')]);
+
+    const pathBase = join(tmpRoot, 'snap-base.json');
+    const pathOurs = join(tmpRoot, 'snap-ours.json');
+    const pathTheirs = join(tmpRoot, 'snap-theirs.json');
+    writeFileSync(pathBase, serializeJournal(baseJournal));
+    writeFileSync(pathOurs, serializeJournal(oursJournal));
+    writeFileSync(pathTheirs, serializeJournal(theirsJournal));
+
+    const result = runMergeDriver(
+      pathBase,
+      pathOurs,
+      pathTheirs,
+      'drizzle/meta/_journal.json',
+      repo,
+    );
+
+    expect(result.exitCode).toBe(0);
+
+    // The losing entry was 0001_b (later when=300); it gets renamed to 0002_b.
+    expect(existsSync(join(drizzleDir, '0002_b.sql'))).toBe(true);
+    // The matching snapshot also moves: 0001_snapshot.json was the only one,
+    // it belonged to the losing entry, so it should now be 0002_snapshot.json.
+    // Actually we conservatively rename when idx-prefix changes for the entry,
+    // so the snapshot follows.
+    expect(existsSync(join(metaDir, '0002_snapshot.json'))).toBe(true);
+    expect(existsSync(join(metaDir, '0001_snapshot.json'))).toBe(false);
+  });
+
+  it('writes a pending-renames marker when the source .sql is not in the worktree', () => {
+    // This is the canonical mid-rebase scenario: git invokes the merge
+    // driver before the rebase commit's tree has been written to the
+    // worktree, so the .sql file we want to rename doesn't exist on disk
+    // yet. We must defer the rename to a post-rewrite hook.
+    const { repo, drizzleDir, metaDir } = setupRepo('e2e-defer');
+
+    const baseJournal = journal([entry(0, 100, '0000_base')]);
+    writeFileSync(join(metaDir, '_journal.json'), serializeJournal(baseJournal));
+    writeFileSync(join(drizzleDir, '0000_base.sql'), '-- base\n');
+    commit(repo, 'base');
+
+    // Note: we deliberately do NOT create 0001_b.sql in the worktree —
+    // simulating the mid-rebase state.
+    const oursJournal = journal([...baseJournal.entries, entry(1, 200, '0001_a')]);
+    const theirsJournal = journal([...baseJournal.entries, entry(1, 300, '0001_b')]);
+
+    const pathBase = join(tmpRoot, 'defer-base.json');
+    const pathOurs = join(tmpRoot, 'defer-ours.json');
+    const pathTheirs = join(tmpRoot, 'defer-theirs.json');
+    writeFileSync(pathBase, serializeJournal(baseJournal));
+    writeFileSync(pathOurs, serializeJournal(oursJournal));
+    writeFileSync(pathTheirs, serializeJournal(theirsJournal));
+
+    const result = runMergeDriver(
+      pathBase,
+      pathOurs,
+      pathTheirs,
+      'drizzle/meta/_journal.json',
+      repo,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.message).toMatch(/deferred to post-rewrite hook/);
+
+    // The marker file was written and contains the rename.
+    const markerPath = join(repo, '.git', 'MIGRATION_RENAMES_PENDING');
+    expect(existsSync(markerPath)).toBe(true);
+    const marker = JSON.parse(readFileSync(markerPath, 'utf-8'));
+    expect(marker.renames).toEqual([{ oldTag: '0001_b', newTag: '0002_b' }]);
+    expect(marker.drizzleDir).toBe('drizzle');
+  });
+
+  it('exits 1 with helpful message when journal JSON is malformed', () => {
+    const repo = mkdtempSync(join(tmpRoot, 'malformed-'));
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+    // Make a real commit so the repo isn't empty (avoids edge cases)
+    writeFileSync(join(repo, 'README'), 'x');
+    execFileSync('git', ['add', '-A'], { cwd: repo });
+    execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: repo });
+
+    const pathBase = join(tmpRoot, 'malformed-base.json');
+    const pathOurs = join(tmpRoot, 'malformed-ours.json');
+    const pathTheirs = join(tmpRoot, 'malformed-theirs.json');
+    writeFileSync(pathBase, '{ not valid json');
+    writeFileSync(pathOurs, '{}');
+    writeFileSync(pathTheirs, '{}');
+
+    const result = runMergeDriver(pathBase, pathOurs, pathTheirs, 'drizzle/meta/_journal.json', repo);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toMatch(/failed to parse/);
+    expect(result.message).toMatch(/crux migrations renumber/);
+  });
+});

--- a/crux/git/drizzle-journal-merge.mjs
+++ b/crux/git/drizzle-journal-merge.mjs
@@ -1,0 +1,521 @@
+/**
+ * Drizzle journal merge driver — auto-resolves `_journal.json` conflicts on rebase.
+ *
+ * Wired up via `.gitattributes`:
+ *
+ *     apps/wiki-server/drizzle/meta/_journal.json merge=drizzle-journal
+ *
+ * plus `git config merge.drizzle-journal.driver "node crux/git/drizzle-journal-merge.mjs %O %A %B %P"`
+ * (set by `pnpm install` / `scripts/setup.sh`).
+ *
+ * The conflict shape: two PRs both add a migration grabbing the next idx (e.g.
+ * both 221), and neither rebase nor a 3-way merge can resolve it without a
+ * human or an LLM round-trip. This driver:
+ *
+ *   1. Parses the three journal versions (base, ours, theirs).
+ *   2. Computes the union of `entries` by tag.
+ *   3. For conflicts (duplicate idx or duplicate tag prefix), renumbers the
+ *      LATER migration (by `when`) to a fresh idx above the current max.
+ *   4. Renames migration .sql files (and snapshot.json siblings) on disk via
+ *      `git mv` when the prefix changes.
+ *   5. Bumps `when` timestamps for renumbered entries to keep strictly
+ *      increasing (else the migrator silently skips them).
+ *   6. Writes the resolved journal to %A.
+ *
+ * Failure mode: on any error (parse failure, file rename failure), exits 1
+ * with a clear message pointing the user at `pnpm crux migrations renumber`
+ * to fix the journal manually after the rebase aborts. Git falls back to
+ * the standard 3-way merge in that case — which leaves conflict markers
+ * in `_journal.json` exactly as before, so this driver is additive: it can
+ * only succeed where the default merge would have failed.
+ *
+ * Implemented as plain ESM (no tsx dependency) so it runs unaltered on
+ * every developer's machine — even on a fresh clone before `pnpm install`
+ * has populated `node_modules`.
+ *
+ * The pure merge logic is exposed as `mergeJournals()` for unit testing —
+ * the side-effecting filesystem operations live in the `runMergeDriver()`
+ * entry point.
+ */
+
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+/**
+ * Resolve duplicate idx values and duplicate tag prefixes by renumbering the
+ * conflicting entries to fresh idx values (above the current max). Historical
+ * entries with valid idx and unique tag prefixes are LEFT UNCHANGED — this
+ * keeps the rewrite minimal and avoids producing a noisy diff that touches
+ * already-applied production migrations.
+ *
+ * Conflict detection:
+ *   - Two or more entries with the same `idx`.
+ *   - Two or more entries whose tag begins with the same numeric prefix.
+ *
+ * Resolution: for each conflict group, the entry with the smallest `when`
+ * (i.e. the migration authored first) keeps its idx/tag. The remaining
+ * entries are renumbered to the next free idx values above the current
+ * maximum, and their tags rewritten to match.
+ *
+ * This is the right shape for the canonical scenario the merge driver is
+ * built for: two PRs both grabbed `idx=221`. The earlier one keeps 221,
+ * the later one becomes 222.
+ *
+ * Used as a fallback (`crux migrations renumber`) and as the shared core of
+ * the 3-way merge below.
+ */
+export function renumberJournal(journal) {
+  // Make a deep copy so callers' input isn't mutated.
+  const entries = journal.entries.map((e) => ({ ...e }));
+
+  // Identify conflict groups by idx and by tag prefix. We collect indices
+  // (positions in the entries array) so we can pick a winner deterministically.
+  const idxGroups = new Map();
+  const prefixGroups = new Map();
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    if (!idxGroups.has(e.idx)) idxGroups.set(e.idx, []);
+    idxGroups.get(e.idx).push(i);
+
+    const m = e.tag.match(/^(\d+)_/);
+    if (m) {
+      const p = m[1];
+      if (!prefixGroups.has(p)) prefixGroups.set(p, []);
+      prefixGroups.get(p).push(i);
+    }
+  }
+
+  // Collect the set of entry indices that need to be renumbered: any entry
+  // not in the "winner" position of its idx-group or prefix-group. Winner
+  // is the entry with smallest `when` (tie-break by tag for determinism).
+  const needsRenum = new Set();
+  const pickWinner = (group) => {
+    let winner = group[0];
+    for (const i of group.slice(1)) {
+      const a = entries[winner];
+      const b = entries[i];
+      if (b.when < a.when || (b.when === a.when && b.tag.localeCompare(a.tag) < 0)) {
+        winner = i;
+      }
+    }
+    return winner;
+  };
+  for (const group of idxGroups.values()) {
+    if (group.length < 2) continue;
+    const winner = pickWinner(group);
+    for (const i of group) {
+      if (i !== winner) needsRenum.add(i);
+    }
+  }
+  for (const group of prefixGroups.values()) {
+    if (group.length < 2) continue;
+    const winner = pickWinner(group);
+    for (const i of group) {
+      if (i !== winner) needsRenum.add(i);
+    }
+  }
+
+  // Compute the next free idx and prefix above any existing entry's value.
+  // A "used" idx comes from any entry's current idx OR any entry's tag prefix
+  // (in case the journal records idx=N for tag `00MM_*` with M != N).
+  const usedIdx = new Set();
+  for (const e of entries) {
+    usedIdx.add(e.idx);
+    const m = e.tag.match(/^(\d+)_/);
+    if (m) usedIdx.add(parseInt(m[1], 10));
+  }
+  let nextFreeIdx = 0;
+  for (const v of usedIdx) if (v >= nextFreeIdx) nextFreeIdx = v + 1;
+
+  // Renumber conflicting entries in `when` order so deterministic tie-breaks
+  // give the older migration the lower new idx.
+  const toRenum = [...needsRenum].sort((a, b) => {
+    const ea = entries[a];
+    const eb = entries[b];
+    return (ea.when - eb.when) || ea.tag.localeCompare(eb.tag);
+  });
+
+  const renames = [];
+  for (const i of toRenum) {
+    const entry = entries[i];
+    const newIdx = nextFreeIdx++;
+    const newPrefix = String(newIdx).padStart(4, '0');
+    const m = entry.tag.match(/^(\d+)_/);
+    if (m && m[1] !== newPrefix) {
+      const oldTag = entry.tag;
+      const newTag = `${newPrefix}_${entry.tag.slice(m[0].length)}`;
+      renames.push({ oldTag, newTag });
+      entry.tag = newTag;
+    }
+    entry.idx = newIdx;
+  }
+
+  // Track which entry references were renumbered. We bump only their `when`
+  // values for monotonicity — historical entries are left untouched so we
+  // don't churn already-applied production state.
+  const touched = new Set(toRenum.map((i) => entries[i]));
+
+  // We don't re-sort the entries array. Drizzle migrations are ordered by
+  // `when`, not by idx — sorting by idx would gratuitously reorder rows
+  // when an existing journal has historical out-of-position entries (idx
+  // gaps, manual cleanups). The validator only requires unique idx, unique
+  // tag prefix, and strictly-increasing `when` in array order.
+
+  // Ensure strictly-increasing `when` — duplicates cause the migrator to
+  // silently skip migrations (it compares `created_at < folderMillis`).
+  let prev = -Infinity;
+  for (const e of entries) {
+    if (touched.has(e) && e.when <= prev) e.when = prev + 1;
+    prev = Math.max(prev, e.when);
+  }
+
+  return {
+    resolved: {
+      version: journal.version,
+      dialect: journal.dialect,
+      entries,
+    },
+    renames,
+  };
+}
+
+/**
+ * Pure JSON merge — given the three versions of `_journal.json` (base, ours,
+ * theirs), compute the resolved journal and the list of file renames implied
+ * by reassigned idx values.
+ *
+ * Strategy:
+ *   - Base entries pass through unchanged (drizzle migrations are append-only;
+ *     entries already in base refer to migrations applied in production).
+ *   - Additions from ours and theirs are unioned by tag, then handed to
+ *     `renumberJournal` which resolves any idx or prefix collisions.
+ *   - Conflicts on top-level keys (`version`, `dialect`) are resolved by
+ *     preferring `ours` — they only change when drizzle-kit's schema version
+ *     bumps, which is rare and the user can re-run drizzle-kit if needed.
+ */
+export function mergeJournals(base, ours, theirs) {
+  const baseTags = new Set(base.entries.map((e) => e.tag));
+  const additionsByTag = new Map();
+  for (const e of ours.entries) {
+    if (!baseTags.has(e.tag)) additionsByTag.set(e.tag, { ...e });
+  }
+  for (const e of theirs.entries) {
+    if (!baseTags.has(e.tag)) additionsByTag.set(e.tag, { ...e });
+  }
+
+  return renumberJournal({
+    version: ours.version,
+    dialect: ours.dialect,
+    entries: [...base.entries.map((e) => ({ ...e })), ...additionsByTag.values()],
+  });
+}
+
+/**
+ * Serialize a journal in drizzle-kit's exact format: 2-space indent + two
+ * trailing newlines. Any deviation produces noisy diffs on every subsequent
+ * `drizzle-kit generate`.
+ */
+export function serializeJournal(journal) {
+  return JSON.stringify(journal, null, 2) + '\n\n';
+}
+
+/**
+ * Run a git command, throwing with a descriptive error on failure.
+ * Uses execFileSync to avoid shell-injection issues with file paths.
+ */
+function git(args, cwd) {
+  try {
+    return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`git ${args.join(' ')} failed: ${message}`);
+  }
+}
+
+/**
+ * Check whether a path is tracked by git (has a known index entry).
+ */
+function isTracked(path, cwd) {
+  try {
+    execFileSync('git', ['ls-files', '--error-unmatch', '--', path], { cwd, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Apply a list of tag renames to the worktree: rename the .sql migration
+ * file and any matching snapshot.json file. Uses `git mv` so the rename
+ * is staged automatically.
+ *
+ * `drizzleDir` is interpreted relative to `repoRoot` if not absolute. We
+ * resolve to an absolute path before calling `existsSync` / `git mv` so the
+ * driver works correctly regardless of the parent process's CWD.
+ *
+ * Operates in two modes depending on whether the source file is in the
+ * worktree:
+ *
+ *   - **Worktree present + index unlocked** (post-rebase / post-merge hook):
+ *     `git mv` the file. The rename is staged and the next commit (or
+ *     `--amend`) picks it up.
+ *   - **File not yet in worktree** (mid-rebase merge driver invocation):
+ *     git's index is held by the rebase machinery — `git mv` fails with
+ *     `index.lock: File exists`. We can't reach the file because it's only
+ *     in the rebase's pending tree, not the worktree. The caller (the
+ *     merge driver) catches this and writes a marker file that the
+ *     post-rewrite/post-merge hook will apply once git releases the lock.
+ *
+ * If the .sql file is already at the new path (idempotent re-run), we
+ * skip silently — git can re-invoke the merge driver during conflict
+ * resolution and we want re-runs to be no-ops.
+ */
+export function applyRenames(renames, drizzleDir, repoRoot) {
+  const skipped = [];
+  const deferred = [];
+  let renamed = 0;
+
+  // Resolve drizzleDir relative to repoRoot so we don't depend on CWD.
+  const absDrizzleDir = drizzleDir.startsWith('/') ? drizzleDir : join(repoRoot, drizzleDir);
+
+  for (const { oldTag, newTag } of renames) {
+    const oldSql = join(absDrizzleDir, `${oldTag}.sql`);
+    const newSql = join(absDrizzleDir, `${newTag}.sql`);
+
+    if (!existsSync(oldSql)) {
+      if (existsSync(newSql)) {
+        // Already renamed — idempotent.
+        skipped.push(`${oldTag}.sql (already renamed to ${newTag}.sql)`);
+        renamed++;
+      } else {
+        // File isn't in the worktree yet (e.g., mid-rebase the .sql will
+        // arrive when git applies the commit's tree). Defer this rename
+        // to the post-rewrite/post-merge hook.
+        deferred.push({ oldTag, newTag });
+      }
+      continue;
+    }
+
+    if (existsSync(newSql)) {
+      throw new Error(
+        `Cannot rename ${oldTag}.sql → ${newTag}.sql: destination already exists. ` +
+          `This indicates a tag collision the merge driver cannot resolve safely.`,
+      );
+    }
+
+    if (isTracked(oldSql, repoRoot)) {
+      try {
+        git(['mv', oldSql, newSql], repoRoot);
+      } catch (err) {
+        // `git mv` fails with `index.lock` while git holds the merge index.
+        // Defer — the post-rewrite/post-merge hook will retry once the lock
+        // is released.
+        const message = err instanceof Error ? err.message : String(err);
+        if (/index\.lock/i.test(message)) {
+          deferred.push({ oldTag, newTag });
+          continue;
+        }
+        throw err;
+      }
+    } else {
+      // Untracked file — rename via fs and stage.
+      renameSync(oldSql, newSql);
+      try {
+        git(['add', newSql], repoRoot);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (/index\.lock/i.test(message)) {
+          deferred.push({ oldTag, newTag });
+          continue;
+        }
+        throw err;
+      }
+    }
+    renamed++;
+
+    // Also rename the snapshot.json sibling, if it exists.
+    // Snapshots are sparse in this codebase — most migrations don't have one.
+    const oldPrefix = oldTag.match(/^(\d+)_/)?.[1];
+    const newPrefix = newTag.match(/^(\d+)_/)?.[1];
+    if (oldPrefix && newPrefix && oldPrefix !== newPrefix) {
+      const oldSnap = join(absDrizzleDir, 'meta', `${oldPrefix}_snapshot.json`);
+      const newSnap = join(absDrizzleDir, 'meta', `${newPrefix}_snapshot.json`);
+      if (existsSync(oldSnap) && !existsSync(newSnap)) {
+        if (isTracked(oldSnap, repoRoot)) {
+          try {
+            git(['mv', oldSnap, newSnap], repoRoot);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (!/index\.lock/i.test(message)) throw err;
+            // Snapshot rename can be deferred too — hook handles it.
+          }
+        } else {
+          renameSync(oldSnap, newSnap);
+          try {
+            git(['add', newSnap], repoRoot);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (!/index\.lock/i.test(message)) throw err;
+          }
+        }
+      }
+    }
+  }
+
+  return { renamed, skipped, deferred };
+}
+
+/**
+ * Locate the repository root by walking up from a starting directory until
+ * a `.git` entry is found. Throws if not inside a git repo.
+ */
+function findRepoRoot(startDir) {
+  let dir = startDir;
+  while (true) {
+    if (existsSync(join(dir, '.git'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Not inside a git repository (started from ${startDir})`);
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * Entry point for the git merge driver. Args correspond to git's `%O %A %B %P`:
+ *
+ *   pathBase    — common ancestor's version (read-only temp file)
+ *   pathOurs    — current branch's version (also the OUTPUT path)
+ *   pathTheirs  — other branch's version (read-only temp file)
+ *   workingPath — pathname of the conflicted file in the worktree
+ *
+ * On success: writes resolved JSON to pathOurs, renames .sql/snapshot files,
+ * exits 0.
+ *
+ * On failure: prints a message recommending `pnpm crux migrations renumber`,
+ * exits 1 — which leaves the conflict markers in place so the user can
+ * inspect and fix manually.
+ */
+export function runMergeDriver(pathBase, pathOurs, pathTheirs, workingPath, cwd = process.cwd()) {
+  let base, ours, theirs;
+  try {
+    base = JSON.parse(readFileSync(pathBase, 'utf-8'));
+    ours = JSON.parse(readFileSync(pathOurs, 'utf-8'));
+    theirs = JSON.parse(readFileSync(pathTheirs, 'utf-8'));
+  } catch (err) {
+    return {
+      exitCode: 1,
+      message:
+        `drizzle-journal-merge: failed to parse one of the input journals: ${err instanceof Error ? err.message : String(err)}\n` +
+        `  Falling back to standard 3-way merge. After resolving manually, run:\n` +
+        `    pnpm crux migrations renumber`,
+    };
+  }
+
+  let mergeResult;
+  try {
+    mergeResult = mergeJournals(base, ours, theirs);
+  } catch (err) {
+    return {
+      exitCode: 1,
+      message:
+        `drizzle-journal-merge: merge logic failed: ${err instanceof Error ? err.message : String(err)}\n` +
+        `  Falling back to standard 3-way merge. After resolving manually, run:\n` +
+        `    pnpm crux migrations renumber`,
+    };
+  }
+
+  let repoRoot;
+  try {
+    repoRoot = findRepoRoot(cwd);
+  } catch (err) {
+    return {
+      exitCode: 1,
+      message: `drizzle-journal-merge: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // The .sql files we need to rename live in the directory containing the
+  // conflicted journal's parent (e.g. apps/wiki-server/drizzle/meta/
+  // _journal.json → apps/wiki-server/drizzle/).
+  const drizzleDir = dirname(dirname(workingPath));
+
+  let deferredRenames = [];
+  try {
+    const result = applyRenames(mergeResult.renames, drizzleDir, repoRoot);
+    deferredRenames = result.deferred;
+  } catch (err) {
+    return {
+      exitCode: 1,
+      message:
+        `drizzle-journal-merge: failed to rename migration files: ${err instanceof Error ? err.message : String(err)}\n` +
+        `  After resolving the rebase, run:\n` +
+        `    pnpm crux migrations renumber`,
+    };
+  }
+
+  // Persist any renames we couldn't apply now (because git's index lock is
+  // held and/or the source .sql file isn't in the worktree yet) so the
+  // post-rewrite / post-merge hook can finish them once the rebase /merge
+  // completes.
+  if (deferredRenames.length > 0) {
+    try {
+      const pendingPath = join(repoRoot, '.git', 'MIGRATION_RENAMES_PENDING');
+      const payload = {
+        version: 1,
+        drizzleDir, // path relative to repo root
+        renames: deferredRenames,
+      };
+      writeFileSync(pendingPath, JSON.stringify(payload, null, 2));
+    } catch (err) {
+      return {
+        exitCode: 1,
+        message:
+          `drizzle-journal-merge: failed to write pending-renames marker: ${err instanceof Error ? err.message : String(err)}\n` +
+          `  After the rebase completes, run:\n` +
+          `    pnpm crux migrations renumber`,
+      };
+    }
+  }
+
+  try {
+    writeFileSync(pathOurs, serializeJournal(mergeResult.resolved));
+  } catch (err) {
+    return {
+      exitCode: 1,
+      message: `drizzle-journal-merge: failed to write resolved journal: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const renameCount = mergeResult.renames.length;
+  let message = `drizzle-journal-merge: resolved ${mergeResult.resolved.entries.length} entries`;
+  if (renameCount > 0) {
+    message += ` (${renameCount} migration${renameCount === 1 ? '' : 's'} renumbered`;
+    if (deferredRenames.length > 0) {
+      message += `; ${deferredRenames.length} rename${deferredRenames.length === 1 ? '' : 's'} deferred to post-rewrite hook`;
+    }
+    message += ')';
+  }
+  return { exitCode: 0, message };
+}
+
+// CLI entry point — only runs when executed directly, not when imported by tests.
+const invokedDirectly =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  /drizzle-journal-merge\.(mjs|cjs|js|ts)$/.test(process.argv[1]);
+
+if (invokedDirectly) {
+  const [, , pathBase, pathOurs, pathTheirs, workingPath] = process.argv;
+  if (!pathBase || !pathOurs || !pathTheirs || !workingPath) {
+    process.stderr.write(
+      'Usage: drizzle-journal-merge.mjs <base> <ours> <theirs> <working-path>\n' +
+        '  This is a git merge driver — git invokes it with %O %A %B %P.\n',
+    );
+    process.exit(2);
+  }
+  const result = runMergeDriver(pathBase, pathOurs, pathTheirs, workingPath);
+  process.stderr.write(result.message + '\n');
+  process.exit(result.exitCode);
+}

--- a/crux/git/drizzle-journal-merge.mjs
+++ b/crux/git/drizzle-journal-merge.mjs
@@ -40,7 +40,24 @@
 
 import { execFileSync } from 'child_process';
 import { existsSync, readFileSync, renameSync, writeFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { dirname, isAbsolute as isAbsolutePath, join } from 'path';
+
+/**
+ * Tag-format guard. Drizzle-kit only emits tags shaped `NNNN_word_word_…`,
+ * so we reject anything that doesn't match before letting it flow into
+ * filesystem operations. Without this, a malicious branch could craft a
+ * journal entry like `{tag: "../../../etc/passwd"}` and (via the .sql
+ * rename code path) cause the driver to mv a file outside the repo.
+ *
+ * The driver only fires for clones that have opted in via setup.sh, but
+ * the *content* of merged branches is untrusted — so this validation runs
+ * as defense in depth.
+ */
+const SAFE_TAG_RE = /^\d+_[A-Za-z0-9_]+$/;
+
+function isSafeTag(tag) {
+  return typeof tag === 'string' && SAFE_TAG_RE.test(tag);
+}
 
 /**
  * Resolve duplicate idx values and duplicate tag prefixes by renumbering the
@@ -95,7 +112,7 @@ export function renumberJournal(journal) {
     for (const i of group.slice(1)) {
       const a = entries[winner];
       const b = entries[i];
-      if (b.when < a.when || (b.when === a.when && b.tag.localeCompare(a.tag) < 0)) {
+      if (b.when < a.when || (b.when === a.when && b.tag < a.tag)) {
         winner = i;
       }
     }
@@ -133,7 +150,10 @@ export function renumberJournal(journal) {
   const toRenum = [...needsRenum].sort((a, b) => {
     const ea = entries[a];
     const eb = entries[b];
-    return (ea.when - eb.when) || ea.tag.localeCompare(eb.tag);
+    // Tie-break by tag using direct string comparison (NOT localeCompare,
+    // which is locale-sensitive and would produce different "winners" on
+    // different machines). Drizzle tags are ASCII so byte-order is fine.
+    return (ea.when - eb.when) || (ea.tag < eb.tag ? -1 : ea.tag > eb.tag ? 1 : 0);
   });
 
   const renames = [];
@@ -145,6 +165,16 @@ export function renumberJournal(journal) {
     if (m && m[1] !== newPrefix) {
       const oldTag = entry.tag;
       const newTag = `${newPrefix}_${entry.tag.slice(m[0].length)}`;
+      // Defense in depth: refuse to emit a rename whose old or new tag
+      // would escape the migrations directory. Drizzle-kit-generated tags
+      // always pass; a hand-crafted journal entry that tries to traverse
+      // is rejected here so the rename never reaches `git mv` / `mv`.
+      if (!isSafeTag(oldTag) || !isSafeTag(newTag)) {
+        throw new Error(
+          `Refusing to rename unsafe tag: ${JSON.stringify(oldTag)} → ${JSON.stringify(newTag)}. ` +
+            `Tags must match ${SAFE_TAG_RE}.`,
+        );
+      }
       renames.push({ oldTag, newTag });
       entry.tag = newTag;
     }
@@ -275,19 +305,33 @@ export function applyRenames(renames, drizzleDir, repoRoot) {
   const skipped = [];
   const deferred = [];
   let renamed = 0;
+  let alreadyRenamed = 0;
 
-  // Resolve drizzleDir relative to repoRoot so we don't depend on CWD.
-  const absDrizzleDir = drizzleDir.startsWith('/') ? drizzleDir : join(repoRoot, drizzleDir);
+  // Resolve drizzleDir relative to repoRoot so we don't depend on CWD. We
+  // use `path.isAbsolute` rather than a `startsWith('/')` check so the
+  // driver works correctly on Windows too.
+  const absDrizzleDir = isAbsolutePath(drizzleDir) ? drizzleDir : join(repoRoot, drizzleDir);
 
   for (const { oldTag, newTag } of renames) {
+    if (!isSafeTag(oldTag) || !isSafeTag(newTag)) {
+      // Should never happen — `renumberJournal` rejects unsafe tags before
+      // emitting a rename — but we re-check here in case `applyRenames`
+      // is invoked with externally-supplied input.
+      throw new Error(
+        `Refusing to apply unsafe rename: ${JSON.stringify(oldTag)} → ${JSON.stringify(newTag)}.`,
+      );
+    }
+
     const oldSql = join(absDrizzleDir, `${oldTag}.sql`);
     const newSql = join(absDrizzleDir, `${newTag}.sql`);
 
     if (!existsSync(oldSql)) {
       if (existsSync(newSql)) {
-        // Already renamed — idempotent.
+        // Already in the desired state — count separately so callers can
+        // report "renamed N, already-renamed M" honestly. Crucial during
+        // hook re-runs and idempotent CLI invocations.
         skipped.push(`${oldTag}.sql (already renamed to ${newTag}.sql)`);
-        renamed++;
+        alreadyRenamed++;
       } else {
         // File isn't in the worktree yet (e.g., mid-rebase the .sql will
         // arrive when git applies the commit's tree). Defer this rename
@@ -363,7 +407,7 @@ export function applyRenames(renames, drizzleDir, repoRoot) {
     }
   }
 
-  return { renamed, skipped, deferred };
+  return { renamed, alreadyRenamed, skipped, deferred };
 }
 
 /**
@@ -438,7 +482,19 @@ export function runMergeDriver(pathBase, pathOurs, pathTheirs, workingPath, cwd 
 
   // The .sql files we need to rename live in the directory containing the
   // conflicted journal's parent (e.g. apps/wiki-server/drizzle/meta/
-  // _journal.json → apps/wiki-server/drizzle/).
+  // _journal.json → apps/wiki-server/drizzle/). Validate the working path
+  // ends with `meta/_journal.json` before deriving — git invokes us with
+  // the path from `.gitattributes`, but a misconfigured attribute could
+  // route an unrelated file here, and `dirname(dirname(…))` would then
+  // produce a wrong (or even outside-the-repo) directory.
+  if (!/(?:^|\/)meta\/_journal\.json$/.test(workingPath)) {
+    return {
+      exitCode: 1,
+      message:
+        `drizzle-journal-merge: refusing to operate on unexpected path ${JSON.stringify(workingPath)} — ` +
+        `expected something ending in 'meta/_journal.json'. Check your .gitattributes configuration.`,
+    };
+  }
   const drizzleDir = dirname(dirname(workingPath));
 
   let deferredRenames = [];
@@ -457,15 +513,39 @@ export function runMergeDriver(pathBase, pathOurs, pathTheirs, workingPath, cwd 
 
   // Persist any renames we couldn't apply now (because git's index lock is
   // held and/or the source .sql file isn't in the worktree yet) so the
-  // post-rewrite / post-merge hook can finish them once the rebase /merge
+  // post-rewrite / post-merge hook can finish them once the rebase / merge
   // completes.
+  //
+  // A multi-commit rebase invokes the merge driver once per conflicting
+  // commit. Each invocation may need to defer renames, so we MERGE with any
+  // existing marker rather than overwriting — otherwise renames from
+  // earlier commits in the rebase chain are lost. Renames are deduped by
+  // `oldTag` (later occurrences win, since the merge driver only writes a
+  // rename when the source still has the old prefix).
   if (deferredRenames.length > 0) {
     try {
       const pendingPath = join(repoRoot, '.git', 'MIGRATION_RENAMES_PENDING');
+      let existingRenames = [];
+      if (existsSync(pendingPath)) {
+        try {
+          const prior = JSON.parse(readFileSync(pendingPath, 'utf-8'));
+          if (Array.isArray(prior?.renames)) existingRenames = prior.renames;
+        } catch {
+          // Corrupt prior marker — overwrite with our renames; better than
+          // failing the merge.
+        }
+      }
+      const merged = new Map();
+      for (const r of existingRenames) {
+        if (r && typeof r.oldTag === 'string' && typeof r.newTag === 'string') {
+          merged.set(r.oldTag, r);
+        }
+      }
+      for (const r of deferredRenames) merged.set(r.oldTag, r);
       const payload = {
         version: 1,
         drizzleDir, // path relative to repo root
-        renames: deferredRenames,
+        renames: [...merged.values()],
       };
       writeFileSync(pendingPath, JSON.stringify(payload, null, 2));
     } catch (err) {

--- a/crux/vitest.config.ts
+++ b/crux/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       'system-cards/**/*.test.ts',
       'frameworks/**/*.test.ts',
       'scripts/**/*.test.ts',
+      'git/**/*.test.ts',
     ],
     exclude: [],
     root: __dirname,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "setup": "bash scripts/setup.sh",
     "setup:quick": "bash scripts/setup.sh --quick",
     "setup:check": "bash scripts/setup.sh --check",
-    "prepare": "git config core.hooksPath .githooks || true"
+    "prepare": "git config core.hooksPath .githooks || true; git config merge.drizzle-journal.driver 'node crux/git/drizzle-journal-merge.mjs %O %A %B %P' || true"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -230,6 +230,21 @@ for hook in pre-push post-merge; do
   fi
 done
 
+# Register the drizzle-journal merge driver — auto-resolves _journal.json
+# conflicts on rebase (QUA-988). The driver is set per-clone via local git
+# config because git refuses to honor `.gitattributes` merge drivers without
+# an opt-in (security: a malicious .gitattributes could otherwise execute
+# arbitrary code on `git pull`). Re-running setup keeps it in sync if the
+# script path or invocation changes.
+DRIVER_CMD='node crux/git/drizzle-journal-merge.mjs %O %A %B %P'
+CURRENT_DRIVER=$(git config --get merge.drizzle-journal.driver 2>/dev/null || echo "")
+if [ "$CURRENT_DRIVER" = "$DRIVER_CMD" ]; then
+  ok "drizzle-journal merge driver registered"
+else
+  git config merge.drizzle-journal.driver "$DRIVER_CMD"
+  ok "drizzle-journal merge driver registered"
+fi
+
 # --- Step 5: Check environment variables ---
 
 step "Checking environment variables"


### PR DESCRIPTION
## Summary

Adds a custom git merge driver that auto-resolves the canonical `_journal.json` conflict (two PRs both grab `idx=N`) and the supporting `pnpm crux migrations renumber` fallback. The conflict was the #3 hottest file in the last 7 days and recurs roughly weekly — every occurrence currently costs an LLM round-trip or hand-resolution.

## How it works

- **Pure ESM merge driver** at `crux/git/drizzle-journal-merge.mjs` (no `tsx` dep — runs on a fresh clone). Computes the union of base + ours + theirs entries; for any duplicate idx or duplicate tag prefix, renumbers the loser (earlier `when` wins) to a fresh idx above the current max. Historical entries pass through unchanged so we don't churn already-applied production migrations. Tags are validated against `^\d+_[A-Za-z0-9_]+$` before any rename to defeat path traversal via attacker-controlled journal content.
- **Wired up via `.gitattributes` + per-clone git config** registered by `scripts/setup.sh` and the `prepare` npm script. Per-clone opt-in is required because git won't honor merge drivers from `.gitattributes` alone (security: a malicious `.gitattributes` could otherwise execute arbitrary code on `git pull`). Until a user runs `pnpm install` on this branch, the driver is inactive and behavior is unchanged.
- **Deferred `.sql` renames**: at merge driver time the rebase commit's `.sql` file isn't yet in the worktree, and git holds the index lock. The driver writes a marker at `.git/MIGRATION_RENAMES_PENDING`; the new `post-rewrite` and updated `post-merge` hooks apply the renames once the lock is released and amend HEAD. **Multi-commit rebases**: the marker accumulates renames across invocations (read-merge-write) so renames from earlier commits in the chain aren't lost.
- **Fallback**: `pnpm crux migrations renumber [--dry-run]` for the case where the merge driver couldn't run (manual edits, legacy state). No-op on a canonical journal.

## Acceptance criteria (from QUA-988)

- [x] Two branches both adding migration `0221_*.sql` rebased onto each other resolve `_journal.json` automatically — verified by `/tmp/qua988-rebase-test.sh` (exits 0, files renamed, journal valid, single commit).
- [x] Patrol's automated rebase no longer falls through to Claude on this conflict shape (the driver handles it deterministically).
- [x] New tests: 21 unit + e2e tests covering the canonical conflict, three-way collisions, when-collisions, idx gaps, malformed input, deferred-rename markers, multi-commit accumulation, path-traversal rejection, and serialization format.

## Files

- `crux/git/drizzle-journal-merge.mjs` — merge driver
- `crux/git/__tests__/drizzle-journal-merge.test.ts` — 21 tests
- `crux/commands/migrations.ts` — `crux migrations renumber` command
- `.githooks/apply-migration-renames.sh` — shared rename-applier
- `.githooks/post-rewrite` — fires after `git rebase`
- `.githooks/post-merge` — also fires after `git pull`/`git merge`
- `.gitattributes` — maps `_journal.json` to `merge=drizzle-journal`
- `scripts/setup.sh` — registers driver via local `git config`
- `package.json` `prepare` — same registration on every `pnpm install`
- `crux/crux.mjs` + `crux/vitest.config.ts` — register command + test path

## Limitations

- For multi-commit branches where the migration is in an earlier commit (not the typical agent flow), the post-rewrite hook amends HEAD, so the rename ends up in the last commit instead of the migration commit. The final state is correct (file renamed, journal valid) but the history is slightly off. Users who care can run `git rebase -i` to move the rename or run `pnpm crux migrations renumber` from a clean state.
- `git merge` (vs rebase) flow: git considers itself "still in the middle of a merge" during the post-merge hook on some git versions, so the amend is skipped and the rename stays staged. The user commits it manually or it goes into their next commit.

## Security

- Tags from journal content are untrusted (the driver runs against arbitrary remote branches). Path-traversal in tags is blocked at three layers: `renumberJournal` rejects unsafe tags before emitting renames; `applyRenames` re-checks defensively; the bash hook filters tags through the same regex when parsing the marker file. Verified by manual red-team: malicious tag as winner stays in journal but emits no rename; malicious tag as loser exits 1 with fallback message; malicious bash marker with out-of-tree paths gets filtered before any `mv` runs.
- Driver registration is per-clone via `git config`. A malicious `.gitattributes` alone cannot activate the driver — git refuses to honor merge drivers it doesn't recognize, falling back to the standard 3-way merge.

## Test plan

- [x] `pnpm test:crux` — 9501 tests pass
- [x] `pnpm crux w validate gate` — all checks green
- [x] `npx tsx crux/validate/validate-drizzle-journal.ts` on canonical journal — passes
- [x] `pnpm crux migrations renumber --dry-run` on canonical journal — no-op
- [x] `/tmp/qua988-rebase-test.sh` — full e2e: branch with idx=221, rebase onto main with conflicting idx=221, verify clean resolution
- [x] Manual red-team: malformed JSON, path-traversal tags as winner/loser, invalid working path, malicious bash marker — all handled safely
- [ ] CI green

Closes QUA-988
