### PR TITLE
fix(build-data): per-page AbortSignal in paginated fetchers (QUA-1000)

### DIFF
--- a/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
+++ b/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   fetchJsonWithRetry,
   fetchRecordVerdicts,
+  fetchPaginatedItems,
   setFullBuildMode,
 } from '../wiki-server-data.mjs';
 
@@ -348,5 +349,134 @@ describe('fetchRecordVerdicts — QUA-421 strict-mode behavior (QUA-448: no env-
     expect(calls[0]).toContain('offset=0');
     expect(calls[1]).toContain('offset=200');
     expect(calls[2]).toContain('offset=400');
+  });
+});
+
+describe('fetchPaginatedItems — QUA-1000 per-page timeout regression', () => {
+  const noSleep = async () => {};
+
+  it('paginates correctly across multiple full pages', async () => {
+    const mkPage = (start, count) =>
+      Array.from({ length: count }, (_, i) => ({ id: start + i }));
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { items: mkPage(0, 200) } }),
+      mockResponse({ ok: true, json: { items: mkPage(200, 200) } }),
+      mockResponse({ ok: true, json: { items: mkPage(400, 7) } }),
+    ]);
+    const result = await fetchPaginatedItems('http://x/api/grants/all', 'items', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result).toHaveLength(407);
+    expect(calls[0]).toContain('limit=200&offset=0');
+    expect(calls[1]).toContain('limit=200&offset=200');
+    expect(calls[2]).toContain('limit=200&offset=400');
+  });
+
+  it('returns null when a mid-pagination page exhausts retries', async () => {
+    // Matches the legacy contract: callers fall back to YAML-only data on
+    // partial pagination failures rather than ship a half-set.
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { items: Array.from({ length: 200 }, (_, i) => ({ id: i })) } }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+    ]);
+    const result = await fetchPaginatedItems('http://x/api/grants/all', 'items', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('retries transient 5xx within a page and continues', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 500 }), // transient on page 1
+      mockResponse({ ok: true, json: { items: Array.from({ length: 200 }, (_, i) => ({ id: i })) } }),
+      mockResponse({ ok: true, json: { items: [{ id: 200 }] } }), // short page → done
+    ]);
+    const result = await fetchPaginatedItems('http://x/api/grants/all', 'items', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result).toHaveLength(201);
+    expect(calls).toHaveLength(3);
+  });
+
+  it('uses a fresh AbortSignal per page (no shared signal across pages)', async () => {
+    // Pre-QUA-1000, the inner fetchAllPages helper shared one AbortSignal
+    // across every page fetch. Each page must now receive its own signal so
+    // that a slow page doesn't poison subsequent pages with an exhausted budget.
+    const seenSignals = [];
+    const fetcher = async (_url, init) => {
+      seenSignals.push(init.signal);
+      return mockResponse({
+        ok: true,
+        json: { items: seenSignals.length < 3
+          ? Array.from({ length: 200 }, (_, i) => ({ id: i }))
+          : [{ id: 999 }] },
+      });
+    };
+    await fetchPaginatedItems('http://x/api/grants/all', 'items', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(seenSignals).toHaveLength(3);
+    // Each call must have received a *different* AbortSignal instance — that's
+    // the regression we're guarding against. A shared signal would make all
+    // three references identical.
+    const unique = new Set(seenSignals);
+    expect(unique.size).toBe(3);
+  });
+
+  it('does not share AbortSignals across parallel pagination calls', async () => {
+    // The QUA-1000 root cause: 11 parallel paginated fetchers in
+    // mergePGRecordsIntoKB shared one 30s AbortSignal. When the wall-clock
+    // budget elapsed, every in-flight request aborted at once. With
+    // fetchPaginatedItems delegating each page to fetchJsonWithRetry, two
+    // parallel calls must produce fully disjoint signal sets.
+    const callerASignals = [];
+    const callerBSignals = [];
+    const makeFetcher = (sink) => async (_url, init) => {
+      sink.push(init.signal);
+      return mockResponse({ ok: true, json: { items: [{ id: 1 }] } });
+    };
+    await Promise.all([
+      fetchPaginatedItems('http://x/api/grants/all', 'items', {
+        fetchImpl: makeFetcher(callerASignals),
+        sleepImpl: noSleep,
+      }),
+      fetchPaginatedItems('http://x/api/personnel/all', 'items', {
+        fetchImpl: makeFetcher(callerBSignals),
+        sleepImpl: noSleep,
+      }),
+    ]);
+    expect(callerASignals).toHaveLength(1);
+    expect(callerBSignals).toHaveLength(1);
+    // The two calls must have completely disjoint signals; pre-fix they would
+    // have shared the single fetchOpts.signal from line 1464.
+    expect(callerASignals[0]).not.toBe(callerBSignals[0]);
+  });
+
+  it('handles empty first page gracefully', async () => {
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { items: [] } }),
+    ]);
+    const result = await fetchPaginatedItems('http://x/api/grants/all', 'items', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('treats missing itemsKey as empty (does not crash)', async () => {
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { /* no items key */ } }),
+    ]);
+    const result = await fetchPaginatedItems('http://x/api/grants/all', 'items', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result).toEqual([]);
   });
 });

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -203,6 +203,59 @@ export async function fetchJsonWithRetry(url, opts = {}) {
 }
 
 /**
+ * Fetch all pages of a paginated wiki-server endpoint.
+ *
+ * Each page gets its own AbortSignal via {@link fetchJsonWithRetry} — there is
+ * no shared signal across pages or parallel callers, and each page benefits
+ * from the retry helper's exponential-backoff on transient 5xx/429/network
+ * errors. Returns `null` on failure (matches the legacy contract: callers
+ * usually fall back to YAML-only data).
+ *
+ * QUA-1000: pre-fix, the inner `fetchAllPages` helper inside
+ * `mergePGRecordsIntoKB` shared a single 30s `AbortSignal.timeout` across
+ * all 11 parallel paginated fetchers AND across every sequential page fetch
+ * within each fetcher. The 30s timer was a wall-clock budget for the entire
+ * parallel fanout — once it fired, every in-flight request aborted, including
+ * the slowest endpoint (grants), which is what blocked CI.
+ *
+ * @param {string} baseUrl - full URL up to the path; no query string
+ * @param {string} itemsKey - response field containing the array
+ * @param {object} [opts]
+ * @param {number} [opts.pageSize=200]
+ * @param {number} [opts.timeoutMs=60_000] - per-page timeout
+ * @param {HeadersInit} [opts.headers]
+ * @param {typeof fetch} [opts.fetchImpl] - test override
+ * @param {(ms: number) => Promise<void>} [opts.sleepImpl] - test override
+ * @returns {Promise<any[] | null>}
+ */
+export async function fetchPaginatedItems(baseUrl, itemsKey, opts = {}) {
+  const {
+    pageSize = 200,
+    timeoutMs = 60_000,
+    headers,
+    fetchImpl,
+    sleepImpl,
+  } = opts;
+  let allItems = [];
+  let offset = 0;
+  while (true) {
+    const url = `${baseUrl}?limit=${pageSize}&offset=${offset}`;
+    const result = await fetchJsonWithRetry(url, {
+      headers,
+      timeoutMs,
+      fetchImpl,
+      sleepImpl,
+    });
+    if (!result.ok) return null;
+    const items = result.data[itemsKey] || [];
+    allItems = allItems.concat(items);
+    if (items.length < pageSize) break;
+    offset += pageSize;
+  }
+  return allItems;
+}
+
+/**
  * Fetch latest edit dates per page from the wiki-server API.
  * Falls back to an empty map if the server is unavailable.
  */
@@ -599,21 +652,20 @@ export async function fetchResearchAreas() {
   }
 
   const headers = buildHeaders();
-  const fetchOpts = { headers, signal: AbortSignal.timeout(30_000) };
 
   try {
     const pageSize = 200;
     let allItems = [];
     let offset = 0;
     while (true) {
+      // Per-page fresh AbortSignal + retries on transient failures (QUA-1000).
       const url = `${serverUrl}/api/research-areas/enriched?limit=${pageSize}&offset=${offset}`;
-      const resp = await fetch(url, fetchOpts);
-      if (!resp.ok) {
-        logWikiServerWarning('research-areas', `HTTP ${resp.status}`);
+      const result = await fetchJsonWithRetry(url, { headers, timeoutMs: 60_000 });
+      if (!result.ok) {
+        logWikiServerWarning('research-areas', result.reason);
         return [];
       }
-      const data = await resp.json();
-      const items = data.researchAreas || [];
+      const items = result.data.researchAreas || [];
       allItems = allItems.concat(items);
       if (items.length < pageSize) break;
       offset += pageSize;
@@ -1460,28 +1512,8 @@ export async function mergePGRecordsIntoKB(kb) {
 
   if (!kb.records) kb.records = {};
 
-  // Fetch all pages (paginate to avoid truncation at MAX_PAGE_SIZE)
-  const fetchOpts = { headers, signal: AbortSignal.timeout(30_000) };
-
-  /**
-   * Generic paginated fetcher. `itemsKey` is the response field containing the array.
-   */
-  async function fetchAllPages(endpoint, itemsKey) {
-    const pageSize = 200;
-    let allItems = [];
-    let offset = 0;
-    while (true) {
-      const url = `${serverUrl}${endpoint}?limit=${pageSize}&offset=${offset}`;
-      const resp = await fetch(url, fetchOpts);
-      if (!resp.ok) return null;
-      const data = await resp.json();
-      const items = data[itemsKey] || [];
-      allItems = allItems.concat(items);
-      if (items.length < pageSize) break; // last page
-      offset += pageSize;
-    }
-    return allItems;
-  }
+  const fetchAllPages = (endpoint, itemsKey) =>
+    fetchPaginatedItems(`${serverUrl}${endpoint}`, itemsKey, { headers });
 
   const [
     personnelResult,
@@ -1933,7 +1965,6 @@ export async function fetchAllEntityStableIds() {
   const serverUrl = getServerUrl();
   if (!serverUrl) return null;
   const headers = buildHeaders();
-  const fetchOpts = { headers, signal: AbortSignal.timeout(30_000) };
 
   // Dedupe at the source — offset-based pagination + concurrent inserts can
   // return the same row twice or skip rows. The downstream Set-merge in
@@ -1945,18 +1976,18 @@ export async function fetchAllEntityStableIds() {
   let offset = 0;
   try {
     while (true) {
+      // Per-page fresh AbortSignal + retries on transient failures (QUA-1000).
       const url = `${serverUrl}/api/entities?limit=${pageSize}&offset=${offset}`;
-      const resp = await fetch(url, fetchOpts);
-      if (!resp.ok) {
+      const result = await fetchJsonWithRetry(url, { headers, timeoutMs: 60_000 });
+      if (!result.ok) {
         // Mid-pagination failure → return null (matches the surrounding
         // fetchAllPages pattern). Caller falls back to the YAML-only set;
         // partial results would be worse than nothing because validators
         // would mis-flag late-page entities as orphans.
-        logWikiServerWarning('allEntityStableIds', `HTTP ${resp.status} at offset=${offset}`);
+        logWikiServerWarning('allEntityStableIds', `${result.reason} at offset=${offset}`);
         return null;
       }
-      const data = await resp.json();
-      const items = data.entities || [];
+      const items = result.data.entities || [];
       for (const e of items) {
         if (e.stableId) stableIds.add(e.stableId);
       }


### PR DESCRIPTION
## Summary

Fixes [QUA-1000](https://linear.app/quantifieduncertainty/issue/QUA-1000) — `kb-pg grants` build-nextjs timeout that was blocking CI on `main` and every PR.

## Root cause

`mergePGRecordsIntoKB` did:

```js
const fetchOpts = { headers, signal: AbortSignal.timeout(30_000) };
// ...
await Promise.allSettled([
  fetchAllPages('/api/personnel/all', 'personnel'),
  fetchAllPages('/api/grants/all', 'grants'),
  // ... 9 more
]);
```

**One** `AbortSignal` was created and reused across **11 paginated fetchers running in parallel** AND across every sequential page fetch within each fetcher. The 30s timer was a wall-clock budget for the entire parallel fanout — once it fired, every in-flight fetch aborted simultaneously. Grants (largest dataset) was consistently still in flight at t+30s and got cut off.

Same pattern existed in `fetchResearchAreas` and `fetchAllEntityStableIds`.

## Fix

Extracted `fetchPaginatedItems` (top-level, exported, testable) that delegates each page to `fetchJsonWithRetry`. Each page now gets its own `AbortSignal.timeout(60_000)` and inherits the retry helper's exponential-backoff on transient 5xx/429/network errors. Applied to all three callers.

```js
// Before — shared 30s wall-clock signal across 11 parallel fetchers
const fetchOpts = { headers, signal: AbortSignal.timeout(30_000) };
const resp = await fetch(url, fetchOpts);

// After — fresh signal per page
const result = await fetchJsonWithRetry(url, { headers, timeoutMs: 60_000 });
```

## Verification

- `pnpm exec vitest run scripts/lib/__tests__/` — 225 tests pass (including 7 new in `fetch-retry.test.mjs` guarding the regression: per-page fresh signals + no signal sharing across parallel calls).
- `WIKI_SERVER_ENV=prod pnpm sync:data` smoke test — 0 wiki-server warnings, 85 research areas + 13976 verdicts paginated cleanly, build succeeded.

## Follow-up

Filed [QUA-1040](https://linear.app/quantifieduncertainty/issue/QUA-1040) to replace pagination with `/bulk` endpoints — structural fix that removes the failure class entirely.

## Test plan

- [x] `pnpm exec vitest run scripts/lib/__tests__/` — 225 tests pass (17 baseline + 7 new for `fetchPaginatedItems` regression)
- [x] `WIKI_SERVER_ENV=prod pnpm sync:data` smoke test against prod — 0 wiki-server warnings
- [ ] CI `build-nextjs` step succeeds on this PR (this is the fix — verify in the run)

Closes QUA-1000
