### PR TITLE
review: simplify metadata builder on races page

### DIFF
--- a/apps/web/src/app/races/[id]/page.tsx
+++ b/apps/web/src/app/races/[id]/page.tsx
@@ -155,16 +155,13 @@ export default async function RaceDetailPage({
     </span>
   );
 
-  const metadataParts: React.ReactNode[] = [];
-  metadataParts.push(<span key="level">{RACE_LEVEL_LABELS[race.level] ?? race.level}</span>);
-  if (race.district) metadataParts.push(<span key="district">{race.district}</span>);
-  if (race.state) metadataParts.push(<span key="state">{race.state}</span>);
-  if (race.electionDate) metadataParts.push(<span key="election">Election: {race.electionDate}</span>);
-  if (race.party) metadataParts.push(<span key="party" className="capitalize">{race.party}</span>);
-
   const metadata = (
     <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
-      {metadataParts}
+      <span>{RACE_LEVEL_LABELS[race.level] ?? race.level}</span>
+      {race.district && <span>{race.district}</span>}
+      {race.state && <span>{race.state}</span>}
+      {race.electionDate && <span>Election: {race.electionDate}</span>}
+      {race.party && <span className="capitalize">{race.party}</span>}
     </span>
   );
 


### PR DESCRIPTION
## Summary

Tiny follow-up to QUA-488 / PR #4782. The `/agent-review-pr` second pass (run after #4782 merged) flagged the imperative `metadataParts.push(...)` builder as more verbose than direct conditional JSX. Inlining drops the array allocation and the explicit React keys (only needed for array children, not direct JSX siblings). Behavior unchanged.

```tsx
// before
const metadataParts: React.ReactNode[] = [];
metadataParts.push(<span key="level">{...}</span>);
if (race.district) metadataParts.push(<span key="district">{race.district}</span>);
// ...
const metadata = <span ...>{metadataParts}</span>;

// after
const metadata = (
  <span ...>
    <span>{...}</span>
    {race.district && <span>{race.district}</span>}
    // ...
  </span>
);
```

## Test plan

- [x] `pnpm test` — 1912 tests pass
- [x] `pnpm crux w validate gate --fix` — 71 checks pass
- [x] Smoke-tested `/races/LDge8ou24V` against prod data via local dev server (verified by render-audit pattern in #4782)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-488
