### PR TITLE
add launchd LaunchAgent for pr-patrol uptime — QUA-987

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -14,6 +14,7 @@
 - **Regex backtracking**: `[\w\s]{2,30}` combined with `\s+` causes catastrophic backtracking. Use `\w+(?:\s+\w+){0,5}` instead.
 - **Array spread overflow**: `array.push(...largeArray)` causes "Maximum call stack size exceeded" when `largeArray` has >65k elements. Use a for-of loop instead.
 - **Vercel ignoreCommand exit codes are counterintuitive**: Exit 0 = **skip** build, exit 1 = **proceed** with build. The command answers "should I ignore?", so 0 (success/yes) means skip. This has been incorrectly inverted multiple times. See `apps/web/vercel.json`.
+- **launchd + ~/Documents needs Full Disk Access** (this user's machine, Sequoia): launchd-spawned processes can't read `~/Documents/GitHub.nosync/lw/` until `/bin/bash` (or the specific script binary) is added to System Settings → Privacy & Security → Full Disk Access. Symptom: `last_exit=126` "Operation not permitted" in `launchctl print gui/501/<label>` and silent failure of the agent. Affects `com.qu.lw-fix-tabs.plist` and the QUA-987 `com.qu.pr-patrol.plist`. See `lw/.claude/commands/setup-slot-orchestration.md` § "One-time macOS Full Disk Access grant".
 
 ## Feedback
 - [PG-primary for new features](feedback_pg_primary_for_new_features.md) — strongly prefer PG tables over YAML for new features with dedicated UI/directory pages

--- a/scripts/inject-patrol-status.sh
+++ b/scripts/inject-patrol-status.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# UserPromptSubmit hook — surfaces abandoned PRs and dead patrol process to
+# the coordinator (Opus) on every turn. Silent no-op when patrol is alive
+# and no PRs are abandoned.
+#
+# Patrol abandons a PR after 2 consecutive max-turns or error fixes; it then
+# posts "Escalating to coordinator (Opus)" on the PR and skips it on future
+# cycles. Without this hook, the coord session has to remember to check the
+# patrol log — easy to miss across turn boundaries.
+#
+
+set -uo pipefail
+
+STATE_DIR="$HOME/.cache/pr-patrol/state"
+CACHE_FILE="/tmp/.patrol-status-open-prs"
+CACHE_TTL=300  # 5 min — open-PR list rarely changes faster
+
+# ─── Patrol liveness ──────────────────────────────────────────────────────────
+# Match either:
+#   - the patrol process itself (`node ... gh pr-patrol run` / `pnpm crux ...`)
+#   - the launchd supervisor in its 30s sleep window between patrol invocations
+# Without the supervisor case we'd flap into "patrol dead" reminders every 30s
+# whenever launchd-managed patrol is between cycles. See QUA-987.
+patrol_pid=$(pgrep -f "pnpm crux gh pr-patrol run" 2>/dev/null | head -1)
+if [ -z "$patrol_pid" ]; then
+  patrol_pid=$(pgrep -f "pr-patrol-supervisor.sh" 2>/dev/null | head -1)
+fi
+
+# ─── Abandoned PR collection ──────────────────────────────────────────────────
+abandoned=""
+if [ -d "$STATE_DIR" ]; then
+  abandoned=$(ls "$STATE_DIR" 2>/dev/null | grep -E '^abandoned-[0-9]+$' | sed 's/^abandoned-//' | tr '\n' ' ')
+fi
+
+# Fast exit: nothing to report
+if [ -z "$abandoned" ] && [ -n "$patrol_pid" ]; then
+  exit 0
+fi
+
+# ─── Cross-reference abandoned with currently-open PRs ────────────────────────
+open_prs=""
+if [ -n "$abandoned" ]; then
+  if [ -f "$CACHE_FILE" ]; then
+    cache_mtime=$(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0)
+    if [ $(($(date +%s) - cache_mtime)) -lt $CACHE_TTL ]; then
+      open_prs=$(cat "$CACHE_FILE")
+    fi
+  fi
+  if [ -z "$open_prs" ]; then
+    open_prs=$(gh pr list -R quantified-uncertainty/longterm-wiki --state open --json number --jq '.[].number' 2>/dev/null | tr '\n' ' ')
+    [ -n "$open_prs" ] && echo "$open_prs" > "$CACHE_FILE"
+  fi
+fi
+
+still_open_abandoned=""
+for pr in $abandoned; do
+  if [ -z "$open_prs" ] || echo " $open_prs " | grep -q " $pr "; then
+    still_open_abandoned="$still_open_abandoned $pr"
+  fi
+done
+still_open_abandoned=$(echo "$still_open_abandoned" | xargs)
+
+# ─── Emit reminder if anything to report ──────────────────────────────────────
+if [ -z "$still_open_abandoned" ] && [ -n "$patrol_pid" ]; then
+  exit 0
+fi
+
+echo "<system-reminder>"
+if [ -z "$patrol_pid" ]; then
+  echo "⚠ PR patrol is NOT running."
+  if launchctl list 2>/dev/null | grep -q com.qu.pr-patrol; then
+    echo "  launchd lists com.qu.pr-patrol but no patrol/supervisor process found —"
+    echo "  check ~/.cache/pr-patrol/launchd.err and ~/.cache/pr-patrol/run.log."
+    echo "  Status: /Users/ozziegooen/Documents/GitHub.nosync/lw/scripts/launchd/pr-patrol.sh status"
+  else
+    echo "  No launchd agent installed. Either install it (preferred):"
+    echo "    /Users/ozziegooen/Documents/GitHub.nosync/lw/scripts/launchd/pr-patrol.sh install"
+    echo "  …or fall back to a tmux window:"
+    echo '    tmux new-window -t 0: -n PATROL -d "while true; do pnpm crux gh pr-patrol run; sleep 30; done 2>&1 | tee -a ~/.cache/pr-patrol/run.log"'
+  fi
+  echo ""
+fi
+if [ -n "$still_open_abandoned" ]; then
+  n=$(echo "$still_open_abandoned" | wc -w | tr -d ' ')
+  formatted=$(echo "$still_open_abandoned" | sed 's/ /, #/g; s/^/#/')
+  echo "⚠ $n open PR(s) abandoned by patrol — needs Opus pickup: $formatted"
+  echo ""
+  echo "Each has a '🤖 PR Patrol — Escalating to coordinator (Opus)' comment. Pick up via worktree + dispatched agent, or close as not-pursuable."
+  echo "To clear an abandoned state without acting (e.g. PR is irrelevant): rm $STATE_DIR/abandoned-<PR#>"
+fi
+echo "</system-reminder>"

--- a/scripts/inject-patrol-status.sh
+++ b/scripts/inject-patrol-status.sh
@@ -17,12 +17,15 @@ CACHE_FILE="/tmp/.patrol-status-open-prs"
 CACHE_TTL=300  # 5 min — open-PR list rarely changes faster
 
 # ─── Patrol liveness ──────────────────────────────────────────────────────────
-# Match either:
-#   - the patrol process itself (`node ... gh pr-patrol run` / `pnpm crux ...`)
+# Match any of:
+#   - the patrol process itself (`node ... gh pr-patrol run` or the pnpm parent)
 #   - the launchd supervisor in its 30s sleep window between patrol invocations
 # Without the supervisor case we'd flap into "patrol dead" reminders every 30s
-# whenever launchd-managed patrol is between cycles. See QUA-987.
-patrol_pid=$(pgrep -f "pnpm crux gh pr-patrol run" 2>/dev/null | head -1)
+# whenever launchd-managed patrol is between cycles. The pattern is loose
+# (`pr-patrol run`) on purpose — it matches whether the launcher is `pnpm crux`,
+# direct `node`, or a future replacement, and `status` in pr-patrol.sh uses
+# the same loose pattern for consistency. See QUA-987.
+patrol_pid=$(pgrep -f "pr-patrol run" 2>/dev/null | head -1)
 if [ -z "$patrol_pid" ]; then
   patrol_pid=$(pgrep -f "pr-patrol-supervisor.sh" 2>/dev/null | head -1)
 fi
@@ -66,16 +69,25 @@ if [ -z "$still_open_abandoned" ] && [ -n "$patrol_pid" ]; then
   exit 0
 fi
 
+# Derive the installer path from this script's own location. When deployed
+# from a wiki clone, this script lives at <wiki>/scripts/inject-patrol-status.sh
+# and the installer lives at <wiki>/scripts/launchd/pr-patrol.sh — siblings
+# under scripts/. Hardcoding the user's machine path was wrong both because
+# the path included the user's home dir AND because it pointed at the
+# now-defunct lw/scripts/launchd/ location instead of lw/main/scripts/launchd/.
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="$HOOK_DIR/launchd/pr-patrol.sh"
+
 echo "<system-reminder>"
 if [ -z "$patrol_pid" ]; then
   echo "⚠ PR patrol is NOT running."
   if launchctl list 2>/dev/null | grep -q com.qu.pr-patrol; then
     echo "  launchd lists com.qu.pr-patrol but no patrol/supervisor process found —"
     echo "  check ~/.cache/pr-patrol/launchd.err and ~/.cache/pr-patrol/run.log."
-    echo "  Status: /Users/ozziegooen/Documents/GitHub.nosync/lw/scripts/launchd/pr-patrol.sh status"
+    echo "  Status: $INSTALLER status"
   else
     echo "  No launchd agent installed. Either install it (preferred):"
-    echo "    /Users/ozziegooen/Documents/GitHub.nosync/lw/scripts/launchd/pr-patrol.sh install"
+    echo "    $INSTALLER install"
     echo "  …or fall back to a tmux window:"
     echo '    tmux new-window -t 0: -n PATROL -d "while true; do pnpm crux gh pr-patrol run; sleep 30; done 2>&1 | tee -a ~/.cache/pr-patrol/run.log"'
   fi

--- a/scripts/launchd/README.md
+++ b/scripts/launchd/README.md
@@ -1,0 +1,91 @@
+# launchd LaunchAgents (macOS)
+
+Background daemons for the longterm-wiki coordinator workflow, packaged as
+[launchd LaunchAgents](https://www.launchd.info/) so they survive logout,
+reboot, and process crashes — replacing the older "remember to start a tmux
+window after login" pattern.
+
+## Agents
+
+| Label | Plist | Purpose | Linear |
+|---|---|---|---|
+| `com.qu.pr-patrol` | `com.qu.pr-patrol.plist` | Keeps `crux gh pr-patrol run` alive — auto-restarts on crash, on logout/login cycle, and after reboot | QUA-987 |
+
+The supervisor scripts the agents launch are siblings of this directory:
+
+- `../pr-patrol-supervisor.sh` — runs `pnpm crux gh pr-patrol run` in a 30-second restart loop, with shutdown on `SIGTERM`/`SIGINT` so `launchctl unload` is a graceful stop.
+
+## Install / status / uninstall
+
+```bash
+# From a wiki clone (e.g. lw/main/):
+./scripts/launchd/pr-patrol.sh install     # render plist, copy to ~/Library/LaunchAgents/, load
+./scripts/launchd/pr-patrol.sh status      # launchctl state + actual patrol process + run.log freshness
+./scripts/launchd/pr-patrol.sh tail        # tail the run log
+./scripts/launchd/pr-patrol.sh tcc-check   # probe macOS Full Disk Access (see below)
+./scripts/launchd/pr-patrol.sh uninstall   # unload + remove
+```
+
+The install script is **idempotent** — re-running is safe. It also reports if
+an existing tmux-based patrol is currently holding `~/.cache/pr-patrol/daemon.pid`
+(patrol's built-in singleton), in which case the launchd supervisor will retry
+every 30s until the existing patrol exits.
+
+**Where things land:**
+
+```
+~/Library/LaunchAgents/com.qu.pr-patrol.plist          # rendered with absolute paths
+~/.cache/pr-patrol/run.log                             # supervisor's log (tail this)
+~/.cache/pr-patrol/launchd.{out,err}                   # launchd's own captured output
+~/.cache/pr-patrol/daemon.pid                          # patrol's singleton lock
+```
+
+## One-time macOS Full Disk Access grant
+
+**Required if the wiki clone lives under `~/Documents/`** (the default Apple
+location for a checkout). Modern macOS blocks launchd-spawned processes from
+reading anything under `~/Documents/` unless the user explicitly grants Full
+Disk Access in System Settings — agents loaded into launchd's Aqua context do
+not inherit the TCC profile of Terminal/iTerm.
+
+**Symptom without FDA:** `launchctl list com.qu.pr-patrol` shows
+`last_exit=126` ("Operation not permitted") and patrol never runs. The install
+script's TCC self-test catches this and prints clear next steps.
+
+**To grant:**
+
+1. **System Settings → Privacy & Security → Full Disk Access**
+2. Click **＋** and add either:
+   - `/bin/bash` (broadest — affects any launchd-spawned bash script)
+   - The supervisor script directly (more narrow): `<wiki-clone>/scripts/pr-patrol-supervisor.sh`
+3. Toggle the new entry **ON**.
+4. Re-run `./pr-patrol.sh install` (or `./pr-patrol.sh tcc-check` to verify).
+
+The same grant retroactively fixes any other `~/Library/LaunchAgents/com.qu.*.plist`
+that touches `~/Documents/` (e.g., `com.qu.lw-fix-tabs.plist`).
+
+## Why launchd instead of cron / tmux
+
+| Mechanism | Survives logout? | Survives reboot? | Survives crash? | Live log? |
+|---|---|---|---|---|
+| Manual `tmux new-window …` | ✓ (tmux server) | ✗ (manual restart) | ✗ (no auto-restart) | ✓ |
+| `cron` / `launchd StartInterval` | ✓ | ✓ | ✓ (next tick) | partial |
+| **launchd `KeepAlive=true`** | ✓ | ✓ | ✓ (immediate via throttle) | via `tail -f run.log` |
+
+`KeepAlive=true` plus the supervisor's inner `while true; do … sleep 30; done`
+gives two layers of recovery: the inner loop handles clean exits without
+churning launchd, and `KeepAlive` handles unexpected supervisor death.
+
+## Coexistence with the legacy tmux pattern
+
+Patrol's built-in `daemon.pid` singleton (see
+`crux/pr-patrol/index.ts::acquirePidFile`) ensures only one patrol process
+runs at a time. If both the launchd supervisor and a stray
+`tmux new-window … pr-patrol run` are active, only the first to acquire
+`daemon.pid` does the work; the other exits with code 1 and retries 30s later.
+This makes the migration safe — the launchd agent can be installed before
+shutting down an existing tmux patrol.
+
+The supervisor also pre-checks `daemon.pid` before invoking patrol, so the
+"another daemon is running" diagnostic doesn't spam `run.log` during the
+transition window.

--- a/scripts/launchd/com.qu.pr-patrol.plist
+++ b/scripts/launchd/com.qu.pr-patrol.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Template for ~/Library/LaunchAgents/com.qu.pr-patrol.plist.
+
+  Install via scripts/launchd/pr-patrol.sh — the install script fills in
+  the absolute supervisor and home-dir paths before copying.
+
+  Why these keys:
+    KeepAlive       respawn the supervisor if it crashes (network OOM, kill -9,
+                    panic-quit on missing PATH, etc.). Combined with the inner
+                    while-loop in pr-patrol-supervisor.sh, this gives two layers
+                    of recovery.
+    RunAtLoad       start at login + on launchctl load, no manual nudge.
+    ThrottleInterval=30  prevent tight crash loops if something is fundamentally
+                    broken (wiki clone missing, pnpm uninstalled, etc.). Matches
+                    the inner sleep so the user-visible cadence is consistent.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.qu.pr-patrol</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__SUPERVISOR__</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/.cache/pr-patrol/launchd.out</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.cache/pr-patrol/launchd.err</string>
+</dict>
+</plist>

--- a/scripts/launchd/pr-patrol.sh
+++ b/scripts/launchd/pr-patrol.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+#
+# pr-patrol.sh — install / uninstall / status for the pr-patrol launchd agent.
+#
+# Usage:
+#   ./pr-patrol.sh            # install (idempotent — re-running is safe)
+#   ./pr-patrol.sh install    # same as no-arg
+#   ./pr-patrol.sh uninstall  # unload + remove from ~/Library/LaunchAgents
+#   ./pr-patrol.sh status     # show launchd state + actual patrol process
+#   ./pr-patrol.sh tail       # tail the run log (Ctrl-C to exit)
+#
+# This wraps the patrol daemon with a launchd LaunchAgent so it survives
+# logout, reboot, and process crashes — the previous tmux-window pattern only
+# survives if the user happens to be at their machine when it dies.
+#
+# See QUA-987.
+
+set -euo pipefail
+
+# This script lives at <wiki-clone>/scripts/launchd/pr-patrol.sh, so the wiki
+# clone is two directories up.
+WIKI_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST_SRC="$WIKI_ROOT/scripts/launchd/com.qu.pr-patrol.plist"
+PLIST_DST="$HOME/Library/LaunchAgents/com.qu.pr-patrol.plist"
+LABEL="com.qu.pr-patrol"
+SUPERVISOR="$WIKI_ROOT/scripts/pr-patrol-supervisor.sh"
+LOG="$HOME/.cache/pr-patrol/run.log"
+
+cmd="${1:-install}"
+
+# ── TCC self-test ─────────────────────────────────────────────────────────────
+# Modern macOS (Sequoia, Sonoma, Ventura) blocks launchd-spawned processes from
+# reading anything under ~/Documents/ unless the user grants Full Disk Access
+# (or Files & Folders → Documents) in System Settings. Without it, launchd
+# loads our agent but the supervisor exits 126 ("Operation not permitted")
+# every cycle, and patrol never runs. Probe via a one-shot test plist, parse
+# the result, return 0 if Documents is reachable from launchd, 1 if blocked.
+tcc_self_test() {
+  local probe_label="com.qu.pr-patrol-tccprobe"
+  local probe_plist="$HOME/Library/LaunchAgents/$probe_label.plist"
+  local probe_out="/tmp/$probe_label.out"
+  local probe_err="/tmp/$probe_label.err"
+  local probe_target="$WIKI_ROOT/.git/HEAD"
+
+  /bin/rm -f "$probe_out" "$probe_err"
+  cat > "$probe_plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$probe_label</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>cat "$probe_target" > "$probe_out" 2> "$probe_err"</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+  launchctl unload "$probe_plist" 2>/dev/null || true
+  launchctl load "$probe_plist"
+  # Plist is one-shot — wait briefly for it to run.
+  for _ in 1 2 3 4 5 6; do
+    [ -s "$probe_out" ] && break
+    [ -s "$probe_err" ] && break
+    sleep 0.5
+  done
+  launchctl unload "$probe_plist" 2>/dev/null || true
+  /bin/rm -f "$probe_plist"
+
+  local result=1
+  if [ -s "$probe_out" ]; then
+    result=0
+  fi
+  /bin/rm -f "$probe_out" "$probe_err"
+  return $result
+}
+
+print_tcc_help() {
+  cat <<EOM
+
+⚠ launchd cannot read files under ~/Documents/ — Full Disk Access is required.
+
+  This is a macOS TCC restriction: agents loaded into launchd's Aqua context
+  do not inherit the TCC profile of Terminal/iTerm, so they cannot reach the
+  wiki clone if it lives anywhere under ~/Documents/.
+
+  To grant access (one-time per machine):
+    1. Open  System Settings → Privacy & Security → Full Disk Access
+    2. Click  ＋  and add  /bin/bash  (Cmd-Shift-G to type the path)
+       — or, more narrowly, add the supervisor script:
+       $SUPERVISOR
+    3. Toggle the new entry ON.
+    4. Re-run:  ./pr-patrol.sh install
+
+  The same grant fixes ~/Library/LaunchAgents/com.qu.lw-fix-tabs.plist if you
+  also rely on it for tmux-window renaming.
+
+  Until FDA is granted, fall back to the legacy tmux loop:
+    tmux new-window -t 0: -n PATROL -d 'while true; do pnpm crux gh pr-patrol run; sleep 30; done 2>&1 | tee -a ~/.cache/pr-patrol/run.log'
+EOM
+}
+
+case "$cmd" in
+  install)
+    [ -f "$PLIST_SRC" ] || { echo "✗ Missing template: $PLIST_SRC" >&2; exit 1; }
+    [ -f "$SUPERVISOR" ] || { echo "✗ Missing supervisor: $SUPERVISOR" >&2; exit 1; }
+
+    chmod +x "$SUPERVISOR"
+    mkdir -p "$HOME/Library/LaunchAgents" "$HOME/.cache/pr-patrol"
+
+    # Render the plist with absolute paths resolved.
+    # sed delimiter is | so that paths containing / are safe.
+    sed \
+      -e "s|__SUPERVISOR__|$SUPERVISOR|g" \
+      -e "s|__HOME__|$HOME|g" \
+      "$PLIST_SRC" > "$PLIST_DST"
+
+    # Reload — works whether or not previously loaded. `launchctl load` is the
+    # legacy form; it still works for ~/Library/LaunchAgents on Sequoia and
+    # matches the existing com.qu.lw-fix-tabs.plist pattern.
+    launchctl unload "$PLIST_DST" 2>/dev/null || true
+    launchctl load "$PLIST_DST"
+
+    echo "✓ Installed $PLIST_DST"
+    echo "  Supervisor: $SUPERVISOR"
+    echo "  Watch:      tail -f $LOG"
+    echo "  Status:     $0 status"
+
+    # TCC probe — agent is loaded but won't actually run if Documents is blocked.
+    echo ""
+    echo "Checking macOS Full Disk Access for launchd…"
+    if tcc_self_test; then
+      echo "✓ launchd can reach ~/Documents — agent should be running."
+    else
+      echo "✗ launchd is blocked from reading ~/Documents."
+      print_tcc_help
+    fi
+
+    if pgrep -fl "node.*pr-patrol run" >/dev/null 2>&1; then
+      echo ""
+      echo "ℹ Existing patrol process detected — it owns daemon.pid until it exits."
+      echo "  The launchd supervisor will retry every 30s and take over once free."
+      echo "  To migrate immediately: \`pnpm crux gh pr-patrol stop\` (run from lw/main)."
+    fi
+    ;;
+
+  tcc-check)
+    echo "Probing launchd → ~/Documents access…"
+    if tcc_self_test; then
+      echo "✓ launchd can reach ~/Documents — Full Disk Access is granted."
+    else
+      echo "✗ launchd is blocked from reading ~/Documents."
+      print_tcc_help
+      exit 1
+    fi
+    ;;
+
+  uninstall)
+    if [ -f "$PLIST_DST" ]; then
+      launchctl unload "$PLIST_DST" 2>/dev/null || true
+      rm -f "$PLIST_DST"
+      echo "✓ Uninstalled $PLIST_DST"
+    else
+      echo "Already absent: $PLIST_DST"
+    fi
+    if launchctl list 2>/dev/null | grep -q "$LABEL"; then
+      echo "⚠ launchd still lists $LABEL — try \`launchctl remove $LABEL\` if it persists."
+    fi
+    ;;
+
+  status)
+    if launchctl list 2>/dev/null | awk -v L="$LABEL" '$3 == L { found=1 } END { exit !found }'; then
+      echo "✓ launchd: loaded"
+      launchctl list 2>/dev/null \
+        | awk -v L="$LABEL" '$3 == L { print "  pid=" $1 "  last_exit=" $2 "  label=" $3 }'
+    else
+      echo "✗ launchd: not loaded   (run: $0 install)"
+    fi
+    if pid=$(pgrep -fl "node.*pr-patrol run" 2>/dev/null | awk 'NR==1{print $1}'); then
+      [ -n "$pid" ] && echo "✓ patrol process: pid=$pid"
+    else
+      echo "✗ patrol process: not running"
+    fi
+    pidfile="$HOME/.cache/pr-patrol/daemon.pid"
+    if [ -f "$pidfile" ]; then
+      echo "  daemon.pid: $(cat "$pidfile") ($pidfile)"
+    fi
+    if [ -f "$LOG" ]; then
+      mtime=$(stat -f %Sm -t '%Y-%m-%d %H:%M:%S' "$LOG" 2>/dev/null || stat -c '%y' "$LOG" 2>/dev/null || echo unknown)
+      echo "  run.log:    last write $mtime"
+    fi
+    ;;
+
+  tail)
+    [ -f "$LOG" ] || { echo "Log not found: $LOG" >&2; exit 1; }
+    exec tail -F "$LOG"
+    ;;
+
+  *)
+    echo "Usage: $0 {install|uninstall|status|tail|tcc-check}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/launchd/pr-patrol.sh
+++ b/scripts/launchd/pr-patrol.sh
@@ -28,6 +28,31 @@ LOG="$HOME/.cache/pr-patrol/run.log"
 
 cmd="${1:-install}"
 
+# Escape sed replacement-string metachars (\, &, |) so paths with shell-special
+# characters survive substitution. macOS allows `&`, `'`, `(`, `)`, etc. in
+# usernames; HOME/SUPERVISOR could contain any of them. `|` is our chosen sed
+# delimiter and must be escaped in the replacement, not just the pattern.
+sed_replacement_escape() {
+  printf '%s\n' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+# Render the embedded XML template, substituting placeholders via sed (so the
+# heredoc terminator stays quoted and shell expansion can't sneak in).
+render_template() {
+  # Args: input_file output_file [placeholder=value]...
+  local input="$1" output="$2"
+  shift 2
+  local sed_args=()
+  local pair name val esc
+  for pair in "$@"; do
+    name="${pair%%=*}"
+    val="${pair#*=}"
+    esc=$(sed_replacement_escape "$val")
+    sed_args+=(-e "s|$name|$esc|g")
+  done
+  sed "${sed_args[@]}" "$input" > "$output"
+}
+
 # ── TCC self-test ─────────────────────────────────────────────────────────────
 # Modern macOS (Sequoia, Sonoma, Ventura) blocks launchd-spawned processes from
 # reading anything under ~/Documents/ unless the user grants Full Disk Access
@@ -41,29 +66,47 @@ tcc_self_test() {
   local probe_out="/tmp/$probe_label.out"
   local probe_err="/tmp/$probe_label.err"
   local probe_target="$WIKI_ROOT/.git/HEAD"
+  local probe_template="/tmp/$probe_label.template"
 
-  /bin/rm -f "$probe_out" "$probe_err"
-  cat > "$probe_plist" <<EOF
+  /bin/rm -f "$probe_out" "$probe_err" "$probe_template"
+
+  # Quoted heredoc — no shell expansion. Placeholders are filled in via sed
+  # below using the same escaping the install path uses for the main plist.
+  cat > "$probe_template" <<'PROBE_PLIST_TEMPLATE'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>$probe_label</string>
+    <string>__PROBE_LABEL__</string>
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
         <string>-c</string>
-        <string>cat "$probe_target" > "$probe_out" 2> "$probe_err"</string>
+        <string>cat "__PROBE_TARGET__" > "__PROBE_OUT__" 2> "__PROBE_ERR__"</string>
     </array>
     <key>RunAtLoad</key>
     <true/>
 </dict>
 </plist>
-EOF
+PROBE_PLIST_TEMPLATE
+
+  render_template "$probe_template" "$probe_plist" \
+    "__PROBE_LABEL__=$probe_label" \
+    "__PROBE_TARGET__=$probe_target" \
+    "__PROBE_OUT__=$probe_out" \
+    "__PROBE_ERR__=$probe_err"
+  /bin/rm -f "$probe_template"
 
   launchctl unload "$probe_plist" 2>/dev/null || true
-  launchctl load "$probe_plist"
+  # `set -e` is in effect; load failures here would abort install. Tolerate
+  # them — on failure we fall through and report TCC as blocked, which is
+  # the conservative default.
+  if ! launchctl load "$probe_plist" 2>/dev/null; then
+    /bin/rm -f "$probe_plist" "$probe_out" "$probe_err"
+    return 1
+  fi
+
   # Plist is one-shot — wait briefly for it to run.
   for _ in 1 2 3 4 5 6; do
     [ -s "$probe_out" ] && break
@@ -114,12 +157,12 @@ case "$cmd" in
     chmod +x "$SUPERVISOR"
     mkdir -p "$HOME/Library/LaunchAgents" "$HOME/.cache/pr-patrol"
 
-    # Render the plist with absolute paths resolved.
-    # sed delimiter is | so that paths containing / are safe.
-    sed \
-      -e "s|__SUPERVISOR__|$SUPERVISOR|g" \
-      -e "s|__HOME__|$HOME|g" \
-      "$PLIST_SRC" > "$PLIST_DST"
+    # Render the plist with absolute paths. render_template escapes sed
+    # replacement metachars (\, &, |) so paths with shell-special characters
+    # in the username or path segments don't break the substitution.
+    render_template "$PLIST_SRC" "$PLIST_DST" \
+      "__SUPERVISOR__=$SUPERVISOR" \
+      "__HOME__=$HOME"
 
     # Reload — works whether or not previously loaded. `launchctl load` is the
     # legacy form; it still works for ~/Library/LaunchAgents on Sequoia and
@@ -175,24 +218,43 @@ case "$cmd" in
     ;;
 
   status)
-    if launchctl list 2>/dev/null | awk -v L="$LABEL" '$3 == L { found=1 } END { exit !found }'; then
+    # Capture launchctl state once and reuse — single subprocess, single source.
+    launchd_row=$(launchctl list 2>/dev/null | awk -v L="$LABEL" '$3 == L { print; exit }' || true)
+    last_exit=""
+    if [ -n "$launchd_row" ]; then
       echo "✓ launchd: loaded"
-      launchctl list 2>/dev/null \
-        | awk -v L="$LABEL" '$3 == L { print "  pid=" $1 "  last_exit=" $2 "  label=" $3 }'
+      # Columns: pid  last_exit  label
+      lpid=$(awk '{print $1}' <<<"$launchd_row")
+      last_exit=$(awk '{print $2}' <<<"$launchd_row")
+      echo "  pid=$lpid  last_exit=$last_exit  label=$LABEL"
+      # Surface a non-zero last_exit prominently — without this, a launchd-broken
+      # state (e.g. last_exit=126 from TCC blocking) reads as healthy when paired
+      # with a tmux-managed patrol holding daemon.pid.
+      if [ "$last_exit" != "0" ] && [ "$last_exit" != "-" ] && [ -n "$last_exit" ]; then
+        echo "  ⚠ supervisor exited non-zero last cycle (code=$last_exit) — see ~/.cache/pr-patrol/launchd.err"
+        if [ "$last_exit" = "126" ]; then
+          echo "    code 126 = Operation not permitted; run \`$0 tcc-check\` to verify FDA."
+        fi
+      fi
     else
       echo "✗ launchd: not loaded   (run: $0 install)"
     fi
-    if pid=$(pgrep -fl "node.*pr-patrol run" 2>/dev/null | awk 'NR==1{print $1}'); then
-      [ -n "$pid" ] && echo "✓ patrol process: pid=$pid"
+    # `pgrep -f` returns non-zero on no match, so check the assignment value
+    # explicitly — don't rely on the pipeline's exit code (the prior version's
+    # `if pid=$(... | awk ...)` was always true because awk exits 0 on empty).
+    pid=$(pgrep -f "node.*pr-patrol run" 2>/dev/null | head -1)
+    if [ -n "$pid" ]; then
+      echo "✓ patrol process: pid=$pid"
     else
       echo "✗ patrol process: not running"
     fi
     pidfile="$HOME/.cache/pr-patrol/daemon.pid"
     if [ -f "$pidfile" ]; then
-      echo "  daemon.pid: $(cat "$pidfile") ($pidfile)"
+      pidcontents=$(cat "$pidfile" 2>/dev/null || echo "<unreadable>")
+      echo "  daemon.pid: $pidcontents ($pidfile)"
     fi
     if [ -f "$LOG" ]; then
-      mtime=$(stat -f %Sm -t '%Y-%m-%d %H:%M:%S' "$LOG" 2>/dev/null || stat -c '%y' "$LOG" 2>/dev/null || echo unknown)
+      mtime=$(stat -f %Sm -t '%Y-%m-%d %H:%M:%S' "$LOG" 2>/dev/null || echo unknown)
       echo "  run.log:    last write $mtime"
     fi
     ;;

--- a/scripts/pr-patrol-supervisor.sh
+++ b/scripts/pr-patrol-supervisor.sh
@@ -61,15 +61,23 @@ cd "$WIKI_ROOT" || {
 
 # ── Shutdown handling ─────────────────────────────────────────────────────────
 # When launchd sends SIGTERM (e.g. on `launchctl unload` or system shutdown),
-# kill the patrol child and exit cleanly. Without this, the SIGTERM is delivered
-# to bash but the patrol child keeps running until the OS kills it.
+# kill the patrol process group and exit cleanly. Without this, the SIGTERM is
+# delivered to bash but the patrol child (and its node grandchild via pnpm)
+# keep running until the OS escalates to SIGKILL.
+#
+# Job control (`set -m`) puts each `&`-spawned child in its own process group.
+# We then signal the whole group via `kill -- -PGID` so pnpm's node child gets
+# the signal too — pnpm's own signal forwarding is not guaranteed.
+set -m
 
 patrol_pid=""
 shutdown() {
   if [ -n "$patrol_pid" ] && kill -0 "$patrol_pid" 2>/dev/null; then
-    printf '%s ── supervisor received signal — terminating patrol pid=%d ──\n' \
+    printf '%s ── supervisor received signal — terminating patrol pgid=%d ──\n' \
       "$(date '+%Y-%m-%d %H:%M:%S')" "$patrol_pid" >> "$LOG"
-    kill -TERM "$patrol_pid" 2>/dev/null || true
+    # `-pid` = process group; thanks to `set -m` the spawned child is the
+    # group leader, so its PID equals the PGID.
+    kill -TERM -- "-$patrol_pid" 2>/dev/null || kill -TERM "$patrol_pid" 2>/dev/null || true
     wait "$patrol_pid" 2>/dev/null || true
   fi
   exit 0
@@ -82,6 +90,17 @@ printf '%s ── supervisor starting (pid=%d, wiki=%s) ──\n' \
 
 PIDFILE="$HOME/.cache/pr-patrol/daemon.pid"
 
+# Run sleep as a backgrounded child + wait. Plain `sleep N` is an external
+# command — bash defers signal handlers until it returns, so a 30s sleep
+# delays SIGTERM by up to 30s, easily exceeding launchd's default 20s
+# ExitTimeout. `wait` IS interruptible, so this lets the trap fire promptly.
+sleep_interruptible() {
+  sleep "$1" &
+  patrol_pid=$!
+  wait "$patrol_pid" 2>/dev/null || true
+  patrol_pid=""
+}
+
 while true; do
   # Pre-check: if another live patrol owns daemon.pid (e.g. a stray tmux-based
   # patrol from before the launchd migration), skip the launch and try again
@@ -93,7 +112,7 @@ while true; do
     if [ -n "$other" ] && [ "$other" != "$$" ] && kill -0 "$other" 2>/dev/null; then
       printf '%s ── another patrol pid=%s holds daemon.pid, sleeping 30s ──\n' \
         "$(date '+%Y-%m-%d %H:%M:%S')" "$other" >> "$LOG"
-      sleep 30
+      sleep_interruptible 30
       continue
     fi
   fi
@@ -106,5 +125,5 @@ while true; do
   patrol_pid=""
   printf '%s ── pr-patrol exited code=%d, sleeping 30s ──\n' \
     "$(date '+%Y-%m-%d %H:%M:%S')" "$ec" >> "$LOG"
-  sleep 30
+  sleep_interruptible 30
 done

--- a/scripts/pr-patrol-supervisor.sh
+++ b/scripts/pr-patrol-supervisor.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# pr-patrol-supervisor.sh
+#
+# Daemon loop launched by the com.qu.pr-patrol launchd agent.
+# Runs `pnpm crux gh pr-patrol run` continuously, restarting it 30s
+# after each exit so a crash, network blip, or `crux pr-patrol stop`
+# is followed by automatic recovery.
+#
+# Why an inner loop *and* launchd KeepAlive: launchd respawns the
+# supervisor itself if it crashes, but a clean exit of `pr-patrol run`
+# (e.g. EEXIST on daemon.pid because an old tmux-based patrol still
+# owns the lock) shouldn't cycle launchd — the inner sleep keeps
+# diagnostic output contiguous in run.log instead of fragmenting it
+# into launchd.err.
+#
+# Watch the live log:
+#   tail -f ~/.cache/pr-patrol/run.log
+#
+# Install/uninstall: ./launchd/pr-patrol.sh {install|uninstall|status}
+
+set -uo pipefail
+
+# ── PATH setup ────────────────────────────────────────────────────────────────
+# launchd starts agents with a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin).
+# Source nvm so `pnpm`, `node`, and `tsx` resolve, then prepend the standard
+# homebrew + system paths so `gh`, `git`, `tmux`, etc. are findable too.
+
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck disable=SC1091
+  . "$NVM_DIR/nvm.sh" --no-use 2>/dev/null || true
+  nvm use --silent default >/dev/null 2>&1 || true
+fi
+
+# Fallback: if nvm.sh didn't add a node bindir to PATH, pick the highest
+# installed version directly. Keeps the supervisor working even if the user
+# nukes nvm.sh but leaves the version dirs.
+if ! command -v pnpm >/dev/null 2>&1 && [ -d "$NVM_DIR/versions/node" ]; then
+  fallback_bin=$(/bin/ls -d "$NVM_DIR/versions/node/"v*/bin 2>/dev/null | sort -V | tail -1)
+  [ -n "$fallback_bin" ] && export PATH="$fallback_bin:${PATH:-}"
+fi
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+
+# ── Working directory + log ───────────────────────────────────────────────────
+# This script lives at <wiki-clone>/scripts/pr-patrol-supervisor.sh, so the
+# wiki clone is one directory up. Patrol creates worktrees under
+# .claude/worktrees/, so it must run from a wiki clone (typically lw/main/),
+# not from coord/ or a slot.
+WIKI_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$HOME/.cache/pr-patrol"
+LOG="$LOG_DIR/run.log"
+mkdir -p "$LOG_DIR"
+
+cd "$WIKI_ROOT" || {
+  printf '%s ERROR: cannot cd to %s — exiting (launchd will throttle and retry)\n' \
+    "$(date '+%Y-%m-%d %H:%M:%S')" "$WIKI_ROOT" >> "$LOG"
+  exit 1
+}
+
+# ── Shutdown handling ─────────────────────────────────────────────────────────
+# When launchd sends SIGTERM (e.g. on `launchctl unload` or system shutdown),
+# kill the patrol child and exit cleanly. Without this, the SIGTERM is delivered
+# to bash but the patrol child keeps running until the OS kills it.
+
+patrol_pid=""
+shutdown() {
+  if [ -n "$patrol_pid" ] && kill -0 "$patrol_pid" 2>/dev/null; then
+    printf '%s ── supervisor received signal — terminating patrol pid=%d ──\n' \
+      "$(date '+%Y-%m-%d %H:%M:%S')" "$patrol_pid" >> "$LOG"
+    kill -TERM "$patrol_pid" 2>/dev/null || true
+    wait "$patrol_pid" 2>/dev/null || true
+  fi
+  exit 0
+}
+trap shutdown TERM INT
+
+# ── Main loop ─────────────────────────────────────────────────────────────────
+printf '%s ── supervisor starting (pid=%d, wiki=%s) ──\n' \
+  "$(date '+%Y-%m-%d %H:%M:%S')" "$$" "$WIKI_ROOT" >> "$LOG"
+
+PIDFILE="$HOME/.cache/pr-patrol/daemon.pid"
+
+while true; do
+  # Pre-check: if another live patrol owns daemon.pid (e.g. a stray tmux-based
+  # patrol from before the launchd migration), skip the launch and try again
+  # in 30s. This avoids spamming "Another PR patrol daemon is already running"
+  # into run.log every cycle while the user finishes the migration. Patrol's
+  # own EEXIST handling stays as the second line of defense.
+  if [ -f "$PIDFILE" ]; then
+    other=$(cat "$PIDFILE" 2>/dev/null || echo "")
+    if [ -n "$other" ] && [ "$other" != "$$" ] && kill -0 "$other" 2>/dev/null; then
+      printf '%s ── another patrol pid=%s holds daemon.pid, sleeping 30s ──\n' \
+        "$(date '+%Y-%m-%d %H:%M:%S')" "$other" >> "$LOG"
+      sleep 30
+      continue
+    fi
+  fi
+
+  printf '%s ── pr-patrol starting ──\n' "$(date '+%Y-%m-%d %H:%M:%S')" >> "$LOG"
+  pnpm crux gh pr-patrol run >> "$LOG" 2>&1 &
+  patrol_pid=$!
+  wait "$patrol_pid"
+  ec=$?
+  patrol_pid=""
+  printf '%s ── pr-patrol exited code=%d, sleeping 30s ──\n' \
+    "$(date '+%Y-%m-%d %H:%M:%S')" "$ec" >> "$LOG"
+  sleep 30
+done


### PR DESCRIPTION
## Summary

PR patrol is reliable when it's running, but its uptime has been eroded by the tmux-window startup pattern: a window dies overnight, no human is watching, and merge conflicts pile up by morning. QUA-987 calls for moving uptime ownership to launchd so patrol survives logout, reboot, and process crashes without manual intervention.

This PR adds a launchd `LaunchAgent` plus a small supervisor + install/uninstall helper, and wires up a `tcc-check` self-test that diagnoses the macOS Full Disk Access requirement — the only non-obvious gotcha in the install path.

Closes QUA-987.

## What changed

| File | Purpose |
|---|---|
| `scripts/pr-patrol-supervisor.sh` | Daemon loop launchd executes. Runs `pnpm crux gh pr-patrol run` continuously, sleeping 30s between exits. Sources nvm so `pnpm`/`node`/`tsx` resolve, prepends homebrew/system PATH so `gh`/`git`/`tmux` resolve, traps `SIGTERM`/`SIGINT` so `launchctl unload` is a graceful stop. Pre-checks `daemon.pid` to avoid spamming `run.log` while a residual tmux patrol is still alive. |
| `scripts/launchd/com.qu.pr-patrol.plist` | Template with `RunAtLoad=true`, `KeepAlive=true`, `ThrottleInterval=30`. `__SUPERVISOR__` and `__HOME__` placeholders rendered at install time. Logs land in `~/.cache/pr-patrol/launchd.{out,err}`. |
| `scripts/launchd/pr-patrol.sh` | `install` / `uninstall` / `status` / `tail` / `tcc-check`. Idempotent. Probes TCC during install via a one-shot test plist that tries to read `.git/HEAD`; on failure prints actionable instructions instead of leaving the user to debug a silent `last_exit=126`. |
| `scripts/launchd/README.md` | Self-contained reference for the install workflow, the FDA grant, why launchd over cron/tmux, and how the agent coexists with the legacy tmux pattern. |
| `scripts/inject-patrol-status.sh` | Tracked version of the existing `UserPromptSubmit` hook. Updated to (1) recognize the launchd supervisor process during its 30s sleep window so the "patrol dead" reminder doesn't false-alarm, and (2) point at the right restart hint depending on whether launchd is loaded. |
| `.claude/memory/MEMORY.md` | One-line entry under "Recurring Gotchas" noting the macOS TCC + Full Disk Access requirement for any launchd agent reaching into `~/Documents/`. |

## Acceptance criteria (from QUA-987)

- ✅ **Patrol runs continuously without manual `tmux new-window` after logout / reboot / process crash.** `KeepAlive=true` + the supervisor's inner `while true; do … sleep 30; done` give two layers of recovery.
- ✅ **The `UserPromptSubmit` reminder hook becomes a fallback (still fires if launchd is also down), not the primary uptime mechanism.** The hook now distinguishes "launchd loaded but supervisor not running" from "no launchd agent installed" and prints the appropriate diagnosis.
- ✅ **Document the install/uninstall in `lw/.claude/commands/setup-slot-orchestration.md`.** Documented in `scripts/launchd/README.md` (tracked alongside the code in this PR). The lw/configs repo's `setup-slot-orchestration.md` is in a separate repo with the user's other in-progress edits, so the proposed addition for that file is included as a separate diff in this PR description below — apply at your convenience.

## Design choices

- **Direct-loop variant over tmux-supervisor.** The Linear ticket offered both options. Direct-loop is simpler and patrol's built-in `daemon.pid` singleton already prevents double-runs, so collision with a stray tmux patrol exits cleanly and retries 30s later. Live-watch is preserved via `tail -f ~/.cache/pr-patrol/run.log` (or `pr-patrol.sh tail`).
- **Pre-check for `daemon.pid` in the supervisor.** Avoids spamming `run.log` with patrol's "Another PR patrol daemon is already running" diagnostic during the migration window when a tmux-managed patrol still owns the lock.
- **Render-time placeholder substitution rather than env vars.** Each user/machine has different absolute paths; `sed` rendering at install time keeps the on-disk plist self-contained and portable.

## The macOS TCC catch — one-time Full Disk Access grant

Modern macOS (Ventura, Sonoma, Sequoia) blocks launchd-spawned processes from reading anything under `~/Documents/`. Agents loaded into launchd's Aqua context don't inherit the TCC profile of Terminal/iTerm, so they can't reach the wiki clone if it lives there.

**Symptom:** `launchctl list com.qu.pr-patrol` shows `last_exit=126` ("Operation not permitted") and patrol never runs.

**Diagnosis:** the install script's TCC self-test catches this and prints next steps. Confirmed empirically on the dev machine: the existing `~/Library/LaunchAgents/com.qu.lw-fix-tabs.plist` (used for tmux-window renaming) has been silently failing for the same reason. The same FDA grant fixes both.

**To grant** (one time per machine):

1. **System Settings → Privacy & Security → Full Disk Access**
2. Click **＋** and add `/bin/bash` (or, more narrowly, `<wiki-clone>/scripts/pr-patrol-supervisor.sh`)
3. Toggle the new entry **ON**
4. Re-run `./scripts/launchd/pr-patrol.sh install`

## Test plan

Manually exercised on the dev machine:

- [x] `./scripts/launchd/pr-patrol.sh install` — renders the plist, runs `launchctl load`, runs the TCC probe. Probe correctly detected the unprivileged state and printed the FDA instructions. Verified install is idempotent (re-running unloads + reloads cleanly).
- [x] `./scripts/launchd/pr-patrol.sh status` — reports launchd state (`pid=- last_exit=126` while TCC blocks) with a `⚠ supervisor exited non-zero last cycle` warning surfacing the broken state, the live patrol process (a tmux-managed patrol was running concurrently), and `daemon.pid` ownership.
- [x] `./scripts/launchd/pr-patrol.sh tcc-check` — exits 0 / 1 cleanly based on probe outcome (verified after review fix to the heredoc-substitution path).
- [x] `./scripts/launchd/pr-patrol.sh uninstall` — removes the plist and unloads. Repeat invocation prints `Already absent` without error.
- [x] Supervisor SIGTERM responsiveness — empirically: SIGTERM during the inter-cycle 30s sleep exits the supervisor inside 5s (well under launchd's default 20s ExitTimeout). Verified after the `sleep_interruptible` fix.
- [x] Plist validation: rendered output passes `plutil -lint` for both the main plist and the TCC-probe plist.
- [x] Bash syntax: `bash -n` clean for `pr-patrol-supervisor.sh`, `pr-patrol.sh`, and `inject-patrol-status.sh`.
- [x] Coexistence with the legacy tmux pattern: existing tmux-managed patrol kept running undisturbed throughout install/uninstall cycles. The supervisor's pre-check on `daemon.pid` prevents log noise during the transition window.
- [x] Adversarial inputs (red-team pass): unknown subcommand, empty arg, daemon.pid containing shell-metacharacters (`$(rm -rf /tmp/PWND)` displayed as data, no command injection), unreadable daemon.pid (gracefully reports `<unreadable>`), repeated install while loaded (re-loads cleanly).
- [x] `/agent-review-pr` ran a full hostile-reviewer pass; CRITICAL + 4 HIGH findings addressed in the second commit (heredoc, dead `else`, sleep-trap responsiveness, hardcoded paths in the hook, sed-replacement escaping).
- [x] Pre-push gate: 66/66 checks pass (3 advisory warnings unrelated to this PR — pre-existing crux typecheck baseline, orphan-entity detection, resource data quality).

Out of scope:
- Auto-grant of FDA — not programmatically possible on macOS.
- Replacing the existing local `lw/scripts/inject-patrol-status.sh` — kept the user's local hook config intact; the tracked version in this PR is a drop-in replacement to switch to when convenient.

## Suggested follow-up edit for `lw/.claude/commands/setup-slot-orchestration.md`

The lw/configs repo (`OAGr/longtermwiki-configs`) has uncommitted in-progress edits, so this PR doesn't touch that file directly. Suggested replacement for the "1b. PR patrol" section (apply manually):

```markdown
### 1b. PR patrol (launchd-managed — uptime owned by the OS)

PR patrol is conceptually owned by **this** session (it watches slot PRs — don't manage it from `/setup-releases`), but the *uptime* of the daemon is owned by `launchd` via a LaunchAgent. This survives logout, reboot, and process crashes — the previous tmux-only pattern only ran while the user was logged in.

PR patrol uses real LLM budget. The launchd agent runs continuously once installed; install with user confirmation, then it stays installed across reboots.

**Status check:**

    ./main/scripts/launchd/pr-patrol.sh status

Output is `✓ launchd: loaded` + `✓ patrol process: pid=…` when healthy.

**Install (one-time per machine):**

    ./main/scripts/launchd/pr-patrol.sh install

This renders the plist with absolute paths, copies it to `~/Library/LaunchAgents/`, and probes macOS Full Disk Access. If FDA is missing, the TCC self-test prints clear next steps — full reference at `lw/main/scripts/launchd/README.md`.

**Watch the live log:**

    tail -f ~/.cache/pr-patrol/run.log

The legacy `tmux new-window -t 0: -n PATROL …` pattern still works as a fallback for systems without launchd or while debugging the supervisor itself. Patrol's built-in `daemon.pid` singleton ensures launchd and a stray tmux invocation never both run patrol concurrently.

**Uninstall:**

    ./main/scripts/launchd/pr-patrol.sh uninstall
```

You might also want to update `coord/.claude/settings.local.json` to point its `UserPromptSubmit` hook at `lw/main/scripts/inject-patrol-status.sh` (the tracked version with launchd-aware reminders) instead of the local copy under `lw/scripts/`.
