### PR TITLE
QUA-1009: standardize directory filter UI on FilterChips + DirectoryFilterDropdown

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -477,3 +477,39 @@ test.describe("Render audit — directory Coverage columns render dots (QUA-900)
     });
   }
 });
+
+test.describe("Render audit — filter chip labels have a separator (QUA-1009)", () => {
+  // QUA-918 / QUA-1009: filter chips used to render `<button>{label}<span>{count}</span></button>`
+  // with no text-node space, producing concatenated textContent like `enacted18`,
+  // `Convertible_note3`, `Leaderboard2 models`. The fix renders `Label (count)`.
+  // This regression check asserts no chip on a directory page has a textContent
+  // ending in `<word><digit>` (i.e. a letter immediately followed by a number).
+  for (const url of [
+    "/legislation",
+    "/funding-rounds",
+    "/funding-programs",
+    "/grants",
+    "/benchmarks",
+    "/research-areas",
+    "/divisions",
+    "/politicians",
+    "/organizations",
+    "/people",
+    "/things",
+  ]) {
+    test(`${url} filter chips don't concatenate label and count`, async ({ page }) => {
+      await loadPage(page, url);
+      const chips = await page
+        .locator('[data-testid="filter-chip"]')
+        .allTextContents();
+      const concatenated = chips.filter((t) =>
+        // letter immediately followed by digit, i.e. no space/paren before count
+        /[A-Za-z][0-9]/.test(t.trim()),
+      );
+      expect(
+        concatenated,
+        `${url} has filter chips with concatenated text: ${concatenated.slice(0, 3).join(" | ")}`,
+      ).toEqual([]);
+    });
+  }
+});

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -502,10 +502,13 @@ test.describe("Render audit — filter chip labels have a separator (QUA-1009)",
       const chips = await page
         .locator('[data-testid="filter-chip"]')
         .allTextContents();
-      const concatenated = chips.filter((t) =>
-        // letter immediately followed by digit, i.e. no space/paren before count
-        /[A-Za-z][0-9]/.test(t.trim()),
-      );
+      const concatenated = chips.filter((t) => {
+        // Bug shape: chip ends in digits with the previous char being a letter
+        // (e.g. "enacted18"). A properly formatted chip ends in "(N)" because
+        // formatFacetTextContent adds parens. Anchor to the end so labels with
+        // embedded numbers like "GPT-4 Vision" don't trip a false positive.
+        return /[A-Za-z]\d+$/.test(t.trim());
+      });
       expect(
         concatenated,
         `${url} has filter chips with concatenated text: ${concatenated.slice(0, 3).join(" | ")}`,

--- a/apps/web/src/app/benchmarks/[slug]/page.tsx
+++ b/apps/web/src/app/benchmarks/[slug]/page.tsx
@@ -219,9 +219,9 @@ export default async function BenchmarkDetailPage({
         {sorted.length > 0 ? (
           <section>
             <h2 className="text-lg font-bold tracking-tight mb-4">
-              Leaderboard
-              <span className="ml-2 text-sm font-normal text-muted-foreground">
-                {sorted.length} {sorted.length === 1 ? "model" : "models"}
+              Leaderboard{" "}
+              <span className="text-sm font-normal text-muted-foreground">
+                ({sorted.length} {sorted.length === 1 ? "model" : "models"})
               </span>
             </h2>
             <div className="border border-border rounded-xl overflow-x-auto">

--- a/apps/web/src/app/benchmarks/benchmarks-table.tsx
+++ b/apps/web/src/app/benchmarks/benchmarks-table.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
 import { SortHeader } from "@/components/directory/SortHeader";
+import { FilterChips } from "@/components/directory/FilterChips";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeBenchmarkCoverage } from "@/components/coverage/coverage-score";
 
@@ -118,37 +119,18 @@ export function BenchmarksTable({ rows }: { rows: BenchmarkRow[] }) {
             onChange={(e) => setSearch(e.target.value)}
             className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
           />
-          <div className="flex flex-wrap gap-1.5">
-            <button
-              onClick={() => setCategoryFilter("all")}
-              aria-pressed={categoryFilter === "all"}
-              className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                categoryFilter === "all"
-                  ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                  : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-              }`}
-            >
-              All
-              <span className="ml-1 text-[10px] opacity-60">{categoryCounts.all}</span>
-            </button>
-            {categories.map((cat) => (
-              <button
-                key={cat}
-                onClick={() => setCategoryFilter(categoryFilter === cat ? "all" : cat)}
-                aria-pressed={categoryFilter === cat}
-                className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                  categoryFilter === cat
-                    ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                    : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-                }`}
-              >
-                {cat.charAt(0).toUpperCase() + cat.slice(1)}
-                <span className="ml-1 text-[10px] opacity-60">
-                  {categoryCounts[cat] ?? 0}
-                </span>
-              </button>
-            ))}
-          </div>
+          <FilterChips
+            items={categories.map((cat) => ({
+              key: cat,
+              label: cat.charAt(0).toUpperCase() + cat.slice(1),
+              count: categoryCounts[cat] ?? 0,
+            }))}
+            allCount={categoryCounts.all}
+            selected={categoryFilter}
+            onSelect={setCategoryFilter}
+            hideTautologyFacets
+            hideWhenTrivial
+          />
         </div>
       </div>
 

--- a/apps/web/src/app/divisions/divisions-table.tsx
+++ b/apps/web/src/app/divisions/divisions-table.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { ProfileStatCard } from "@/components/directory/ProfileStatCard";
+import { FilterChips } from "@/components/directory/FilterChips";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeDivisionCoverage } from "@/components/coverage/coverage-score";
 import { formatCount } from "@/lib/format-compact";
@@ -112,57 +113,22 @@ export function DivisionsTable({
         ))}
       </div>
 
-      {/* By type filter badges */}
+      {/* By type filter */}
       {filteredTypeSummary.length > 0 && (
         <div className="mb-6">
           <h2 className="text-lg font-semibold mb-3">By Type</h2>
-          <div className="flex gap-3 flex-wrap">
-            {/* "All" badge */}
-            <button
-              type="button"
-              aria-pressed={selectedType === null}
-              onClick={() => setSelectedType(null)}
-              className={`rounded-lg border px-4 py-2 flex items-center gap-2 transition-all cursor-pointer ${
-                selectedType === null
-                  ? "border-primary/50 bg-primary/5 ring-1 ring-primary/20"
-                  : "border-border/60 hover:border-primary/30"
-              }`}
-            >
-              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-                All
-              </span>
-              <span className="text-sm tabular-nums text-muted-foreground">
-                {showAll ? rows.length : divisionsWithData}
-              </span>
-            </button>
-            {filteredTypeSummary.map((t) => (
-              <button
-                type="button"
-                key={t.type}
-                aria-pressed={selectedType === t.type}
-                onClick={() =>
-                  setSelectedType(selectedType === t.type ? null : t.type)
-                }
-                className={`rounded-lg border px-4 py-2 flex items-center gap-2 transition-all cursor-pointer ${
-                  selectedType === t.type
-                    ? "border-primary/50 bg-primary/5 ring-1 ring-primary/20"
-                    : "border-border/60 hover:border-primary/30"
-                }`}
-              >
-                <span
-                  className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
-                    DIVISION_TYPE_COLORS[t.type] ??
-                    "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                  }`}
-                >
-                  {t.label}
-                </span>
-                <span className="text-sm tabular-nums text-muted-foreground">
-                  {t.count}
-                </span>
-              </button>
-            ))}
-          </div>
+          <FilterChips
+            items={filteredTypeSummary.map((t) => ({
+              key: t.type,
+              label: t.label,
+              count: t.count,
+            }))}
+            allCount={showAll ? rows.length : divisionsWithData}
+            selected={selectedType ?? "all"}
+            onSelect={(key) => setSelectedType(key === "all" ? null : key)}
+            hideTautologyFacets
+            hideWhenTrivial
+          />
         </div>
       )}
 

--- a/apps/web/src/app/funding-programs/funding-programs-table.tsx
+++ b/apps/web/src/app/funding-programs/funding-programs-table.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
+import { FilterChips } from "@/components/directory/FilterChips";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeFundingProgramCoverage } from "@/components/coverage/coverage-score";
 import type { RecordVerdict } from "@/data/tablebase";
@@ -188,96 +189,40 @@ export function FundingProgramsListTable({
         />
 
         {/* Status filter */}
-        <div className="flex flex-wrap gap-1.5">
-          <span className="text-xs text-muted-foreground mr-1 self-center">
-            Status:
-          </span>
-          <button
-            type="button"
-            onClick={() => {
-              setStatusFilter("all");
-              setPage(0);
-            }}
-            aria-pressed={statusFilter === "all"}
-            className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-              statusFilter === "all"
-                ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-            }`}
-          >
-            All
-            <span className="ml-1 text-[10px] opacity-60">
-              {statusCounts.all}
-            </span>
-          </button>
-          {statuses.map((s) => (
-            <button
-              type="button"
-              key={s}
-              onClick={() => {
-                setStatusFilter(statusFilter === s ? "all" : s);
-                setPage(0);
-              }}
-              aria-pressed={statusFilter === s}
-              className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                statusFilter === s
-                  ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                  : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-              }`}
-            >
-              {s}
-              <span className="ml-1 text-[10px] opacity-60">
-                {statusCounts[s] ?? 0}
-              </span>
-            </button>
-          ))}
-        </div>
+        <FilterChips
+          prefix="Status:"
+          items={statuses.map((s) => ({
+            key: s,
+            label: s,
+            count: statusCounts[s] ?? 0,
+          }))}
+          allCount={statusCounts.all}
+          selected={statusFilter}
+          onSelect={(key) => {
+            setStatusFilter(key);
+            setPage(0);
+          }}
+          hideTautologyFacets
+          hideWhenTrivial
+        />
 
         {/* Type filter */}
-        <div className="flex flex-wrap gap-1.5">
-          <span className="text-xs text-muted-foreground mr-1 self-center">
-            Type:
-          </span>
-          <button
-            type="button"
-            onClick={() => {
-              setTypeFilter("all");
-              setPage(0);
-            }}
-            aria-pressed={typeFilter === "all"}
-            className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-              typeFilter === "all"
-                ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-            }`}
-          >
-            All
-            <span className="ml-1 text-[10px] opacity-60">
-              {typeCounts.all}
-            </span>
-          </button>
-          {programTypes.map((t) => (
-            <button
-              type="button"
-              key={t}
-              onClick={() => {
-                setTypeFilter(typeFilter === t ? "all" : t);
-                setPage(0);
-              }}
-              aria-pressed={typeFilter === t}
-              className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                typeFilter === t
-                  ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                  : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-              }`}
-            >
-              {PROGRAM_TYPE_LABELS[t] ?? t}
-              <span className="ml-1 text-[10px] opacity-60">
-                {typeCounts[t] ?? 0}
-              </span>
-            </button>
-          ))}
-        </div>
+        <FilterChips
+          prefix="Type:"
+          items={programTypes.map((t) => ({
+            key: t,
+            label: PROGRAM_TYPE_LABELS[t] ?? t,
+            count: typeCounts[t] ?? 0,
+          }))}
+          allCount={typeCounts.all}
+          selected={typeFilter}
+          onSelect={(key) => {
+            setTypeFilter(key);
+            setPage(0);
+          }}
+          hideTautologyFacets
+          hideWhenTrivial
+        />
       </div>
 
       {/* Results count + pagination */}

--- a/apps/web/src/app/funding-rounds/funding-rounds-table.tsx
+++ b/apps/web/src/app/funding-rounds/funding-rounds-table.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
+import { FilterChips } from "@/components/directory/FilterChips";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeFundingRoundCoverage } from "@/components/coverage/coverage-score";
 import { PaginationControls } from "@/components/directory/PaginationControls";
@@ -120,52 +121,22 @@ export function FundingRoundsTable({ rows }: { rows: FundingRoundRow[] }) {
         />
 
         {/* Instrument filter */}
-        {instruments.length > 1 && (
-          <div className="flex flex-wrap gap-1.5">
-            <span className="text-xs text-muted-foreground mr-1 self-center">
-              Instrument:
-            </span>
-            <button
-              type="button"
-              onClick={() => {
-                setInstrumentFilter("all");
-                setPage(0);
-              }}
-              aria-pressed={instrumentFilter === "all"}
-              className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                instrumentFilter === "all"
-                  ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                  : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-              }`}
-            >
-              All
-              <span className="ml-1 text-[10px] opacity-60">
-                {instrumentCounts.all}
-              </span>
-            </button>
-            {instruments.map((inst) => (
-              <button
-                type="button"
-                key={inst}
-                onClick={() => {
-                  setInstrumentFilter(instrumentFilter === inst ? "all" : inst);
-                  setPage(0);
-                }}
-                aria-pressed={instrumentFilter === inst}
-                className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                  instrumentFilter === inst
-                    ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                    : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-                }`}
-              >
-                {instrumentLabel(inst)}
-                <span className="ml-1 text-[10px] opacity-60">
-                  {instrumentCounts[inst] ?? 0}
-                </span>
-              </button>
-            ))}
-          </div>
-        )}
+        <FilterChips
+          prefix="Instrument:"
+          items={instruments.map((inst) => ({
+            key: inst,
+            label: instrumentLabel(inst),
+            count: instrumentCounts[inst] ?? 0,
+          }))}
+          allCount={instrumentCounts.all}
+          selected={instrumentFilter}
+          onSelect={(key) => {
+            setInstrumentFilter(key);
+            setPage(0);
+          }}
+          hideTautologyFacets
+          hideWhenTrivial
+        />
       </div>
 
       {/* Results count + pagination */}

--- a/apps/web/src/app/grants/grants-table.tsx
+++ b/apps/web/src/app/grants/grants-table.tsx
@@ -4,6 +4,8 @@ import { useState, useMemo, useCallback } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
+import { FilterChips } from "@/components/directory/FilterChips";
+import { DirectoryFilterDropdown } from "@/components/directory/DirectoryFilterDropdown";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeGrantCoverage } from "@/components/coverage/coverage-score";
 import { PaginationControls } from "@/components/directory/PaginationControls";
@@ -202,125 +204,64 @@ export function GrantsTable({
           />
           {/* Status filter — only shown when any grants have status data */}
           {hasAnyStatus && (
-            <div className="flex flex-wrap gap-1.5">
-              <button
-                type="button"
-                onClick={() => {
-                  setStatusFilter("all");
-                  setPage(0);
-                  updateUrl({ status: null, page: null });
-                }}
-                aria-pressed={statusFilter === "all"}
-                className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                  statusFilter === "all"
-                    ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                    : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-                }`}
-              >
-                All
-                <span className="ml-1 text-[10px] opacity-60">
-                  {statusCounts.all}
-                </span>
-              </button>
-              {statuses.map((s) => (
-                <button
-                  type="button"
-                  key={s}
-                  onClick={() => {
-                    const next = statusFilter === s ? "all" : s;
-                    setStatusFilter(next);
-                    setPage(0);
-                    updateUrl({ status: next, page: null });
-                  }}
-                  aria-pressed={statusFilter === s}
-                  className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                    statusFilter === s
-                      ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                      : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-                  }`}
-                >
-                  {s}
-                  <span className="ml-1 text-[10px] opacity-60">
-                    {statusCounts[s] ?? 0}
-                  </span>
-                </button>
-              ))}
-            </div>
+            <FilterChips
+              items={statuses.map((s) => ({
+                key: s,
+                label: s,
+                count: statusCounts[s] ?? 0,
+              }))}
+              allCount={statusCounts.all}
+              selected={statusFilter}
+              onSelect={(key) => {
+                setStatusFilter(key);
+                setPage(0);
+                updateUrl({ status: key === "all" ? null : key, page: null });
+              }}
+              hideTautologyFacets
+              hideWhenTrivial
+            />
           )}
         </div>
 
-        {/* Data source filter */}
-        {dataSourceOptions.length >= 2 && (
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground">Source:</span>
-            <select
-              aria-label="Filter by data source"
-              value={dataSourceFilter}
-              onChange={(e) => {
-                setDataSourceFilter(e.target.value);
-                setPage(0);
-                updateUrl({ dataSource: e.target.value === "all" ? null : e.target.value, page: null });
-              }}
-              className="text-xs px-2 py-1.5 rounded-lg border border-border bg-card"
-            >
-              <option value="all">All sources ({rows.length})</option>
-              {dataSourceOptions.map(({ id, name, count }) => (
-                <option key={id} value={id}>
-                  {name} ({count})
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
+        {/* Data source filter — dropdown for compact ≥2-option list */}
+        <DirectoryFilterDropdown
+          ariaLabel="Filter by data source"
+          prefix="Source:"
+          items={dataSourceOptions.map(({ id, name, count }) => ({
+            key: id,
+            label: name,
+            count,
+          }))}
+          allLabel="All sources"
+          allCount={rows.length}
+          selected={dataSourceFilter}
+          onSelect={(key) => {
+            setDataSourceFilter(key);
+            setPage(0);
+            updateUrl({ dataSource: key === "all" ? null : key, page: null });
+          }}
+          hideWhenTrivial
+        />
 
         {/* Funder filter */}
-        {funders.length > 1 && (
-          <div className="flex flex-wrap gap-1.5">
-            <span className="text-xs text-muted-foreground self-center mr-1">Funder:</span>
-            <button
-              type="button"
-              onClick={() => {
-                setFunderFilter("all");
-                setPage(0);
-                updateUrl({ funder: null, page: null });
-              }}
-              aria-pressed={funderFilter === "all"}
-              className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                funderFilter === "all"
-                  ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                  : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-              }`}
-            >
-              All funders
-              <span className="ml-1 text-[10px] opacity-60">
-                {rows.length}
-              </span>
-            </button>
-            {funders.map((f) => (
-              <button
-                type="button"
-                key={f.id}
-                onClick={() => {
-                  const next = funderFilter === f.id ? "all" : f.id;
-                  setFunderFilter(next);
-                  setPage(0);
-                  updateUrl({ funder: next, page: null });
-                }}
-                aria-pressed={funderFilter === f.id}
-                className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-                  funderFilter === f.id
-                    ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-                    : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-                }`}
-              >
-                {f.name}
-                <span className="ml-1 text-[10px] opacity-60">
-                  {f.count}
-                </span>
-              </button>
-            ))}
-          </div>
-        )}
+        <FilterChips
+          prefix="Funder:"
+          items={funders.map((f) => ({
+            key: f.id,
+            label: f.name,
+            count: f.count,
+          }))}
+          allLabel="All funders"
+          allCount={rows.length}
+          selected={funderFilter}
+          onSelect={(key) => {
+            setFunderFilter(key);
+            setPage(0);
+            updateUrl({ funder: key === "all" ? null : key, page: null });
+          }}
+          hideTautologyFacets
+          hideWhenTrivial
+        />
       </div>
 
       {/* Results count + pagination */}

--- a/apps/web/src/app/legislation/legislation-table.tsx
+++ b/apps/web/src/app/legislation/legislation-table.tsx
@@ -4,7 +4,8 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
 import { SortHeader } from "@/components/directory/SortHeader";
-import { STATUS_COLORS, SCOPE_COLORS, normalizeStatus } from "./legislation-constants";
+import { FilterChips } from "@/components/directory/FilterChips";
+import { STATUS_COLORS, SCOPE_COLORS } from "./legislation-constants";
 import { formatIntroducedDate } from "@/lib/format-compact";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeLegislationCoverage } from "@/components/coverage/coverage-score";
@@ -327,10 +328,6 @@ export function LegislationTable({ rows }: { rows: LegislationRow[] }) {
     );
   }
 
-  const pillBase = "text-xs px-3 py-1.5 rounded-lg border transition-all";
-  const pillActive = "bg-primary/10 border-primary/30 text-primary font-semibold";
-  const pillInactive = "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground";
-
   return (
     <div>
       {/* Filters */}
@@ -345,54 +342,35 @@ export function LegislationTable({ rows }: { rows: LegislationRow[] }) {
             className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
           />
           {/* Status filter pills */}
-          <div className="flex flex-wrap gap-1.5">
-            <button
-              onClick={() => setStatusFilter("all")}
-              aria-pressed={statusFilter === "all"}
-              className={`${pillBase} ${statusFilter === "all" ? pillActive : pillInactive}`}
-            >
-              All
-              <span className="ml-1 text-[10px] opacity-60">{rows.length}</span>
-            </button>
-            {statuses.map(([status, count]) => (
-              <button
-                key={status}
-                onClick={() => setStatusFilter(statusFilter === status ? "all" : status)}
-                aria-pressed={statusFilter === status}
-                className={`${pillBase} capitalize ${statusFilter === status ? pillActive : pillInactive}`}
-              >
-                {status}
-                <span className="ml-1 text-[10px] opacity-60">{count}</span>
-              </button>
-            ))}
-          </div>
+          <FilterChips
+            items={statuses.map(([status, count]) => ({
+              key: status,
+              label: status,
+              count,
+            }))}
+            allCount={rows.length}
+            selected={statusFilter}
+            onSelect={setStatusFilter}
+            hideTautologyFacets
+            hideWhenTrivial
+          />
         </div>
 
         {/* Scope filter + View controls */}
         <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-          {scopes.length > 1 && (
-            <div className="flex flex-wrap items-center gap-1.5">
-              <span className="text-xs text-muted-foreground/70 mr-0.5">Scope:</span>
-              <button
-                onClick={() => setScopeFilter("all")}
-                aria-pressed={scopeFilter === "all"}
-                className={`${pillBase} ${scopeFilter === "all" ? pillActive : pillInactive}`}
-              >
-                All
-              </button>
-              {scopes.map(([scope, count]) => (
-                <button
-                  key={scope}
-                  onClick={() => setScopeFilter(scopeFilter === scope ? "all" : scope)}
-                  aria-pressed={scopeFilter === scope}
-                  className={`${pillBase} capitalize ${scopeFilter === scope ? pillActive : pillInactive}`}
-                >
-                  {scope}
-                  <span className="ml-1 text-[10px] opacity-60">{count}</span>
-                </button>
-              ))}
-            </div>
-          )}
+          <FilterChips
+            prefix="Scope:"
+            items={scopes.map(([scope, count]) => ({
+              key: scope,
+              label: scope,
+              count,
+            }))}
+            allCount={rows.length}
+            selected={scopeFilter}
+            onSelect={setScopeFilter}
+            hideTautologyFacets
+            hideWhenTrivial
+          />
 
           <div className="flex items-center gap-1.5 border-l border-border/40 pl-4">
             <span className="text-xs text-muted-foreground/70 mr-0.5">View:</span>

--- a/apps/web/src/app/organizations/organizations-view.tsx
+++ b/apps/web/src/app/organizations/organizations-view.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { OrganizationsTable, type OrgRow, type OrgStatDef } from "./organizations-table";
 import { OrganizationsGrouped, GROUPS } from "./organizations-grouped";
 import { useDirectoryUrl } from "@/hooks/use-directory-url";
+import { formatFacetTextContent } from "@/components/directory/filter-shared";
 
 type ViewMode = "groups" | "table";
 
@@ -256,6 +257,11 @@ export function OrganizationsView({
   );
 }
 
+// Local ChipButton for /organizations specifically: needs the "click again to
+// scroll/escalate-to-table" UX (see handleChipClick) which the canonical
+// FilterChips deliberately does not model. Visible label uses the same
+// "Label (count)" format as FilterChips so textContent is "Funders (55)"
+// and not "Funders55" (closes the QUA-918 bug class for this surface too).
 function ChipButton({
   label,
   count,
@@ -267,8 +273,8 @@ function ChipButton({
   selected: boolean;
   onClick: () => void;
 }) {
-  // Build a screen-reader label so chips read as "Funders, 55 organizations"
-  // rather than "Funders 55" run together.
+  // Screen-reader label reads "Funders, 55 organizations" — richer than the
+  // canonical "Funders (55)" because this directory's chips count entities.
   const ariaLabel =
     count != null ? `${label}, ${count} organization${count === 1 ? "" : "s"}` : label;
   return (
@@ -277,18 +283,14 @@ function ChipButton({
       onClick={onClick}
       aria-pressed={selected}
       aria-label={ariaLabel}
+      data-testid="filter-chip"
       className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
         selected
           ? "bg-primary/10 border-primary/30 text-primary font-semibold"
           : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
       }`}
     >
-      <span aria-hidden="true">
-        {label}
-        {count != null && (
-          <span className="ml-1 text-[10px] opacity-60">{count}</span>
-        )}
-      </span>
+      <span aria-hidden="true">{formatFacetTextContent(label, count)}</span>
     </button>
   );
 }

--- a/apps/web/src/app/politicians/politicians-table.tsx
+++ b/apps/web/src/app/politicians/politicians-table.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { formatCompactCurrency } from "@/lib/format-compact";
+import { FilterChips } from "@/components/directory/FilterChips";
 import { PoliticianScoresCell } from "@/components/political/politician-scores-cell";
 import type { PoliticalScore } from "@/components/political/types";
 import {
@@ -97,10 +98,6 @@ export function PoliticiansTable({ rows }: { rows: PoliticianRow[] }) {
     return [...result].sort((a, b) => compareByValue(a, b, getValue, sortDir));
   }, [rows, search, partyFilter, statusFilter, sortKey, sortDir]);
 
-  const pillBase = "text-xs px-3 py-1.5 rounded-lg border transition-all";
-  const pillActive = "bg-primary/10 border-primary/30 text-primary font-semibold";
-  const pillInactive = "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground";
-
   return (
     <div>
       {/* Filters */}
@@ -115,49 +112,33 @@ export function PoliticiansTable({ rows }: { rows: PoliticianRow[] }) {
             className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-64"
           />
           {/* Party filter */}
-          <div className="flex flex-wrap gap-1.5">
-            <button
-              onClick={() => setPartyFilter("all")}
-              aria-pressed={partyFilter === "all"}
-              className={`${pillBase} ${partyFilter === "all" ? pillActive : pillInactive}`}
-            >
-              All <span className="ml-1 text-[10px] opacity-60">{rows.length}</span>
-            </button>
-            {parties.map(([party, count]) => (
-              <button
-                key={party}
-                onClick={() => setPartyFilter(partyFilter === party ? "all" : party)}
-                aria-pressed={partyFilter === party}
-                className={`${pillBase} capitalize ${partyFilter === party ? pillActive : pillInactive}`}
-              >
-                {party} <span className="ml-1 text-[10px] opacity-60">{count}</span>
-              </button>
-            ))}
-          </div>
+          <FilterChips
+            items={parties.map(([party, count]) => ({
+              key: party,
+              label: party,
+              count,
+            }))}
+            allCount={rows.length}
+            selected={partyFilter}
+            onSelect={setPartyFilter}
+            hideTautologyFacets
+            hideWhenTrivial
+          />
         </div>
         {/* Status filter */}
-        {statuses.length > 1 && (
-          <div className="flex flex-wrap items-center gap-1.5">
-            <span className="text-xs text-muted-foreground/70 mr-0.5">Status:</span>
-            <button
-              onClick={() => setStatusFilter("all")}
-              aria-pressed={statusFilter === "all"}
-              className={`${pillBase} ${statusFilter === "all" ? pillActive : pillInactive}`}
-            >
-              All
-            </button>
-            {statuses.map(([status, count]) => (
-              <button
-                key={status}
-                onClick={() => setStatusFilter(statusFilter === status ? "all" : status)}
-                aria-pressed={statusFilter === status}
-                className={`${pillBase} capitalize ${statusFilter === status ? pillActive : pillInactive}`}
-              >
-                {status} <span className="ml-1 text-[10px] opacity-60">{count}</span>
-              </button>
-            ))}
-          </div>
-        )}
+        <FilterChips
+          prefix="Status:"
+          items={statuses.map(([status, count]) => ({
+            key: status,
+            label: status,
+            count,
+          }))}
+          allCount={rows.length}
+          selected={statusFilter}
+          onSelect={setStatusFilter}
+          hideTautologyFacets
+          hideWhenTrivial
+        />
       </div>
 
       <div className="text-xs text-muted-foreground mb-3">

--- a/apps/web/src/app/research-areas/research-areas-table.tsx
+++ b/apps/web/src/app/research-areas/research-areas-table.tsx
@@ -4,6 +4,8 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
 import { SortHeader } from "@/components/directory/SortHeader";
+import { FilterChips } from "@/components/directory/FilterChips";
+import { DirectoryFilterDropdown } from "@/components/directory/DirectoryFilterDropdown";
 import { CoverageDots } from "@/components/coverage/CoverageDots";
 import { computeGenericCoverage } from "@/components/coverage/coverage-score";
 import { CLUSTER_COLORS, STATUS_COLORS, formatCluster } from "./research-area-constants";
@@ -101,50 +103,37 @@ export function ResearchAreasTable({ rows }: { rows: ResearchAreaRow[] }) {
         <input
           type="text"
           placeholder="Search research areas..."
+          aria-label="Search research areas"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="rounded-lg border border-border bg-background px-3 py-2 text-sm flex-1 min-w-0"
         />
-        <select
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value)}
-          className="rounded-lg border border-border bg-background px-3 py-2 text-sm"
-        >
-          <option value="all">All statuses</option>
-          {statusOptions.map((s) => (
-            <option key={s} value={s}>
-              {s.charAt(0).toUpperCase() + s.slice(1)}
-            </option>
-          ))}
-        </select>
+        <DirectoryFilterDropdown
+          ariaLabel="Filter by status"
+          allLabel="All statuses"
+          items={statusOptions.map((s) => ({
+            key: s,
+            label: s.charAt(0).toUpperCase() + s.slice(1),
+          }))}
+          selected={statusFilter}
+          onSelect={setStatusFilter}
+        />
       </div>
 
-      {/* Cluster filter pills */}
-      <div className="flex flex-wrap gap-1.5 mb-4">
-        <button
-          onClick={() => setClusterFilter("all")}
-          className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
-            clusterFilter === "all"
-              ? "bg-foreground text-background"
-              : "bg-muted text-muted-foreground hover:bg-muted/80"
-          }`}
-        >
-          All ({clusterCounts.all})
-        </button>
-        {clusters.map((c) => (
-          <button
-            key={c}
-            onClick={() => setClusterFilter(c)}
-            className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
-              clusterFilter === c
-                ? "bg-foreground text-background"
-                : CLUSTER_COLORS[c] ?? "bg-muted text-muted-foreground"
-            }`}
-          >
-            {formatCluster(c)} ({clusterCounts[c] ?? 0})
-          </button>
-        ))}
-      </div>
+      {/* Cluster filter chips */}
+      <FilterChips
+        className="mb-4"
+        items={clusters.map((c) => ({
+          key: c,
+          label: formatCluster(c),
+          count: clusterCounts[c] ?? 0,
+        }))}
+        allCount={clusterCounts.all}
+        selected={clusterFilter}
+        onSelect={setClusterFilter}
+        hideTautologyFacets
+        hideWhenTrivial
+      />
 
       <div className="text-xs text-muted-foreground mb-2">
         {filtered.length} of {rows.length} research areas

--- a/apps/web/src/components/directory/DirectoryFilterDropdown.tsx
+++ b/apps/web/src/components/directory/DirectoryFilterDropdown.tsx
@@ -4,7 +4,7 @@ import {
   filterVisibleFacets,
   formatFacetTextContent,
   type FilterFacet,
-} from "./filter-shared";
+} from "@components/directory/filter-shared";
 
 export type FilterDropdownItem = FilterFacet;
 

--- a/apps/web/src/components/directory/DirectoryFilterDropdown.tsx
+++ b/apps/web/src/components/directory/DirectoryFilterDropdown.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import {
+  filterVisibleFacets,
+  formatFacetTextContent,
+  type FilterFacet,
+} from "./filter-shared";
+
+export type FilterDropdownItem = FilterFacet;
+
+export interface DirectoryFilterDropdownProps {
+  items: FilterDropdownItem[];
+  selected: string;
+  onSelect: (key: string) => void;
+  /** Label for the "All" reset option. Default: "All". */
+  allLabel?: string;
+  /** Total count shown next to "All". Used as the tautology threshold too. */
+  allCount?: number;
+  /** Required for accessibility — names the filter (e.g., "Filter by funder"). */
+  ariaLabel: string;
+  /** Inline label rendered before the select (e.g., "Funder:"). */
+  prefix?: string;
+  /** Drop facets whose count equals `allCount` (tautology). Default: false. */
+  hideTautologyFacets?: boolean;
+  /**
+   * If only one option (other than "All") would render, hide the whole
+   * dropdown — a one-option filter is no filter. Default: false.
+   */
+  hideWhenTrivial?: boolean;
+  className?: string;
+}
+
+/**
+ * Shared dropdown filter for directory pages (QUA-1009).
+ *
+ * Pairs with `FilterChips`. Use this when a filter has more than ~8 facets,
+ * or when vertical space is at premium. Wraps a native `<select>` styled
+ * to match the chip pattern.
+ *
+ * Option labels use `formatFacetTextContent` to ensure "Label (count)" with a
+ * real space separator (closes QUA-918 by construction).
+ */
+export function DirectoryFilterDropdown({
+  items,
+  selected,
+  onSelect,
+  allLabel = "All",
+  allCount,
+  ariaLabel,
+  prefix,
+  hideTautologyFacets = false,
+  hideWhenTrivial = false,
+  className,
+}: DirectoryFilterDropdownProps) {
+  const visible = filterVisibleFacets(items, {
+    total: allCount,
+    hideTautologyFacets,
+  });
+
+  if (hideWhenTrivial && visible.length <= 1) return null;
+
+  return (
+    <div
+      data-testid="filter-dropdown"
+      className={`flex items-center gap-1.5 ${className ?? ""}`}
+    >
+      {prefix && (
+        <span className="text-xs text-muted-foreground/70">{prefix}</span>
+      )}
+      <select
+        aria-label={ariaLabel}
+        value={selected}
+        onChange={(e) => onSelect(e.target.value)}
+        className="text-xs px-2.5 py-1.5 rounded-lg border border-border/60 bg-card hover:bg-muted/50 text-muted-foreground transition-all focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40"
+      >
+        <option value="all">{formatFacetTextContent(allLabel, allCount)}</option>
+        {visible.map((item) => (
+          <option key={item.key} value={item.key}>
+            {formatFacetTextContent(item.label, item.count)}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/apps/web/src/components/directory/FilterChips.tsx
+++ b/apps/web/src/components/directory/FilterChips.tsx
@@ -59,7 +59,7 @@ export function FilterChips({
     hideTautologyFacets,
   });
 
-  if (hideWhenTrivial && visible.length <= 1) return null;
+  if (hideWhenTrivial && selected === "all" && visible.length <= 1) return null;
 
   return (
     <div

--- a/apps/web/src/components/directory/FilterChips.tsx
+++ b/apps/web/src/components/directory/FilterChips.tsx
@@ -4,7 +4,7 @@ import {
   filterVisibleFacets,
   formatFacetTextContent,
   type FilterFacet,
-} from "./filter-shared";
+} from "@components/directory/filter-shared";
 
 export type FilterChipItem = FilterFacet;
 

--- a/apps/web/src/components/directory/FilterChips.tsx
+++ b/apps/web/src/components/directory/FilterChips.tsx
@@ -1,24 +1,47 @@
 "use client";
 
-export interface FilterChipItem {
-  key: string;
-  label: string;
-  count?: number;
-}
+import {
+  filterVisibleFacets,
+  formatFacetTextContent,
+  type FilterFacet,
+} from "./filter-shared";
+
+export type FilterChipItem = FilterFacet;
 
 export interface FilterChipsProps {
   items: FilterChipItem[];
   selected: string;
   onSelect: (key: string) => void;
+  /** Label for the "All" reset chip. Default: "All". */
   allLabel?: string;
+  /** Total count shown next to "All". Used as the tautology threshold too. */
   allCount?: number;
+  /** Inline label rendered before the chip row (e.g., "Status:"). */
+  prefix?: string;
+  /**
+   * Drop facets whose count equals `allCount` (tautology — match every row).
+   * Default: false. Closes the QUA-919 tautology arm at the component layer.
+   */
+  hideTautologyFacets?: boolean;
+  /**
+   * If only one chip would be visible after filtering, render nothing.
+   * Default: false. A "filter" with one option is no filter.
+   */
+  hideWhenTrivial?: boolean;
+  className?: string;
 }
 
 /**
- * Shared filter chip bar for directory pages.
+ * Shared filter chip bar for directory pages (QUA-1009).
  *
  * Renders an "All" button followed by one button per item.
  * Clicking the currently-selected chip deselects it (resets to "all").
+ *
+ * Label format: "Label (count)" with a real text-node space, so screen
+ * readers and Playwright `textContent` see the separator. Bespoke chip rows
+ * across the codebase used `{label}<span>{count}</span>` with only CSS
+ * margin and produced concatenated `Label18` text — that bug class is
+ * eliminated by construction here.
  */
 export function FilterChips({
   items,
@@ -26,42 +49,83 @@ export function FilterChips({
   onSelect,
   allLabel = "All",
   allCount,
+  prefix,
+  hideTautologyFacets = false,
+  hideWhenTrivial = false,
+  className,
 }: FilterChipsProps) {
+  const visible = filterVisibleFacets(items, {
+    total: allCount,
+    hideTautologyFacets,
+  });
+
+  if (hideWhenTrivial && visible.length <= 1) return null;
+
   return (
-    <div className="flex flex-wrap gap-1.5">
-      <button
-        type="button"
+    <div
+      data-testid="filter-chips"
+      className={`flex flex-wrap items-center gap-1.5 ${className ?? ""}`}
+    >
+      {prefix && (
+        <span className="text-xs text-muted-foreground/70 mr-0.5 self-center">
+          {prefix}
+        </span>
+      )}
+      <FilterChipButton
+        label={allLabel}
+        count={allCount}
+        active={selected === "all"}
         onClick={() => onSelect("all")}
-        aria-pressed={selected === "all"}
-        className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-          selected === "all"
-            ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-            : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-        }`}
-      >
-        {allLabel}
-        {allCount != null && (
-          <span className="ml-1 text-[10px] opacity-60">{allCount}</span>
-        )}
-      </button>
-      {items.map((item) => (
-        <button
-          type="button"
+      />
+      {visible.map((item) => (
+        <FilterChipButton
           key={item.key}
+          label={item.label}
+          count={item.count}
+          active={selected === item.key}
           onClick={() => onSelect(selected === item.key ? "all" : item.key)}
-          aria-pressed={selected === item.key}
-          className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
-            selected === item.key
-              ? "bg-primary/10 border-primary/30 text-primary font-semibold"
-              : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
-          }`}
-        >
-          {item.label}
-          {item.count != null && (
-            <span className="ml-1 text-[10px] opacity-60">{item.count}</span>
-          )}
-        </button>
+          className="capitalize"
+        />
       ))}
     </div>
+  );
+}
+
+interface FilterChipButtonProps {
+  label: string;
+  count?: number;
+  active: boolean;
+  onClick: () => void;
+  className?: string;
+}
+
+function FilterChipButton({
+  label,
+  count,
+  active,
+  onClick,
+  className,
+}: FilterChipButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={formatFacetTextContent(label, count)}
+      data-testid="filter-chip"
+      className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+        active
+          ? "bg-primary/10 border-primary/30 text-primary font-semibold"
+          : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+      } ${className ?? ""}`}
+    >
+      {label}
+      {count != null && (
+        <>
+          {" "}
+          <span className="text-[10px] opacity-60 font-normal">({count})</span>
+        </>
+      )}
+    </button>
   );
 }

--- a/apps/web/src/components/directory/__tests__/DirectoryFilterDropdown.test.tsx
+++ b/apps/web/src/components/directory/__tests__/DirectoryFilterDropdown.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DirectoryFilterDropdown } from "../DirectoryFilterDropdown";
+
+function renderDropdown(
+  props: Partial<React.ComponentProps<typeof DirectoryFilterDropdown>> = {},
+) {
+  const onSelect = vi.fn();
+  const utils = render(
+    <DirectoryFilterDropdown
+      ariaLabel="Filter by funder"
+      items={[
+        { key: "open-phil", label: "Open Philanthropy", count: 42 },
+        { key: "ftx", label: "FTX Future Fund", count: 5 },
+      ]}
+      selected="all"
+      onSelect={onSelect}
+      allCount={47}
+      {...props}
+    />,
+  );
+  return { ...utils, onSelect };
+}
+
+describe("DirectoryFilterDropdown", () => {
+  it("formats option labels as 'Label (count)' with a real space (closes QUA-918)", () => {
+    renderDropdown();
+    const select = screen.getByLabelText(
+      "Filter by funder",
+    ) as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.textContent);
+    expect(options).toEqual([
+      "All (47)",
+      "Open Philanthropy (42)",
+      "FTX Future Fund (5)",
+    ]);
+    // Specifically: no concatenated 'OpenPhilanthropy42' shape.
+    for (const t of options) {
+      expect(t).toMatch(/\)$/);
+    }
+  });
+
+  it("calls onSelect with the chosen value", () => {
+    const { onSelect } = renderDropdown();
+    const select = screen.getByLabelText(
+      "Filter by funder",
+    ) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "ftx" } });
+    expect(onSelect).toHaveBeenCalledWith("ftx");
+  });
+
+  it("uses the selected prop as the controlled value", () => {
+    renderDropdown({ selected: "open-phil" });
+    const select = screen.getByLabelText(
+      "Filter by funder",
+    ) as HTMLSelectElement;
+    expect(select.value).toBe("open-phil");
+  });
+
+  it("hides options with count === 0", () => {
+    renderDropdown({
+      items: [
+        { key: "open-phil", label: "Open Philanthropy", count: 42 },
+        { key: "phantom", label: "Phantom", count: 0 },
+      ],
+    });
+    const options = Array.from(
+      (screen.getByLabelText("Filter by funder") as HTMLSelectElement).options,
+    ).map((o) => o.value);
+    expect(options).not.toContain("phantom");
+  });
+
+  it("hides tautology options when hideTautologyFacets is set", () => {
+    renderDropdown({
+      items: [
+        { key: "active", label: "Active", count: 50 },
+        { key: "emerging", label: "Emerging", count: 5 },
+      ],
+      allCount: 50,
+      hideTautologyFacets: true,
+    });
+    const options = Array.from(
+      (screen.getByLabelText("Filter by funder") as HTMLSelectElement).options,
+    ).map((o) => o.value);
+    expect(options).not.toContain("active");
+    expect(options).toContain("emerging");
+  });
+
+  it("renders nothing when hideWhenTrivial leaves zero or one items", () => {
+    const { container } = render(
+      <DirectoryFilterDropdown
+        ariaLabel="x"
+        items={[{ key: "active", label: "Active", count: 50 }]}
+        selected="all"
+        onSelect={vi.fn()}
+        allCount={50}
+        hideTautologyFacets
+        hideWhenTrivial
+      />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders a prefix label when provided", () => {
+    renderDropdown({ prefix: "Funder:" });
+    expect(screen.getByText("Funder:")).toBeDefined();
+  });
+});

--- a/apps/web/src/components/directory/__tests__/DirectoryFilterDropdown.test.tsx
+++ b/apps/web/src/components/directory/__tests__/DirectoryFilterDropdown.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { DirectoryFilterDropdown } from "../DirectoryFilterDropdown";
+import { DirectoryFilterDropdown } from "@components/directory/DirectoryFilterDropdown";
 
 function renderDropdown(
   props: Partial<React.ComponentProps<typeof DirectoryFilterDropdown>> = {},

--- a/apps/web/src/components/directory/__tests__/FilterChips.test.tsx
+++ b/apps/web/src/components/directory/__tests__/FilterChips.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { FilterChips } from "../FilterChips";
+import { FilterChips } from "@components/directory/FilterChips";
 
 function renderChips(props: Partial<React.ComponentProps<typeof FilterChips>> = {}) {
   const onSelect = vi.fn();

--- a/apps/web/src/components/directory/__tests__/FilterChips.test.tsx
+++ b/apps/web/src/components/directory/__tests__/FilterChips.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FilterChips } from "../FilterChips";
+
+function renderChips(props: Partial<React.ComponentProps<typeof FilterChips>> = {}) {
+  const onSelect = vi.fn();
+  const utils = render(
+    <FilterChips
+      items={[
+        { key: "enacted", label: "enacted", count: 18 },
+        { key: "vetoed", label: "vetoed", count: 1 },
+      ]}
+      selected="all"
+      onSelect={onSelect}
+      allCount={19}
+      {...props}
+    />,
+  );
+  return { ...utils, onSelect };
+}
+
+describe("FilterChips", () => {
+  it("renders 'Label (count)' with a real space in textContent (closes QUA-918)", () => {
+    renderChips();
+    const enactedChip = screen.getByRole("button", { name: /enacted/i });
+    // The fix: real space + parentheses so textContent isn't 'enacted18'.
+    expect(enactedChip.textContent).toBe("enacted (18)");
+    expect(enactedChip.textContent).not.toBe("enacted18");
+  });
+
+  it("renders the All chip with its count formatted the same way", () => {
+    renderChips();
+    const allChip = screen.getByRole("button", { name: /all/i });
+    expect(allChip.textContent).toBe("All (19)");
+  });
+
+  it("aria-label uses the same 'Label (count)' format", () => {
+    renderChips();
+    expect(
+      screen.getByRole("button", { name: "enacted (18)" }),
+    ).toBeDefined();
+  });
+
+  it("calls onSelect with the chip key when clicked", () => {
+    const { onSelect } = renderChips();
+    fireEvent.click(screen.getByRole("button", { name: /enacted/i }));
+    expect(onSelect).toHaveBeenCalledWith("enacted");
+  });
+
+  it("clicking the currently-selected chip resets to 'all'", () => {
+    const { onSelect } = renderChips({ selected: "enacted" });
+    fireEvent.click(screen.getByRole("button", { name: /enacted/i }));
+    expect(onSelect).toHaveBeenCalledWith("all");
+  });
+
+  it("clicking the All chip selects 'all'", () => {
+    const { onSelect } = renderChips({ selected: "enacted" });
+    fireEvent.click(screen.getByRole("button", { name: /all/i }));
+    expect(onSelect).toHaveBeenCalledWith("all");
+  });
+
+  it("aria-pressed reflects the selected key", () => {
+    renderChips({ selected: "enacted" });
+    expect(
+      screen.getByRole("button", { name: /enacted/i }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("button", { name: /vetoed/i }).getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
+  it("renders a prefix label when provided", () => {
+    renderChips({ prefix: "Status:" });
+    expect(screen.getByText("Status:")).toBeDefined();
+  });
+
+  it("hides chips with count === 0", () => {
+    renderChips({
+      items: [
+        { key: "enacted", label: "enacted", count: 18 },
+        { key: "phantom", label: "phantom", count: 0 },
+      ],
+    });
+    expect(screen.queryByRole("button", { name: /phantom/i })).toBeNull();
+  });
+
+  it("hides tautology facets when hideTautologyFacets is set", () => {
+    renderChips({
+      items: [
+        { key: "active", label: "Active", count: 50 },
+        { key: "emerging", label: "Emerging", count: 5 },
+      ],
+      allCount: 50,
+      hideTautologyFacets: true,
+    });
+    // Active === total, should be hidden (closes QUA-919 tautology arm).
+    expect(screen.queryByRole("button", { name: /^Active/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /emerging/i })).toBeDefined();
+  });
+
+  it("renders nothing when hideWhenTrivial leaves zero or one chips", () => {
+    const { container } = render(
+      <FilterChips
+        items={[{ key: "active", label: "Active", count: 50 }]}
+        selected="all"
+        onSelect={vi.fn()}
+        allCount={50}
+        hideTautologyFacets
+        hideWhenTrivial
+      />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders without count when chip has no count field", () => {
+    renderChips({
+      items: [{ key: "all-time", label: "All time" }],
+      allCount: undefined,
+    });
+    const chip = screen.getByRole("button", { name: "All time" });
+    expect(chip.textContent).toBe("All time");
+  });
+
+  it("handles labels with internal spaces correctly (closes QUA-918 'Convertible Note3' case)", () => {
+    renderChips({
+      items: [{ key: "convertible-note", label: "Convertible Note", count: 3 }],
+    });
+    const chip = screen.getByRole("button", { name: /Convertible Note/i });
+    expect(chip.textContent).toBe("Convertible Note (3)");
+  });
+});

--- a/apps/web/src/components/directory/__tests__/FilterChips.test.tsx
+++ b/apps/web/src/components/directory/__tests__/FilterChips.test.tsx
@@ -114,6 +114,21 @@ describe("FilterChips", () => {
     expect(container.textContent).toBe("");
   });
 
+  it("keeps chip row visible when hideWhenTrivial is true but a non-all filter is active", () => {
+    // If only 1 visible chip but user has selected it, we must render so they can clear it.
+    const { container } = render(
+      <FilterChips
+        items={[{ key: "active", label: "Active", count: 50 }]}
+        selected="active"
+        onSelect={vi.fn()}
+        allCount={50}
+        hideTautologyFacets
+        hideWhenTrivial
+      />,
+    );
+    expect(container.textContent).not.toBe("");
+  });
+
   it("renders without count when chip has no count field", () => {
     renderChips({
       items: [{ key: "all-time", label: "All time" }],

--- a/apps/web/src/components/directory/__tests__/filter-shared.test.ts
+++ b/apps/web/src/components/directory/__tests__/filter-shared.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   filterVisibleFacets,
   formatFacetTextContent,
-} from "../filter-shared";
+} from "@components/directory/filter-shared";
 
 describe("formatFacetTextContent", () => {
   it("returns just the label when count is undefined", () => {

--- a/apps/web/src/components/directory/__tests__/filter-shared.test.ts
+++ b/apps/web/src/components/directory/__tests__/filter-shared.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterVisibleFacets,
+  formatFacetTextContent,
+} from "../filter-shared";
+
+describe("formatFacetTextContent", () => {
+  it("returns just the label when count is undefined", () => {
+    expect(formatFacetTextContent("All")).toBe("All");
+  });
+
+  it("returns 'label (count)' with a real space separator", () => {
+    // Closes QUA-918 — string contains the space text node, not just CSS margin.
+    expect(formatFacetTextContent("Enacted", 18)).toBe("Enacted (18)");
+  });
+
+  it("renders a count of 0 (callers may rely on this for raw access)", () => {
+    expect(formatFacetTextContent("Vetoed", 0)).toBe("Vetoed (0)");
+  });
+
+  it("preserves spaces inside the label", () => {
+    expect(formatFacetTextContent("Convertible Note", 3)).toBe(
+      "Convertible Note (3)",
+    );
+  });
+
+  it("handles big counts unchanged", () => {
+    expect(formatFacetTextContent("Models", 12345)).toBe("Models (12345)");
+  });
+});
+
+describe("filterVisibleFacets", () => {
+  const items = [
+    { key: "a", label: "A", count: 5 },
+    { key: "b", label: "B", count: 0 },
+    { key: "c", label: "C", count: 10 },
+    { key: "d", label: "D" }, // no count
+  ];
+
+  it("drops facets with count === 0 by default", () => {
+    const result = filterVisibleFacets(items, {});
+    expect(result.map((i) => i.key)).toEqual(["a", "c", "d"]);
+  });
+
+  it("keeps facets with no count", () => {
+    const result = filterVisibleFacets(items, {});
+    expect(result).toContainEqual({ key: "d", label: "D" });
+  });
+
+  it("drops tautology facets when hideTautologyFacets is set and total matches", () => {
+    const result = filterVisibleFacets(items, {
+      total: 10,
+      hideTautologyFacets: true,
+    });
+    expect(result.map((i) => i.key)).toEqual(["a", "d"]);
+    expect(result.find((i) => i.key === "c")).toBeUndefined();
+  });
+
+  it("does NOT drop tautology facets when hideTautologyFacets is false", () => {
+    const result = filterVisibleFacets(items, {
+      total: 10,
+      hideTautologyFacets: false,
+    });
+    expect(result.map((i) => i.key)).toEqual(["a", "c", "d"]);
+  });
+
+  it("does nothing tautology-related when total is unset, even if flag is true", () => {
+    const result = filterVisibleFacets(items, { hideTautologyFacets: true });
+    expect(result.map((i) => i.key)).toEqual(["a", "c", "d"]);
+  });
+
+  it("returns empty array when all items are filtered out", () => {
+    const all5 = [
+      { key: "x", label: "X", count: 5 },
+      { key: "y", label: "Y", count: 5 },
+    ];
+    expect(
+      filterVisibleFacets(all5, { total: 5, hideTautologyFacets: true }),
+    ).toEqual([]);
+  });
+
+  it("handles empty input", () => {
+    expect(filterVisibleFacets([], {})).toEqual([]);
+  });
+});

--- a/apps/web/src/components/directory/filter-shared.ts
+++ b/apps/web/src/components/directory/filter-shared.ts
@@ -1,0 +1,47 @@
+// Shared formatting + behavior for directory filter chips and dropdowns (QUA-1009).
+
+export interface FilterFacet {
+  key: string;
+  label: string;
+  count?: number;
+}
+
+/**
+ * Text content for a single facet button/option.
+ *
+ * Always includes a real text-node separator between the label and the count
+ * (a space + parentheses), so screen readers and `textContent` produce
+ * "Enacted (18)" rather than "Enacted18". Closes QUA-918 by construction —
+ * any caller using this helper can't reproduce the bug.
+ */
+export function formatFacetTextContent(label: string, count?: number): string {
+  if (count == null) return label;
+  return `${label} (${count})`;
+}
+
+/**
+ * Filter visible facets per the documented anti-pattern rules (QUA-919):
+ *
+ * - `hideTautologyFacets`: drop chips whose count equals the total — they
+ *   match every row and carry no information ("Active 50/50").
+ * - Always: drop chips with `count === 0` — nothing to filter to.
+ *
+ * `total` is the count for the "All" chip. If unset, only the count===0 rule
+ * applies.
+ */
+export function filterVisibleFacets<T extends FilterFacet>(
+  items: T[],
+  opts: { total?: number; hideTautologyFacets?: boolean },
+): T[] {
+  return items.filter((item) => {
+    if (item.count === 0) return false;
+    if (
+      opts.hideTautologyFacets &&
+      opts.total != null &&
+      item.count === opts.total
+    ) {
+      return false;
+    }
+    return true;
+  });
+}

--- a/apps/web/src/components/directory/index.ts
+++ b/apps/web/src/components/directory/index.ts
@@ -26,6 +26,16 @@ export {
   type FilterChipItem,
   type FilterChipsProps,
 } from "./FilterChips";
+export {
+  DirectoryFilterDropdown,
+  type FilterDropdownItem,
+  type DirectoryFilterDropdownProps,
+} from "./DirectoryFilterDropdown";
+export {
+  formatFacetTextContent,
+  filterVisibleFacets,
+  type FilterFacet,
+} from "./filter-shared";
 export { EntityDataPage } from "./EntityDataPage";
 export {
   DirectoryIndexShell,

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -487,6 +487,18 @@ const PARALLEL_STEPS: Step[] = [
     // see QUA-770 for the migration plan.
   },
   {
+    id: 'no-bespoke-filter-chips',
+    name: 'No new bespoke filter-chip rows (QUA-1009) — use <FilterChips> from @/components/directory',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-no-bespoke-filter-chips.ts'],
+    cwd: PROJECT_ROOT,
+    // Blocking: locks down the QUA-1009 sweep. Bans the
+    // `ml-1 text-[10px] opacity-60` chip-count signature anywhere
+    // outside the canonical components. Annotate per-line with
+    // `// filter-chip-ok: <reason>` for the rare bespoke chip with
+    // genuinely custom UX (see organizations-view.tsx).
+  },
+  {
     id: 'factbase-stableid',
     name: 'FactBase lookups use stableIds (not slugs)',
     command: 'npx',

--- a/crux/validate/validate-no-bespoke-filter-chips.ts
+++ b/crux/validate/validate-no-bespoke-filter-chips.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that no .tsx file under apps/web reintroduces the bespoke
+ * filter-chip pattern that QUA-1009 swept away.
+ *
+ * The bug class (QUA-918): chip-style filter buttons that render
+ *
+ *   <button>
+ *     {label}
+ *     <span className="ml-1 text-[10px] opacity-60">{count}</span>
+ *   </button>
+ *
+ * with no text-node separator. textContent comes out as "Label18" — wrong
+ * for screen readers, copy-paste, and Playwright. The fix is to use
+ * `<FilterChips>` / `<DirectoryFilterDropdown>` from @/components/directory,
+ * which formats labels as "Label (count)" with a real space.
+ *
+ * This validator catches the precise CSS-class signature of the bespoke
+ * pattern: `ml-1 text-[10px] opacity-60`. After the QUA-1009 sweep there
+ * are zero matches in the codebase; any new occurrence is a regression.
+ *
+ * Suppression: append `// filter-chip-ok: <reason>` on the same line, used
+ * by the canonical components themselves and the rare bespoke chip that
+ * legitimately needs custom UX (e.g. /organizations chip with double-click
+ * escalation — see organizations-view.tsx).
+ *
+ * Usage: npx tsx crux/validate/validate-no-bespoke-filter-chips.ts
+ */
+
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, relative } from "path";
+import { PROJECT_ROOT } from "../lib/content-types.ts";
+import { getColors } from "../lib/output.ts";
+
+const SCAN_DIRS = ["apps/web/src"];
+
+const BUG_PATTERN = /ml-1\s+text-\[10px\]\s+opacity-60/;
+
+const SUPPRESSION = "filter-chip-ok";
+
+interface Violation {
+  file: string;
+  line: number;
+  text: string;
+}
+
+function collectTsxFiles(dir: string): string[] {
+  const results: string[] = [];
+
+  function walk(current: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(current);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(current, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      if (stat.isDirectory()) {
+        if (entry === "node_modules" || entry === ".next" || entry === "__tests__") {
+          continue;
+        }
+        walk(fullPath);
+      } else if (entry.endsWith(".tsx") && !entry.endsWith(".test.tsx")) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  walk(dir);
+  return results;
+}
+
+function scanFile(absPath: string): Violation[] {
+  const content = readFileSync(absPath, "utf-8");
+  const lines = content.split("\n");
+  const violations: Violation[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!BUG_PATTERN.test(line)) continue;
+    if (line.includes(SUPPRESSION)) continue;
+    violations.push({
+      file: relative(PROJECT_ROOT, absPath),
+      line: i + 1,
+      text: line.trim(),
+    });
+  }
+
+  return violations;
+}
+
+export function runCheck(): {
+  passed: boolean;
+  errors: string[];
+  violations: Violation[];
+} {
+  const violations: Violation[] = [];
+  for (const dir of SCAN_DIRS) {
+    violations.push(...collectTsxFiles(join(PROJECT_ROOT, dir)).flatMap(scanFile));
+  }
+
+  if (violations.length === 0) {
+    return { passed: true, errors: [], violations: [] };
+  }
+
+  const errors = violations.map(
+    (v) =>
+      `${v.file}:${v.line}: bespoke filter-chip pattern (use <FilterChips> from @/components/directory; if you genuinely need a custom chip, add // filter-chip-ok: <reason>)\n    ${v.text}`,
+  );
+
+  return { passed: false, errors, violations };
+}
+
+function main() {
+  const colors = getColors(process.stdout.isTTY);
+  const result = runCheck();
+
+  if (result.passed) {
+    console.log(
+      `${colors.green}✓${colors.reset} validate-no-bespoke-filter-chips: 0 violations`,
+    );
+    process.exit(0);
+  }
+
+  console.error(
+    `${colors.red}✗${colors.reset} validate-no-bespoke-filter-chips: ${result.violations.length} violation${result.violations.length === 1 ? "" : "s"}`,
+  );
+  for (const err of result.errors) {
+    console.error(`  ${err}`);
+  }
+  console.error(
+    "\nThe bespoke chip pattern produces concatenated text content like 'enacted18'.",
+  );
+  console.error(
+    "Use <FilterChips> from @/components/directory for canonical chips.",
+  );
+  console.error(
+    "Or add `// filter-chip-ok: <reason>` on the offending line if a custom chip is genuinely needed.",
+  );
+  process.exit(1);
+}
+
+if (
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("validate-no-bespoke-filter-chips.ts")
+) {
+  main();
+}


### PR DESCRIPTION
## Summary

Standardizes directory filter UI on two canonical components and fixes the long-tail of `enacted18` / `Convertible Note3` / `Leaderboard2 models` text concatenation bugs by construction.

- **Two canonical components:** `<FilterChips>` (existing, fixed) for ≤8 facets, new `<DirectoryFilterDropdown>` for >8. Both label options as `"Label (count)"` with a real text-node space, so screen readers, copy-paste, and Playwright `textContent` see the separator.
- **Sweep across 11 directory pages:** legislation, funding-rounds, funding-programs, grants, politicians, benchmarks, divisions, research-areas — every bespoke chip row replaced with `<FilterChips>`. Native `<select>`s on `/grants` (data source) and `/research-areas` (status) replaced with `<DirectoryFilterDropdown>`. Plus the standalone `Leaderboard2 models` heading concat bug in `benchmarks/[slug]/page.tsx`.
- **QUA-919 anti-patterns suppressed at the component layer.** New `hideTautologyFacets` + `hideWhenTrivial` props that every sweep call enables — chips with `count === total` (e.g. `Active 50/50` on `/research-areas`) and rows with ≤1 chip after filtering disappear without each page re-implementing the suppression.
- **Lockdown:** `validate-no-bespoke-filter-chips.ts` blocks the `ml-1 text-[10px] opacity-60` chip-count CSS signature anywhere outside the canonical components (0 matches in the codebase post-sweep). Plus a render-audit Playwright assertion that fails any directory page whose filter chips contain `[A-Za-z][0-9]` in `textContent`.

Closes QUA-1009. Folds in QUA-918 + QUA-919 per the umbrella ticket.

Fixes QUA-1009
Fixes QUA-918
Fixes QUA-919

## Acceptance criteria (QUA-1009)

- [x] Audit comment posted before code — see [QUA-1009 comment](https://linear.app/quantifieduncertainty/issue/QUA-1009/standardize-filter-ui-on-directory-tables-chipsdropdowns).
- [x] One canonical chip and one canonical dropdown component (`apps/web/src/components/directory/FilterChips.tsx`, `DirectoryFilterDropdown.tsx`).
- [x] Every directory page uses one of those two, no bespoke filter rows. Sole exception: `organizations-view.tsx` keeps a custom `ChipButton` because of its load-bearing UX (chip click = scroll-to-section, double-click within 8s = escalate to filtered table view) — but its visible text now goes through the shared `formatFacetTextContent` helper, so QUA-918 is closed there too.
- [x] QUA-918 and QUA-919 closed by this ticket.
- [x] Gate validator (`validate-no-bespoke-filter-chips`) in place. Plus render-audit Playwright assertion as a second layer.
- [x] No regressions in existing e2e tests. Full local gate (69 checks) green; 1954 unit tests pass; type-check clean.

## What changed

### New components

- `apps/web/src/components/directory/filter-shared.ts` — `formatFacetTextContent(label, count)` returns `"Label (count)"` and `filterVisibleFacets(items, opts)` drops `count === 0` and (optionally) tautology facets. Single source of truth.
- `apps/web/src/components/directory/DirectoryFilterDropdown.tsx` — wrapper around native `<select>` styled to match `FilterChips`. Same label format, same `hideTautologyFacets` / `hideWhenTrivial` props. Required `ariaLabel`.
- `apps/web/src/components/directory/FilterChips.tsx` — fixed (real text-node space, parens around count). Added `prefix`, `hideTautologyFacets`, `hideWhenTrivial`, `className` props to absorb the patterns the bespoke duplicates were doing.

### Tests added (32)

- `__tests__/filter-shared.test.ts` (12) — formatter and facet-filter behavior, including count=0, tautology, empty input, big counts, labels with internal spaces.
- `__tests__/FilterChips.test.tsx` (13) — `textContent` is `"Label (count)"` not `"Label18"`; aria-label format; click semantics (deselect to "all", click "All" to reset); `prefix` rendering; `hideTautologyFacets` / `hideWhenTrivial`; the explicit `Convertible Note 3` regression case.
- `__tests__/DirectoryFilterDropdown.test.tsx` (7) — option text format, controlled `value`, `onSelect`, hide-on-trivial, prefix.

### Lockdown

- `crux/validate/validate-no-bespoke-filter-chips.ts` — blocking gate validator. Bans the `ml-1 text-[10px] opacity-60` CSS signature outside the canonical components. Suppression: `// filter-chip-ok: <reason>` per-line. Wired into `validate-gate.ts` `parallelChecks`.
- `apps/web/e2e/render-audit.spec.ts` — new `Render audit — filter chip labels have a separator (QUA-1009)` describe block runs against 11 directory pages, fails any chip whose `textContent.match(/[A-Za-z][0-9]/)`.

### Net code change

`14 files changed, 382 insertions(+), 505 deletions(-)` for the migration, plus 6 new files (components, tests, validator, validator wire-up). 11 hand-rolled chip rows collapsed into single calls; the chip + count rendering is no longer copy-pasted anywhere.

## Hostile review (review-done)

Reviewer pass found 0 HIGH, 4 MEDIUM, 5 LOW. Fixed 1 (render-audit regex anchoring — see follow-up commit). Accepted the rest as known-acceptable:

- **Visual: lost per-item colors on `/divisions` By Type and `/research-areas` cluster pills.** Both directories had hand-rolled chips with category-specific background colors (`DIVISION_TYPE_COLORS`, `CLUSTER_COLORS`). The standardization to `FilterChips` produces uniform monochrome pills. Color was decorative, not load-bearing — active state is still visible via the primary-color outline. Future work could add an `itemClassName` prop to `FilterChips` if the colors are missed.
- **UX: `/research-areas` cluster filter gains click-to-deselect.** Original handler was `onClick={() => setClusterFilter(c)}` — clicking the active cluster did nothing. New `FilterChips` resets to "all" on second click. Net improvement (provides a way to reset without going to the All chip), accepted as-is.
- **Tautology hiding edge case.** `hideTautologyFacets` drops chips where `count === total`. If a directory has exactly one facet at 100% (e.g. all rows are `Active`), the chip row hides entirely. Same end result as the pre-existing `funders.length > 1` guards in old code; nothing surprising, but flagged for future tuning if needed.
- **Validator pattern is exact-string.** `validate-no-bespoke-filter-chips` greps for `ml-1 text-[10px] opacity-60` literal. Class-reordering or substituting `ml-2`/`text-xs` would bypass it. Acceptable trade — false positives matter more than catching every theoretical variant. Documented in the validator file.

## Test plan

- [ ] `pnpm build` exits 0 (verified locally).
- [ ] `pnpm test` exits 0 — 1954 tests pass including 32 new tests for the canonical components.
- [ ] `pnpm crux w validate gate` exits 0 — 69 checks pass including the new `validate-no-bespoke-filter-chips` validator.
- [ ] After deploy: `cd apps/web && PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com npx playwright test e2e/render-audit.spec.ts -g "filter chip labels"` — should pass on prod once this PR ships, fails today (intentional — that's what catches the bug).
- [ ] Manual smoke: `/legislation`, `/funding-rounds`, `/grants`, `/research-areas` filter chips show `Status (5)` style labels with parens and a space, not `Status5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced filter components across multiple directories with consistent formatting, improved accessibility, and proper spacing in filter labels.
  * Added dropdown filter option for streamlined filtering on select pages.

* **Bug Fixes**
  * Fixed filter label formatting to prevent unintended text concatenation in chip displays.

* **Tests**
  * Added regression test suite for filter chip label validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->