### PR TITLE
QUA-987 follow-up: simplify launchd supervisor (log rotation, fork reduction)

### DIFF
--- a/scripts/inject-patrol-status.sh
+++ b/scripts/inject-patrol-status.sh
@@ -17,24 +17,27 @@ CACHE_FILE="/tmp/.patrol-status-open-prs"
 CACHE_TTL=300  # 5 min — open-PR list rarely changes faster
 
 # ─── Patrol liveness ──────────────────────────────────────────────────────────
-# Match any of:
-#   - the patrol process itself (`node ... gh pr-patrol run` or the pnpm parent)
-#   - the launchd supervisor in its 30s sleep window between patrol invocations
-# Without the supervisor case we'd flap into "patrol dead" reminders every 30s
-# whenever launchd-managed patrol is between cycles. The pattern is loose
-# (`pr-patrol run`) on purpose — it matches whether the launcher is `pnpm crux`,
-# direct `node`, or a future replacement, and `status` in pr-patrol.sh uses
-# the same loose pattern for consistency. See QUA-987.
-patrol_pid=$(pgrep -f "pr-patrol run" 2>/dev/null | head -1)
-if [ -z "$patrol_pid" ]; then
-  patrol_pid=$(pgrep -f "pr-patrol-supervisor.sh" 2>/dev/null | head -1)
-fi
+# Match either the patrol process (`node ... pr-patrol run` / pnpm parent) or
+# the launchd supervisor mid-sleep — without the supervisor case we'd false-
+# alarm every 30s during the launchd-managed restart cadence. Single pgrep
+# with alternation = one process-table walk per user prompt.
+patrol_pid=$(pgrep -f 'pr-patrol run|pr-patrol-supervisor\.sh' 2>/dev/null | head -1)
 
 # ─── Abandoned PR collection ──────────────────────────────────────────────────
+# Use a glob (with nullglob) instead of `ls | grep | sed | tr` — fewer forks
+# on every user prompt, no ls-parsing, and the existing files are exclusively
+# `abandoned-<N>` so there's nothing to filter further.
 abandoned=""
-if [ -d "$STATE_DIR" ]; then
-  abandoned=$(ls "$STATE_DIR" 2>/dev/null | grep -E '^abandoned-[0-9]+$' | sed 's/^abandoned-//' | tr '\n' ' ')
-fi
+shopt -s nullglob
+for f in "$STATE_DIR"/abandoned-*; do
+  n="${f##*/abandoned-}"
+  case "$n" in
+    ''|*[!0-9]*) ;;  # skip empty or non-numeric
+    *) abandoned="$abandoned $n" ;;
+  esac
+done
+shopt -u nullglob
+abandoned="${abandoned# }"
 
 # Fast exit: nothing to report
 if [ -z "$abandoned" ] && [ -n "$patrol_pid" ]; then
@@ -56,13 +59,14 @@ if [ -n "$abandoned" ]; then
   fi
 fi
 
+# Bash substring matching avoids forking `echo | grep -q` once per abandoned PR.
 still_open_abandoned=""
 for pr in $abandoned; do
-  if [ -z "$open_prs" ] || echo " $open_prs " | grep -q " $pr "; then
+  if [ -z "$open_prs" ] || [[ " $open_prs " == *" $pr "* ]]; then
     still_open_abandoned="$still_open_abandoned $pr"
   fi
 done
-still_open_abandoned=$(echo "$still_open_abandoned" | xargs)
+still_open_abandoned="${still_open_abandoned# }"
 
 # ─── Emit reminder if anything to report ──────────────────────────────────────
 if [ -z "$still_open_abandoned" ] && [ -n "$patrol_pid" ]; then

--- a/scripts/launchd/pr-patrol.sh
+++ b/scripts/launchd/pr-patrol.sh
@@ -17,14 +17,17 @@
 
 set -euo pipefail
 
-# This script lives at <wiki-clone>/scripts/launchd/pr-patrol.sh, so the wiki
-# clone is two directories up.
 WIKI_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PLIST_SRC="$WIKI_ROOT/scripts/launchd/com.qu.pr-patrol.plist"
 PLIST_DST="$HOME/Library/LaunchAgents/com.qu.pr-patrol.plist"
 LABEL="com.qu.pr-patrol"
 SUPERVISOR="$WIKI_ROOT/scripts/pr-patrol-supervisor.sh"
-LOG="$HOME/.cache/pr-patrol/run.log"
+CACHE_DIR="$HOME/.cache/pr-patrol"
+LOG="$CACHE_DIR/run.log"
+# Loose pattern matches the patrol process (`node ... pr-patrol run` /
+# pnpm parent) AND the launchd supervisor in its 30s sleep window. Kept in
+# sync with inject-patrol-status.sh so liveness checks agree across files.
+PATROL_PROCESS_PATTERN='pr-patrol run|pr-patrol-supervisor\.sh'
 
 cmd="${1:-install}"
 
@@ -38,18 +41,24 @@ sed_replacement_escape() {
 
 # Render the embedded XML template, substituting placeholders via sed (so the
 # heredoc terminator stays quoted and shell expansion can't sneak in).
+# Placeholders are processed longest-first so a future short name can never
+# clobber bytes inside a longer one (e.g. `__HOME__` inside `__HOME_DIR__`).
 render_template() {
   # Args: input_file output_file [placeholder=value]...
   local input="$1" output="$2"
   shift 2
+  local pairs=("$@")
+  # Sort pairs by placeholder length descending.
+  local sorted
+  sorted=$(printf '%s\n' "${pairs[@]}" | awk '{ print length($0)"\t"$0 }' | sort -rn | cut -f2-)
   local sed_args=()
   local pair name val esc
-  for pair in "$@"; do
+  while IFS= read -r pair; do
     name="${pair%%=*}"
     val="${pair#*=}"
     esc=$(sed_replacement_escape "$val")
     sed_args+=(-e "s|$name|$esc|g")
-  done
+  done <<<"$sorted"
   sed "${sed_args[@]}" "$input" > "$output"
 }
 
@@ -67,6 +76,16 @@ tcc_self_test() {
   local probe_err="/tmp/$probe_label.err"
   local probe_target="$WIKI_ROOT/.git/HEAD"
   local probe_template="/tmp/$probe_label.template"
+
+  # Cleanup trap — if the probe is interrupted (Ctrl-C, kill, error), make
+  # sure we don't leave the probe plist in ~/Library/LaunchAgents/ where
+  # launchd would re-run it on next login.
+  local prev_int_trap prev_term_trap prev_exit_trap
+  cleanup_probe() {
+    launchctl unload "$probe_plist" 2>/dev/null || true
+    /bin/rm -f "$probe_plist" "$probe_out" "$probe_err" "$probe_template"
+  }
+  trap cleanup_probe EXIT INT TERM
 
   /bin/rm -f "$probe_out" "$probe_err" "$probe_template"
 
@@ -96,31 +115,29 @@ PROBE_PLIST_TEMPLATE
     "__PROBE_TARGET__=$probe_target" \
     "__PROBE_OUT__=$probe_out" \
     "__PROBE_ERR__=$probe_err"
-  /bin/rm -f "$probe_template"
 
   launchctl unload "$probe_plist" 2>/dev/null || true
-  # `set -e` is in effect; load failures here would abort install. Tolerate
-  # them — on failure we fall through and report TCC as blocked, which is
-  # the conservative default.
+  # `set -e` is in effect; tolerate load failure (the cleanup trap still runs).
+  # On failure we fall through and report TCC as blocked — the conservative
+  # default.
   if ! launchctl load "$probe_plist" 2>/dev/null; then
-    /bin/rm -f "$probe_plist" "$probe_out" "$probe_err"
+    trap - EXIT INT TERM
+    cleanup_probe
     return 1
   fi
 
-  # Plist is one-shot — wait briefly for it to run.
+  # One-shot plist — wait briefly for output.
   for _ in 1 2 3 4 5 6; do
     [ -s "$probe_out" ] && break
     [ -s "$probe_err" ] && break
     sleep 0.5
   done
-  launchctl unload "$probe_plist" 2>/dev/null || true
-  /bin/rm -f "$probe_plist"
 
   local result=1
-  if [ -s "$probe_out" ]; then
-    result=0
-  fi
-  /bin/rm -f "$probe_out" "$probe_err"
+  [ -s "$probe_out" ] && result=0
+
+  trap - EXIT INT TERM
+  cleanup_probe
   return $result
 }
 
@@ -155,7 +172,7 @@ case "$cmd" in
     [ -f "$SUPERVISOR" ] || { echo "✗ Missing supervisor: $SUPERVISOR" >&2; exit 1; }
 
     chmod +x "$SUPERVISOR"
-    mkdir -p "$HOME/Library/LaunchAgents" "$HOME/.cache/pr-patrol"
+    mkdir -p "$HOME/Library/LaunchAgents" "$CACHE_DIR"
 
     # Render the plist with absolute paths. render_template escapes sed
     # replacement metachars (\, &, |) so paths with shell-special characters
@@ -185,7 +202,7 @@ case "$cmd" in
       print_tcc_help
     fi
 
-    if pgrep -fl "node.*pr-patrol run" >/dev/null 2>&1; then
+    if pgrep -f "$PATROL_PROCESS_PATTERN" >/dev/null 2>&1; then
       echo ""
       echo "ℹ Existing patrol process detected — it owns daemon.pid until it exits."
       echo "  The launchd supervisor will retry every 30s and take over once free."
@@ -239,16 +256,15 @@ case "$cmd" in
     else
       echo "✗ launchd: not loaded   (run: $0 install)"
     fi
-    # `pgrep -f` returns non-zero on no match, so check the assignment value
-    # explicitly — don't rely on the pipeline's exit code (the prior version's
-    # `if pid=$(... | awk ...)` was always true because awk exits 0 on empty).
-    pid=$(pgrep -f "node.*pr-patrol run" 2>/dev/null | head -1)
+    # Loose pattern matches the patrol process AND the launchd supervisor's
+    # 30s sleep window between cycles, aligned with inject-patrol-status.sh.
+    pid=$(pgrep -f "$PATROL_PROCESS_PATTERN" 2>/dev/null | head -1)
     if [ -n "$pid" ]; then
       echo "✓ patrol process: pid=$pid"
     else
       echo "✗ patrol process: not running"
     fi
-    pidfile="$HOME/.cache/pr-patrol/daemon.pid"
+    pidfile="$CACHE_DIR/daemon.pid"
     if [ -f "$pidfile" ]; then
       pidcontents=$(cat "$pidfile" 2>/dev/null || echo "<unreadable>")
       echo "  daemon.pid: $pidcontents ($pidfile)"

--- a/scripts/pr-patrol-supervisor.sh
+++ b/scripts/pr-patrol-supervisor.sh
@@ -43,40 +43,48 @@ fi
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
 
-# ── Working directory + log ───────────────────────────────────────────────────
-# This script lives at <wiki-clone>/scripts/pr-patrol-supervisor.sh, so the
-# wiki clone is one directory up. Patrol creates worktrees under
-# .claude/worktrees/, so it must run from a wiki clone (typically lw/main/),
-# not from coord/ or a slot.
+# Patrol creates worktrees under .claude/worktrees/, so the supervisor must
+# run from a wiki clone (typically lw/main/), not from coord/ or a slot.
 WIKI_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-LOG_DIR="$HOME/.cache/pr-patrol"
-LOG="$LOG_DIR/run.log"
-mkdir -p "$LOG_DIR"
+CACHE_DIR="$HOME/.cache/pr-patrol"
+LOG="$CACHE_DIR/run.log"
+PIDFILE="$CACHE_DIR/daemon.pid"
+LOG_MAX_BYTES=$((50 * 1024 * 1024))  # 50 MB before rotating to .log.1
+mkdir -p "$CACHE_DIR"
+
+# Bash builtin %(...)T format avoids forking a `date` subshell per log line.
+# At ~30s cadence the supervisor logs hundreds of lines per hour; replacing
+# the subshell saves ~240 forks/hour at idle.
+ts() { printf '%(%Y-%m-%d %H:%M:%S)T' -1; }
+
+# Rotate run.log when it exceeds LOG_MAX_BYTES so an unattended supervisor
+# doesn't grow the log unbounded over weeks/months.
+maybe_rotate_log() {
+  [ -f "$LOG" ] || return 0
+  local size
+  size=$(/usr/bin/stat -f %z "$LOG" 2>/dev/null) || return 0
+  if [ "$size" -gt "$LOG_MAX_BYTES" ]; then
+    /bin/mv "$LOG" "$LOG.1" 2>/dev/null || true
+  fi
+}
 
 cd "$WIKI_ROOT" || {
   printf '%s ERROR: cannot cd to %s — exiting (launchd will throttle and retry)\n' \
-    "$(date '+%Y-%m-%d %H:%M:%S')" "$WIKI_ROOT" >> "$LOG"
+    "$(ts)" "$WIKI_ROOT" >> "$LOG"
   exit 1
 }
 
-# ── Shutdown handling ─────────────────────────────────────────────────────────
-# When launchd sends SIGTERM (e.g. on `launchctl unload` or system shutdown),
-# kill the patrol process group and exit cleanly. Without this, the SIGTERM is
-# delivered to bash but the patrol child (and its node grandchild via pnpm)
-# keep running until the OS escalates to SIGKILL.
-#
-# Job control (`set -m`) puts each `&`-spawned child in its own process group.
-# We then signal the whole group via `kill -- -PGID` so pnpm's node child gets
-# the signal too — pnpm's own signal forwarding is not guaranteed.
+# When launchd sends SIGTERM (`launchctl unload` or shutdown), kill the patrol
+# process group and exit cleanly. `set -m` puts each `&`-spawned child in its
+# own process group; signalling -PGID reaches pnpm's node grandchild too,
+# whose signal forwarding from pnpm is not guaranteed.
 set -m
 
 patrol_pid=""
 shutdown() {
   if [ -n "$patrol_pid" ] && kill -0 "$patrol_pid" 2>/dev/null; then
-    printf '%s ── supervisor received signal — terminating patrol pgid=%d ──\n' \
-      "$(date '+%Y-%m-%d %H:%M:%S')" "$patrol_pid" >> "$LOG"
-    # `-pid` = process group; thanks to `set -m` the spawned child is the
-    # group leader, so its PID equals the PGID.
+    printf '%s ── supervisor received signal — terminating child pgid=%d ──\n' \
+      "$(ts)" "$patrol_pid" >> "$LOG"
     kill -TERM -- "-$patrol_pid" 2>/dev/null || kill -TERM "$patrol_pid" 2>/dev/null || true
     wait "$patrol_pid" 2>/dev/null || true
   fi
@@ -84,16 +92,15 @@ shutdown() {
 }
 trap shutdown TERM INT
 
-# ── Main loop ─────────────────────────────────────────────────────────────────
 printf '%s ── supervisor starting (pid=%d, wiki=%s) ──\n' \
-  "$(date '+%Y-%m-%d %H:%M:%S')" "$$" "$WIKI_ROOT" >> "$LOG"
+  "$(ts)" "$$" "$WIKI_ROOT" >> "$LOG"
 
-PIDFILE="$HOME/.cache/pr-patrol/daemon.pid"
-
-# Run sleep as a backgrounded child + wait. Plain `sleep N` is an external
-# command — bash defers signal handlers until it returns, so a 30s sleep
-# delays SIGTERM by up to 30s, easily exceeding launchd's default 20s
-# ExitTimeout. `wait` IS interruptible, so this lets the trap fire promptly.
+# `wait` is interruptible by signals; bare `sleep N` is not (bash defers the
+# trap until the external sleep returns), so backgrounding sleep + wait lets
+# SIGTERM fire promptly during the inter-cycle pause. We share `patrol_pid`
+# with the foreground patrol invocation deliberately — `set -m` gives each
+# backgrounded child its own pgid, so `kill -- -patrol_pid` works for the
+# sleep child too (a no-op if sleep already finished).
 sleep_interruptible() {
   sleep "$1" &
   patrol_pid=$!
@@ -102,28 +109,28 @@ sleep_interruptible() {
 }
 
 while true; do
-  # Pre-check: if another live patrol owns daemon.pid (e.g. a stray tmux-based
-  # patrol from before the launchd migration), skip the launch and try again
-  # in 30s. This avoids spamming "Another PR patrol daemon is already running"
-  # into run.log every cycle while the user finishes the migration. Patrol's
-  # own EEXIST handling stays as the second line of defense.
+  maybe_rotate_log
+
+  # Skip the launch if another live patrol holds daemon.pid (e.g. a stray
+  # tmux-based patrol from before the launchd migration) — patrol's own
+  # EEXIST handling is the backstop, but pre-checking keeps the launch
+  # error out of run.log during the migration window.
   if [ -f "$PIDFILE" ]; then
     other=$(cat "$PIDFILE" 2>/dev/null || echo "")
     if [ -n "$other" ] && [ "$other" != "$$" ] && kill -0 "$other" 2>/dev/null; then
       printf '%s ── another patrol pid=%s holds daemon.pid, sleeping 30s ──\n' \
-        "$(date '+%Y-%m-%d %H:%M:%S')" "$other" >> "$LOG"
+        "$(ts)" "$other" >> "$LOG"
       sleep_interruptible 30
       continue
     fi
   fi
 
-  printf '%s ── pr-patrol starting ──\n' "$(date '+%Y-%m-%d %H:%M:%S')" >> "$LOG"
+  printf '%s ── pr-patrol starting ──\n' "$(ts)" >> "$LOG"
   pnpm crux gh pr-patrol run >> "$LOG" 2>&1 &
   patrol_pid=$!
   wait "$patrol_pid"
   ec=$?
   patrol_pid=""
-  printf '%s ── pr-patrol exited code=%d, sleeping 30s ──\n' \
-    "$(date '+%Y-%m-%d %H:%M:%S')" "$ec" >> "$LOG"
+  printf '%s ── pr-patrol exited code=%d, sleeping 30s ──\n' "$(ts)" "$ec" >> "$LOG"
   sleep_interruptible 30
 done


### PR DESCRIPTION
## Summary

Follow-up to PR #4795 (QUA-987) addressing findings from `/simplify` that didn't make it before that PR merged. Three correctness/efficiency improvements to the launchd-managed pr-patrol stack:

- **Log rotation**: the supervisor now trims `~/.cache/pr-patrol/run.log` to its last copy when it grows past 50 MB instead of letting it grow unbounded across weeks of uptime. Without this, an unattended supervisor on KeepAlive reaches hundreds of MB inside a month.
- **Hot-path fork reduction in the `UserPromptSubmit` hook** (`scripts/inject-patrol-status.sh`): collapsed two `pgrep -f` invocations into one alternation, replaced an `ls | grep | sed | tr` four-process pipeline with an in-shell `nullglob` loop, and replaced per-PR `echo | grep -q` with bash substring matching. Net: 4–6 fewer forks on every user prompt at idle.
- **Bash builtin timestamps in the supervisor** (`scripts/pr-patrol-supervisor.sh`): replaced `$(date '+...')` subshell-per-log-line with the `printf '%(...)T'` builtin via a `ts()` helper. ~240 fewer forks per hour at idle.

Plus a few smaller items the simplify pass surfaced:

- Aligned the loose `pgrep` pattern (`pr-patrol run|pr-patrol-supervisor\.sh`) between `inject-patrol-status.sh` and `pr-patrol.sh status` — the prior gap had the install script using `node.*pr-patrol run` while the hook used the looser pattern, causing inconsistent liveness reporting.
- Hoisted `CACHE_DIR` and `PATROL_PROCESS_PATTERN` constants in both files so paths and patterns aren't repeated.
- Sorted `render_template` placeholders longest-first so a future short placeholder name can never substring-clobber a longer one's bytes.
- Added a cleanup `trap` to `tcc_self_test` so an interrupted probe (Ctrl-C, kill, error) doesn't leave the probe plist in `~/Library/LaunchAgents/` for launchd to re-run on next login.
- Trimmed redundant WHAT comments that just narrated `cd $(dirname ../)/..`.

## Why a follow-up PR

`/simplify` ran after PR #4795 was already pushed and the user merged it (with the `gate:rules-ok` label) before the simplify commit could land on the same branch. The simplify findings are still useful — particularly the log rotation, which would otherwise have to be added under an "incident: run.log got huge" Linear ticket later — so this PR ships them as a clean follow-up against `main`.

## Test plan

- [x] Bash syntax: `bash -n` clean for `pr-patrol-supervisor.sh`, `pr-patrol.sh`, `inject-patrol-status.sh`.
- [x] `./scripts/launchd/pr-patrol.sh install` — TCC probe still works correctly with the cleanup trap; no orphan probe plist.
- [x] `./scripts/launchd/pr-patrol.sh status` — uses the aligned pgrep pattern; reports patrol-process state correctly.
- [x] `./scripts/launchd/pr-patrol.sh uninstall` — clean removal.
- [x] Simulated patrol-run and supervisor processes both match the new `pr-patrol run|pr-patrol-supervisor\.sh` pattern via `pgrep -fl`.
- [x] Pre-push gate: 66/66 checks pass (3 advisory warnings — the pre-existing baseline noted in #4795).

Closes follow-up to QUA-987.

Fixes QUA-987
