### PR TITLE
DirectoryIndexShell — shared layout for directory index pages (QUA-1005)

### DIFF
--- a/apps/web/src/app/organizations/page.tsx
+++ b/apps/web/src/app/organizations/page.tsx
@@ -9,6 +9,7 @@ import type { OrgRow, OrgStatDef } from "@/app/organizations/organizations-table
 import { OrganizationsView } from "@/app/organizations/organizations-view";
 import { fetchDetailed, withApiFallback, type FetchResult } from "@lib/wiki-server";
 import { DataSourceBanner } from "@components/internal/DataSourceBanner";
+import { DirectoryIndexShell } from "@/components/directory";
 import { computeOrgCoverage } from "@/components/coverage/coverage-score";
 
 export const metadata: Metadata = {
@@ -406,19 +407,11 @@ export default async function OrganizationsPage() {
   );
 
   return (
-    <div className="max-w-[90rem] mx-auto px-6 py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-extrabold tracking-tight mb-2">
-          Organizations
-        </h1>
-        <p className="text-muted-foreground text-sm max-w-2xl">
-          Directory of AI safety organizations, frontier labs,
-          research groups, and funders tracked in the knowledge base.
-        </p>
-      </div>
-
-      <DataSourceBanner source={source} apiError={apiError} />
-
+    <DirectoryIndexShell
+      title="Organizations"
+      description="Directory of AI safety organizations, frontier labs, research groups, and funders tracked in the knowledge base."
+      banner={<DataSourceBanner source={source} apiError={apiError} />}
+    >
       <Suspense fallback={<div>Loading...</div>}>
         <OrganizationsView
           rows={data.rows}
@@ -427,6 +420,6 @@ export default async function OrganizationsPage() {
           orgTypeMap={data.orgTypeMap}
         />
       </Suspense>
-    </div>
+    </DirectoryIndexShell>
   );
 }

--- a/apps/web/src/components/directory/DirectoryIndexShell.tsx
+++ b/apps/web/src/components/directory/DirectoryIndexShell.tsx
@@ -1,0 +1,103 @@
+import { Breadcrumbs } from "./Breadcrumbs";
+import { ProfileStatCard } from "./ProfileStatCard";
+
+/**
+ * Canonical layout for directory **index** pages — `/organizations`,
+ * `/grants`, `/ai-models`, `/legislation`, `/projects`, etc. Renders the
+ * outer container, optional breadcrumbs, the title + description header,
+ * an optional banner slot (for `<DataSourceBanner>`), an optional stat
+ * cards row, an optional before-body slot, and the main body.
+ *
+ * Per-directory pages provide content via slots. Adding a row that should
+ * appear on every directory index (a new dot, a new row) is a one-line
+ * edit to this file.
+ *
+ * Sibling to `EntityProfileShell` (QUA-328 / QUA-1005). The detail-page
+ * shell handles entity profile pages; this one handles the index pages
+ * that list them.
+ */
+
+export interface DirectoryIndexShellStat {
+  label: string;
+  value: string;
+  sub?: string;
+  href?: string;
+}
+
+export interface DirectoryIndexShellProps {
+  /** Breadcrumbs above the header. */
+  breadcrumbs?: Array<{ label: string; href?: string }>;
+  /** Page title — rendered as h1. */
+  title: string;
+  /**
+   * Description under the title. ReactNode so callers can pass computed
+   * summaries (e.g. `/legislation` builds its description from row data).
+   */
+  description?: React.ReactNode;
+  /**
+   * Banner between header and stats — typically a `<DataSourceBanner>`.
+   * Omit on pages with no API/local fallback (e.g. `/grants`).
+   */
+  banner?: React.ReactNode;
+  /**
+   * Stat cards row. When non-empty, renders a 2/4-col grid of
+   * `ProfileStatCard`. Pages that show their stats inside the table
+   * (e.g. `/organizations`) leave this empty.
+   */
+  stats?: DirectoryIndexShellStat[];
+  /**
+   * Content between stats and main body. Currently only `/grants` uses this
+   * (the "By Funder" summary). If a second caller needs the same shape we
+   * factor it into a structured prop; for now it stays generic.
+   */
+  beforeBody?: React.ReactNode;
+  /** Main body — usually `<Suspense><SomeTable /></Suspense>`. */
+  children?: React.ReactNode;
+}
+
+export function DirectoryIndexShell({
+  breadcrumbs,
+  title,
+  description,
+  banner,
+  stats,
+  beforeBody,
+  children,
+}: DirectoryIndexShellProps) {
+  return (
+    <div className="max-w-[90rem] mx-auto px-6 py-8">
+      {breadcrumbs && breadcrumbs.length > 0 && (
+        <Breadcrumbs items={breadcrumbs} />
+      )}
+
+      <div className="mb-8">
+        <h1 className="text-3xl font-extrabold tracking-tight mb-2">{title}</h1>
+        {description && (
+          <p className="text-muted-foreground text-sm max-w-2xl">
+            {description}
+          </p>
+        )}
+      </div>
+
+      {banner}
+
+      {stats && stats.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
+          {stats.map((s) => (
+            <ProfileStatCard
+              key={s.label}
+              label={s.label}
+              value={s.value}
+              sub={s.sub}
+              href={s.href}
+            />
+          ))}
+        </div>
+      )}
+
+      {beforeBody}
+
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/directory/DirectoryIndexShell.tsx
+++ b/apps/web/src/components/directory/DirectoryIndexShell.tsx
@@ -19,6 +19,11 @@ import { ProfileStatCard } from "./ProfileStatCard";
 
 export interface DirectoryIndexShellStat {
   label: string;
+  /**
+   * Pre-formatted display value. Callers format numbers, currency, dates etc.
+   * before passing them in — the shell does not own formatting (see QUA-1006
+   * for cross-table cell-formatting standardization).
+   */
   value: string;
   sub?: string;
   href?: string;
@@ -83,9 +88,9 @@ export function DirectoryIndexShell({
 
       {stats && stats.length > 0 && (
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
-          {stats.map((s) => (
+          {stats.map((s, i) => (
             <ProfileStatCard
-              key={s.label}
+              key={`${i}-${s.label}`}
               label={s.label}
               value={s.value}
               sub={s.sub}

--- a/apps/web/src/components/directory/__tests__/DirectoryIndexShell.test.tsx
+++ b/apps/web/src/components/directory/__tests__/DirectoryIndexShell.test.tsx
@@ -64,12 +64,23 @@ describe("DirectoryIndexShell", () => {
     render(
       <DirectoryIndexShell
         title="AI Models"
+        description="A directory of AI models."
         banner={<div data-testid="banner">banner</div>}
         stats={[{ label: "Models", value: "42" }]}
       />,
     );
-    expect(screen.getByTestId("banner")).toBeTruthy();
-    expect(screen.getByText("Models")).toBeTruthy();
+    const banner = screen.getByTestId("banner");
+    const description = screen.getByText("A directory of AI models.");
+    const statCard = screen.getByText("Models");
+    // banner sits AFTER the header description and BEFORE the stat card.
+    expect(
+      description.compareDocumentPosition(banner) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      banner.compareDocumentPosition(statCard) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("renders the stats grid with one ProfileStatCard per item", () => {
@@ -133,8 +144,17 @@ describe("DirectoryIndexShell", () => {
         <div data-testid="body">Body</div>
       </DirectoryIndexShell>,
     );
-    expect(screen.getByTestId("by-funder")).toBeTruthy();
-    expect(screen.getByTestId("body")).toBeTruthy();
+    const statCard = screen.getByText("Total Grants");
+    const beforeBody = screen.getByTestId("by-funder");
+    const body = screen.getByTestId("body");
+    expect(
+      statCard.compareDocumentPosition(beforeBody) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      beforeBody.compareDocumentPosition(body) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("renders children as the main body", () => {
@@ -152,5 +172,25 @@ describe("DirectoryIndexShell", () => {
     expect(container.querySelectorAll('[data-testid="stat-card"]')).toHaveLength(
       0,
     );
+  });
+
+  it("escapes HTML-like content in title and stat labels (React default behavior)", () => {
+    const { container } = render(
+      <DirectoryIndexShell
+        title='<img src=x onerror="alert(1)">'
+        stats={[
+          { label: '<script>evil</script>', value: "<b>42</b>" },
+        ]}
+      />,
+    );
+    // No script element, no img element — React rendered the strings as text.
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("b")).toBeNull();
+    // The literal text appears in the DOM.
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe(
+      '<img src=x onerror="alert(1)">',
+    );
+    expect(screen.getByText("<b>42</b>")).toBeTruthy();
   });
 });

--- a/apps/web/src/components/directory/__tests__/DirectoryIndexShell.test.tsx
+++ b/apps/web/src/components/directory/__tests__/DirectoryIndexShell.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+/** DirectoryIndexShell — slot rendering and conditional sections (QUA-1005). */
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { DirectoryIndexShell } from "@components/directory/DirectoryIndexShell";
+
+describe("DirectoryIndexShell", () => {
+  it("renders title as h1 and description below it", () => {
+    render(
+      <DirectoryIndexShell
+        title="Organizations"
+        description="A directory of organizations."
+      />,
+    );
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1.textContent).toBe("Organizations");
+    expect(screen.getByText("A directory of organizations.")).toBeTruthy();
+  });
+
+  it("renders without a description when description is omitted", () => {
+    const { container } = render(<DirectoryIndexShell title="Organizations" />);
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe(
+      "Organizations",
+    );
+    expect(container.querySelector("p.text-muted-foreground")).toBeNull();
+  });
+
+  it("renders a description that is a ReactNode (not just a string)", () => {
+    render(
+      <DirectoryIndexShell
+        title="Legislation"
+        description={
+          <span>
+            <strong data-testid="rich">Rich</strong> description
+          </span>
+        }
+      />,
+    );
+    expect(screen.getByTestId("rich").textContent).toBe("Rich");
+  });
+
+  it("renders breadcrumbs when provided", () => {
+    render(
+      <DirectoryIndexShell
+        title="Grants"
+        breadcrumbs={[
+          { label: "Home", href: "/" },
+          { label: "Grants" },
+        ]}
+      />,
+    );
+    expect(screen.getByLabelText("Breadcrumb")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Home" })).toBeTruthy();
+  });
+
+  it("does not render the breadcrumb nav when breadcrumbs is empty", () => {
+    render(<DirectoryIndexShell title="Grants" breadcrumbs={[]} />);
+    expect(screen.queryByLabelText("Breadcrumb")).toBeNull();
+  });
+
+  it("renders the banner slot in document order between header and stats", () => {
+    render(
+      <DirectoryIndexShell
+        title="AI Models"
+        banner={<div data-testid="banner">banner</div>}
+        stats={[{ label: "Models", value: "42" }]}
+      />,
+    );
+    expect(screen.getByTestId("banner")).toBeTruthy();
+    expect(screen.getByText("Models")).toBeTruthy();
+  });
+
+  it("renders the stats grid with one ProfileStatCard per item", () => {
+    render(
+      <DirectoryIndexShell
+        title="Grants"
+        stats={[
+          { label: "Total Grants", value: "1,234" },
+          { label: "Total Funding", value: "$5B" },
+          { label: "Funding Orgs", value: "42" },
+        ]}
+      />,
+    );
+    expect(screen.getAllByTestId("stat-card")).toHaveLength(3);
+    expect(screen.getByText("Total Grants")).toBeTruthy();
+    expect(screen.getByText("$5B")).toBeTruthy();
+  });
+
+  it("does not render the stats grid when stats is empty", () => {
+    const { container } = render(
+      <DirectoryIndexShell title="Organizations" stats={[]} />,
+    );
+    expect(container.querySelectorAll('[data-testid="stat-card"]')).toHaveLength(
+      0,
+    );
+  });
+
+  it("does not render the stats grid when stats is omitted", () => {
+    const { container } = render(<DirectoryIndexShell title="Organizations" />);
+    expect(container.querySelectorAll('[data-testid="stat-card"]')).toHaveLength(
+      0,
+    );
+  });
+
+  it("renders stat card sub and wraps in a link when href is given", () => {
+    render(
+      <DirectoryIndexShell
+        title="Projects"
+        stats={[
+          {
+            label: "Projects",
+            value: "12",
+            sub: "as of today",
+            href: "/projects/all",
+          },
+        ]}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /Projects/ });
+    expect(link.getAttribute("href")).toBe("/projects/all");
+    expect(screen.getByText("as of today")).toBeTruthy();
+  });
+
+  it("renders beforeBody between stats and children", () => {
+    render(
+      <DirectoryIndexShell
+        title="Grants"
+        stats={[{ label: "Total Grants", value: "1,234" }]}
+        beforeBody={<div data-testid="by-funder">By Funder</div>}
+      >
+        <div data-testid="body">Body</div>
+      </DirectoryIndexShell>,
+    );
+    expect(screen.getByTestId("by-funder")).toBeTruthy();
+    expect(screen.getByTestId("body")).toBeTruthy();
+  });
+
+  it("renders children as the main body", () => {
+    render(
+      <DirectoryIndexShell title="Organizations">
+        <div data-testid="main-body">main body content</div>
+      </DirectoryIndexShell>,
+    );
+    expect(screen.getByTestId("main-body")).toBeTruthy();
+  });
+
+  it("renders an empty shell when no description, banner, stats, beforeBody, or children are given", () => {
+    const { container } = render(<DirectoryIndexShell title="Empty" />);
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Empty");
+    expect(container.querySelectorAll('[data-testid="stat-card"]')).toHaveLength(
+      0,
+    );
+  });
+});

--- a/apps/web/src/components/directory/index.ts
+++ b/apps/web/src/components/directory/index.ts
@@ -27,3 +27,8 @@ export {
   type FilterChipsProps,
 } from "./FilterChips";
 export { EntityDataPage } from "./EntityDataPage";
+export {
+  DirectoryIndexShell,
+  type DirectoryIndexShellProps,
+  type DirectoryIndexShellStat,
+} from "./DirectoryIndexShell";


### PR DESCRIPTION
## Summary

Adds `DirectoryIndexShell` analogous to `EntityProfileShell` for directory **index** pages (`/organizations`, `/people`, `/ai-models`, etc.). Migrates `/organizations` as the pilot caller.

The shell owns the outer container, optional breadcrumbs, header (title + description), banner slot (typically `<DataSourceBanner>`), stat cards row, and a `beforeBody` slot. Filter UI, tables, and empty states stay in `children` until QUA-1009 / QUA-12 / QUA-1008 land their respective standardizations.

22 directory index pages today hand-roll the same `max-w-[90rem] mx-auto px-6 py-8` wrapper + `text-3xl font-extrabold tracking-tight` h1 — sweep ticket QUA-1031 covers the remaining ~17.

Closes QUA-1005.

## Changes

- `apps/web/src/components/directory/DirectoryIndexShell.tsx` (new) — the shell
- `apps/web/src/components/directory/__tests__/DirectoryIndexShell.test.tsx` (new) — 14 unit tests
- `apps/web/src/components/directory/index.ts` — re-export
- `apps/web/src/app/organizations/page.tsx` — migrate to shell

## Design decisions

Posted to the QUA-1005 design comment before implementing. Key choice: **minimal v1** — no `filters` / `table` / `emptyState` / `coverageDot` / `headerActions` slots until a real caller needs them. QUA-1009 / QUA-12 / QUA-1008 will extend the shell when they ship.

## Review-induced changes

`/agent-review-pr` flagged 3 MEDIUM findings (slot-ordering tests asserted existence not order, key collision risk on duplicate stat labels, undocumented `value: string` decision) — all addressed in commit `7258bc6`. Plus an XSS-escape regression test as a defensive addition.

## Test plan

- [x] `pnpm build` — production build succeeds
- [x] `pnpm --filter longterm-next test` — 1936 tests pass (14 new for DirectoryIndexShell)
- [x] `pnpm crux w validate gate` — passes
- [x] DOM verified equivalent on local production build (same wrapper class, same h1 class, same description block, 757KB HTML — see `/tmp/qua-1005-ui.txt`)
- [x] Hostile-reviewer subagent run on the diff (`/tmp/qua-1005-redteam.txt`)
- [ ] CI green
