### PR TITLE
QUA-1012: pipeline_runs cost telemetry columns

### DIFF
--- a/apps/wiki-server/drizzle/0223_qua_1012_pipeline_runs_cost_columns.sql
+++ b/apps/wiki-server/drizzle/0223_qua_1012_pipeline_runs_cost_columns.sql
@@ -8,9 +8,12 @@
 -- improve pipeline, #3 = wire the source-check pipeline) start
 -- populating these.
 --
--- - `cost_usd numeric(10,4)` — dollars-and-tenths-of-a-cent precision.
---   Wide enough for a single $999,999.9999 run; aggregating across runs
---   uses SUM() into a wider numeric in the dashboard query.
+-- - `cost_usd numeric(10,4)` — 4 decimal places (hundredths-of-a-cent
+--   precision). Max storable value is $999,999.9999, but the API caps
+--   single-run cost at $10,000 (`MAX_COST_USD` in api-types.ts) — the
+--   column is intentionally over-provisioned vs the cap so the cap can
+--   move without a column-widening migration. Aggregates across runs
+--   use SUM() into a wider numeric in the dashboard query.
 -- - `tokens_*` are integer (signed 32-bit, max ~2.1B). Single-run token
 --   counts are far below that ceiling — Anthropic's 200k context cap
 --   bounds a single call's input tokens, and even a long multi-call

--- a/apps/wiki-server/drizzle/0223_qua_1012_pipeline_runs_cost_columns.sql
+++ b/apps/wiki-server/drizzle/0223_qua_1012_pipeline_runs_cost_columns.sql
@@ -1,0 +1,32 @@
+-- QUA-1012 (parent QUA-1011): pipeline_runs cost telemetry columns.
+--
+-- Adds nullable cost / token-count columns so pipelines can attribute
+-- their LLM spend to a run on the /internal/pipeline-runs dashboard.
+-- All five columns are nullable: existing rows have no telemetry, and
+-- pipelines that don't track cost (or fail before they can attribute)
+-- continue to land NULL. Subsequent QUA-1011 children (#2 = wire the
+-- improve pipeline, #3 = wire the source-check pipeline) start
+-- populating these.
+--
+-- - `cost_usd numeric(10,4)` — dollars-and-tenths-of-a-cent precision.
+--   Wide enough for a single $999,999.9999 run; aggregating across runs
+--   uses SUM() into a wider numeric in the dashboard query.
+-- - `tokens_*` are integer (signed 32-bit, max ~2.1B). Single-run token
+--   counts are far below that ceiling — Anthropic's 200k context cap
+--   bounds a single call's input tokens, and even a long multi-call
+--   pipeline lands well under 1B total. bigint would be overkill.
+-- - All columns are NULL-default; no backfill needed (no caller writes
+--   them yet — they start populating in QUA-1011 children).
+-- - Pipeline_runs table just shipped in 0222 (QUA-954). Row count is
+--   small / zero on most environments, so plain ADD COLUMN is fine —
+--   no NOT VALID dance, no batched UPDATE.
+-- - Audit trigger from 0222 (apply_audit_trigger) automatically picks
+--   up the new columns; per-row UPDATE writes already capture them in
+--   `full_audit_log`.
+
+ALTER TABLE "pipeline_runs"
+  ADD COLUMN IF NOT EXISTS "cost_usd"            numeric(10,4),
+  ADD COLUMN IF NOT EXISTS "tokens_input"        integer,
+  ADD COLUMN IF NOT EXISTS "tokens_output"       integer,
+  ADD COLUMN IF NOT EXISTS "tokens_cache_read"   integer,
+  ADD COLUMN IF NOT EXISTS "tokens_cache_write"  integer;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1555,6 +1555,13 @@
       "when": 1788000000000,
       "tag": "0222_qua_954_pipeline_runs",
       "breakpoints": true
+    },
+    {
+      "idx": 223,
+      "version": "7",
+      "when": 1788000100000,
+      "tag": "0223_qua_1012_pipeline_runs_cost_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/pipeline-runs.test.ts
+++ b/apps/wiki-server/src/__tests__/pipeline-runs.test.ts
@@ -609,19 +609,152 @@ describe("PATCH /api/pipeline-runs/:id/end", () => {
     expect(res.status).toBe(400);
   });
 
-  it("rejects non-integer token counts", async () => {
+  it("rejects non-integer token counts on every token field", async () => {
+    const app = buildApp();
+    const fields = [
+      "tokensInput",
+      "tokensOutput",
+      "tokensCacheRead",
+      "tokensCacheWrite",
+    ] as const;
+    for (const field of fields) {
+      const runId = `frac-${field}`;
+      await postJson(app, "/api/pipeline-runs", {
+        runId,
+        pipelineName: "improve-page",
+      });
+      const res = await app.request(`/api/pipeline-runs/${runId}/end`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "committed", [field]: 1.5 }),
+      });
+      expect(res.status, `${field} should reject 1.5`).toBe(400);
+    }
+  });
+
+  it("rejects negative values on every token field", async () => {
+    const app = buildApp();
+    const fields = [
+      "tokensInput",
+      "tokensOutput",
+      "tokensCacheRead",
+      "tokensCacheWrite",
+    ] as const;
+    for (const field of fields) {
+      const runId = `neg-${field}`;
+      await postJson(app, "/api/pipeline-runs", {
+        runId,
+        pipelineName: "improve-page",
+      });
+      const res = await app.request(`/api/pipeline-runs/${runId}/end`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "committed", [field]: -1 }),
+      });
+      expect(res.status, `${field} should reject -1`).toBe(400);
+    }
+  });
+
+  it("rejects token counts above MAX_TOKENS cap (overflow guard)", async () => {
     const app = buildApp();
     await postJson(app, "/api/pipeline-runs", {
-      runId: "frac-001",
+      runId: "huge-tokens-001",
+      pipelineName: "improve-page",
+    });
+    const res = await app.request("/api/pipeline-runs/huge-tokens-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      // 2_000_000_001 — one over the documented cap.
+      body: JSON.stringify({ status: "committed", tokensInput: 2_000_000_001 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects costUsd with more than 4 decimal places (column is numeric(10,4))", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "precision-001",
+      pipelineName: "improve-page",
+    });
+    const res = await app.request("/api/pipeline-runs/precision-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "committed", costUsd: 1.23456 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("preserves prior cost telemetry on retry that omits the fields (idempotent /end)", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "retry-001",
       pipelineName: "improve-page",
     });
 
-    const res = await app.request("/api/pipeline-runs/frac-001/end", {
+    // First end — record cost + tokens. Use partial_failure so a retry
+    // is semantically motivated.
+    const r1 = await app.request("/api/pipeline-runs/retry-001/end", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ status: "committed", tokensInput: 1.5 }),
+      body: JSON.stringify({
+        status: "partial_failure",
+        costUsd: 2.5,
+        tokensInput: 100,
+        tokensOutput: 50,
+      }),
     });
-    expect(res.status).toBe(400);
+    expect(r1.status).toBe(200);
+    expect(runStore[0].costUsd).toBe("2.5");
+    expect(runStore[0].tokensInput).toBe(100);
+    expect(runStore[0].tokensOutput).toBe(50);
+
+    // Second end — caller retried, succeeded, but didn't re-send cost.
+    // The conditional spread must NOT clobber the previously-recorded
+    // values with NULL.
+    const r2 = await app.request("/api/pipeline-runs/retry-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "committed" }),
+    });
+    expect(r2.status).toBe(200);
+    expect(runStore[0].status).toBe("committed");
+    expect(runStore[0].costUsd).toBe("2.5");
+    expect(runStore[0].tokensInput).toBe(100);
+    expect(runStore[0].tokensOutput).toBe(50);
+  });
+
+  it("explicit null overwrites prior cost telemetry (caller actively cleared)", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "clear-001",
+      pipelineName: "improve-page",
+    });
+
+    await app.request("/api/pipeline-runs/clear-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: "partial_failure",
+        costUsd: 1.5,
+        tokensInput: 200,
+      }),
+    });
+    expect(runStore[0].costUsd).toBe("1.5");
+
+    // Caller explicitly nulls cost on the second /end — distinct from
+    // omitting (which would preserve).
+    const r2 = await app.request("/api/pipeline-runs/clear-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: "committed",
+        costUsd: null,
+        tokensInput: null,
+      }),
+    });
+    expect(r2.status).toBe(200);
+    expect(runStore[0].costUsd).toBeNull();
+    expect(runStore[0].tokensInput).toBeNull();
   });
 });
 

--- a/apps/wiki-server/src/__tests__/pipeline-runs.test.ts
+++ b/apps/wiki-server/src/__tests__/pipeline-runs.test.ts
@@ -54,6 +54,11 @@ function rowToSql(r: Row): Record<string, unknown> {
     error_code: r.errorCode,
     error_payload: r.errorPayload,
     followup_actions: r.followupActions,
+    cost_usd: r.costUsd,
+    tokens_input: r.tokensInput,
+    tokens_output: r.tokensOutput,
+    tokens_cache_read: r.tokensCacheRead,
+    tokens_cache_write: r.tokensCacheWrite,
     created_at: r.createdAt,
     updated_at: r.updatedAt,
   };
@@ -107,6 +112,11 @@ const dispatch: SqlDispatcher = (query, params) => {
       error_code: "errorCode",
       error_payload: "errorPayload",
       followup_actions: "followupActions",
+      cost_usd: "costUsd",
+      tokens_input: "tokensInput",
+      tokens_output: "tokensOutput",
+      tokens_cache_read: "tokensCacheRead",
+      tokens_cache_write: "tokensCacheWrite",
       created_at: "createdAt",
       updated_at: "updatedAt",
     };
@@ -127,6 +137,11 @@ const dispatch: SqlDispatcher = (query, params) => {
       errorCode: null,
       errorPayload: null,
       followupActions: [],
+      costUsd: null,
+      tokensInput: null,
+      tokensOutput: null,
+      tokensCacheRead: null,
+      tokensCacheWrite: null,
       createdAt: now,
       updatedAt: now,
     };
@@ -201,6 +216,11 @@ const dispatch: SqlDispatcher = (query, params) => {
       error_code: "errorCode",
       error_payload: "errorPayload",
       followup_actions: "followupActions",
+      cost_usd: "costUsd",
+      tokens_input: "tokensInput",
+      tokens_output: "tokensOutput",
+      tokens_cache_read: "tokensCacheRead",
+      tokens_cache_write: "tokensCacheWrite",
       created_at: "createdAt",
       updated_at: "updatedAt",
     };
@@ -497,6 +517,111 @@ describe("PATCH /api/pipeline-runs/:id/end", () => {
       body: JSON.stringify({ status: "committed" }),
     });
     expect(res.status).toBe(404);
+  });
+
+  it("persists costUsd + token counts when supplied (QUA-1012)", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "cost-001",
+      pipelineName: "improve-page",
+    });
+
+    const res = await app.request("/api/pipeline-runs/cost-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: "committed",
+        costUsd: 1.2345,
+        tokensInput: 1000,
+        tokensOutput: 500,
+        tokensCacheRead: 800,
+        tokensCacheWrite: 200,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    // numeric() returns the value as a string (Drizzle convention).
+    expect(body.costUsd).toBe("1.2345");
+    expect(body.tokensInput).toBe(1000);
+    expect(body.tokensOutput).toBe(500);
+    expect(body.tokensCacheRead).toBe(800);
+    expect(body.tokensCacheWrite).toBe(200);
+    // Verify the row was actually mutated (defends against the test
+    // dispatcher silently ignoring an unknown SET column).
+    expect(runStore[0].costUsd).toBe("1.2345");
+    expect(runStore[0].tokensInput).toBe(1000);
+  });
+
+  it("leaves cost telemetry NULL when omitted from end body", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "no-cost-001",
+      pipelineName: "improve-page",
+    });
+
+    const res = await app.request("/api/pipeline-runs/no-cost-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "committed" }),
+    });
+    expect(res.status).toBe(200);
+    expect(runStore[0].costUsd).toBeNull();
+    expect(runStore[0].tokensInput).toBeNull();
+    expect(runStore[0].tokensOutput).toBeNull();
+    expect(runStore[0].tokensCacheRead).toBeNull();
+    expect(runStore[0].tokensCacheWrite).toBeNull();
+  });
+
+  it("rejects negative costUsd / token counts", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "neg-001",
+      pipelineName: "improve-page",
+    });
+
+    const r1 = await app.request("/api/pipeline-runs/neg-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "committed", costUsd: -0.01 }),
+    });
+    expect(r1.status).toBe(400);
+
+    const r2 = await app.request("/api/pipeline-runs/neg-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "committed", tokensInput: -1 }),
+    });
+    expect(r2.status).toBe(400);
+  });
+
+  it("rejects costUsd over the 10k cap (overflow guard)", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "huge-cost-001",
+      pipelineName: "improve-page",
+    });
+
+    const res = await app.request("/api/pipeline-runs/huge-cost-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "committed", costUsd: 10_001 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-integer token counts", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "frac-001",
+      pipelineName: "improve-page",
+    });
+
+    const res = await app.request("/api/pipeline-runs/frac-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "committed", tokensInput: 1.5 }),
+    });
+    expect(res.status).toBe(400);
   });
 });
 

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1617,6 +1617,13 @@ export const StartPipelineRunSchema = z.object({
 });
 export type StartPipelineRun = z.infer<typeof StartPipelineRunSchema>;
 
+// QUA-1012: cost-telemetry caps. costUsd is bounded well above any
+// realistic single-run spend ($10k) so a buggy CostTracker can't post
+// a billion-dollar value into prod; token counts are bounded below
+// signed-int32 max so the integer column never overflows.
+const MAX_COST_USD = 10_000;
+const MAX_TOKENS = 2_000_000_000;
+
 export const EndPipelineRunSchema = z.object({
   status: PipelineRunEndStatusSchema,
   failureReason: z.string().max(200).nullable().optional(),
@@ -1624,6 +1631,11 @@ export const EndPipelineRunSchema = z.object({
   errorPayload: BoundedJsonObjectSchema.nullable().optional(),
   snapshotPath: z.string().max(500).nullable().optional(),
   followupActions: z.array(BoundedFollowupSchema).max(MAX_FOLLOWUPS_COUNT).optional(),
+  costUsd: z.number().nonnegative().finite().max(MAX_COST_USD).nullable().optional(),
+  tokensInput: z.number().int().nonnegative().max(MAX_TOKENS).nullable().optional(),
+  tokensOutput: z.number().int().nonnegative().max(MAX_TOKENS).nullable().optional(),
+  tokensCacheRead: z.number().int().nonnegative().max(MAX_TOKENS).nullable().optional(),
+  tokensCacheWrite: z.number().int().nonnegative().max(MAX_TOKENS).nullable().optional(),
 });
 export type EndPipelineRun = z.infer<typeof EndPipelineRunSchema>;
 

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1621,8 +1621,23 @@ export type StartPipelineRun = z.infer<typeof StartPipelineRunSchema>;
 // realistic single-run spend ($10k) so a buggy CostTracker can't post
 // a billion-dollar value into prod; token counts are bounded below
 // signed-int32 max so the integer column never overflows.
-const MAX_COST_USD = 10_000;
-const MAX_TOKENS = 2_000_000_000;
+//
+// Exported so the typed client (and any other caller) can reference the
+// canonical cap rather than re-stating the literal in JSDoc, where it
+// silently drifts when the cap moves.
+export const MAX_COST_USD = 10_000;
+export const MAX_TOKENS = 2_000_000_000;
+
+// Shared chain so a refactor that drops `.int()` from one field can't
+// silently weaken validation on the other three.
+const TokenCountSchema = z
+  .number()
+  .int()
+  .nonnegative()
+  .finite()
+  .max(MAX_TOKENS)
+  .nullable()
+  .optional();
 
 export const EndPipelineRunSchema = z.object({
   status: PipelineRunEndStatusSchema,
@@ -1631,11 +1646,25 @@ export const EndPipelineRunSchema = z.object({
   errorPayload: BoundedJsonObjectSchema.nullable().optional(),
   snapshotPath: z.string().max(500).nullable().optional(),
   followupActions: z.array(BoundedFollowupSchema).max(MAX_FOLLOWUPS_COUNT).optional(),
-  costUsd: z.number().nonnegative().finite().max(MAX_COST_USD).nullable().optional(),
-  tokensInput: z.number().int().nonnegative().max(MAX_TOKENS).nullable().optional(),
-  tokensOutput: z.number().int().nonnegative().max(MAX_TOKENS).nullable().optional(),
-  tokensCacheRead: z.number().int().nonnegative().max(MAX_TOKENS).nullable().optional(),
-  tokensCacheWrite: z.number().int().nonnegative().max(MAX_TOKENS).nullable().optional(),
+  // `0` is a valid cost (the caller tracked spend and it really was zero).
+  // `null` / omitted means "not tracked" — distinct semantics. Aggregates in
+  // the dashboard use `SUM(cost_usd)` which treats both NULL and 0 as 0, but
+  // count-of-tracked-runs queries should filter `WHERE cost_usd IS NOT NULL`.
+  // `.multipleOf(0.0001)` rejects values with more precision than the
+  // numeric(10,4) column can store, so what the caller submits is what gets
+  // persisted (no silent PG-side rounding that returns a different value).
+  costUsd: z
+    .number()
+    .nonnegative()
+    .finite()
+    .max(MAX_COST_USD)
+    .multipleOf(0.0001)
+    .nullable()
+    .optional(),
+  tokensInput: TokenCountSchema,
+  tokensOutput: TokenCountSchema,
+  tokensCacheRead: TokenCountSchema,
+  tokensCacheWrite: TokenCountSchema,
 });
 export type EndPipelineRun = z.infer<typeof EndPipelineRunSchema>;
 

--- a/apps/wiki-server/src/routes/operational/pipeline-runs.ts
+++ b/apps/wiki-server/src/routes/operational/pipeline-runs.ts
@@ -254,6 +254,23 @@ const pipelineRunsApp = new Hono()
           ...(d.followupActions !== undefined
             ? { followupActions: d.followupActions }
             : {}),
+          // QUA-1012 cost telemetry. Drizzle's `numeric` column expects
+          // a string on write; integer columns take the number directly.
+          // Only set when the caller passed the field — undefined means
+          // "leave the existing value alone" (existing value is NULL on
+          // first end, but a partial-failure → retry → end-again caller
+          // shouldn't overwrite a previously-recorded cost with NULL).
+          ...(d.costUsd !== undefined
+            ? { costUsd: d.costUsd === null ? null : String(d.costUsd) }
+            : {}),
+          ...(d.tokensInput !== undefined ? { tokensInput: d.tokensInput } : {}),
+          ...(d.tokensOutput !== undefined ? { tokensOutput: d.tokensOutput } : {}),
+          ...(d.tokensCacheRead !== undefined
+            ? { tokensCacheRead: d.tokensCacheRead }
+            : {}),
+          ...(d.tokensCacheWrite !== undefined
+            ? { tokensCacheWrite: d.tokensCacheWrite }
+            : {}),
         })
         .where(eq(pipelineRuns.runId, id))
         .returning();

--- a/apps/wiki-server/src/routes/operational/pipeline-runs.ts
+++ b/apps/wiki-server/src/routes/operational/pipeline-runs.ts
@@ -256,10 +256,14 @@ const pipelineRunsApp = new Hono()
             : {}),
           // QUA-1012 cost telemetry. Drizzle's `numeric` column expects
           // a string on write; integer columns take the number directly.
-          // Only set when the caller passed the field — undefined means
-          // "leave the existing value alone" (existing value is NULL on
-          // first end, but a partial-failure → retry → end-again caller
-          // shouldn't overwrite a previously-recorded cost with NULL).
+          //
+          // Each field is only set when the caller passed it explicitly
+          // (`!== undefined`). On a retry-after-partial-failure, omitting
+          // a field on the second `/end` preserves whatever was recorded
+          // on the first `/end`. Passing the field explicitly — including
+          // `null` — overwrites it. (The route does not gate on terminal
+          // status, so re-`/end` is allowed and will replace fields the
+          // caller chose to re-send.)
           ...(d.costUsd !== undefined
             ? { costUsd: d.costUsd === null ? null : String(d.costUsd) }
             : {}),

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1465,6 +1465,13 @@ export const pipelineRuns = pgTable(
       .$type<Array<Record<string, unknown>>>()
       .notNull()
       .default(sql`'[]'::jsonb`),
+    // QUA-1012 cost telemetry. Nullable — pipelines that don't track
+    // cost (or fail before they can attribute) land NULL.
+    costUsd: numeric("cost_usd", { precision: 10, scale: 4 }),
+    tokensInput: integer("tokens_input"),
+    tokensOutput: integer("tokens_output"),
+    tokensCacheRead: integer("tokens_cache_read"),
+    tokensCacheWrite: integer("tokens_cache_write"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/crux/lib/wiki-server/pipeline-runs.ts
+++ b/crux/lib/wiki-server/pipeline-runs.ts
@@ -53,8 +53,13 @@ export interface EndPipelineRunInput {
   snapshotPath?: string | null;
   followupActions?: Array<Record<string, unknown>>;
   // QUA-1012 cost telemetry. All optional — pipelines that don't track
-  // cost simply omit them. Server caps: costUsd <= 10_000, each token
-  // count <= 2_000_000_000.
+  // cost simply omit them. Caps are enforced server-side (see
+  // `MAX_COST_USD` / `MAX_TOKENS` in `apps/wiki-server/src/api-types.ts`)
+  // — don't restate the numeric values here, they drift.
+  // Distinguish `null` (caller actively cleared the field) from omitted
+  // (caller didn't pass the field — server preserves the existing value
+  // for retry-after-partial-failure). `costUsd: 0` is "tracked at $0",
+  // not "not tracked"; pass `null`/omit for the latter.
   costUsd?: number | null;
   tokensInput?: number | null;
   tokensOutput?: number | null;

--- a/crux/lib/wiki-server/pipeline-runs.ts
+++ b/crux/lib/wiki-server/pipeline-runs.ts
@@ -52,6 +52,14 @@ export interface EndPipelineRunInput {
   errorPayload?: Record<string, unknown> | null;
   snapshotPath?: string | null;
   followupActions?: Array<Record<string, unknown>>;
+  // QUA-1012 cost telemetry. All optional — pipelines that don't track
+  // cost simply omit them. Server caps: costUsd <= 10_000, each token
+  // count <= 2_000_000_000.
+  costUsd?: number | null;
+  tokensInput?: number | null;
+  tokensOutput?: number | null;
+  tokensCacheRead?: number | null;
+  tokensCacheWrite?: number | null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Schema scaffolding for QUA-1011 (pipeline cost telemetry umbrella). Adds nullable `cost_usd` + four token-count columns to `pipeline_runs` so subsequent QUA-1011 children can wire `CostTracker` into the improve pipeline (#2) and source-check pipeline (#3) without further schema work.

## What changed

| Column | Type | Notes |
|---|---|---|
| `cost_usd` | `numeric(10,4)` | 4 decimal places (hundredths-of-a-cent precision); API caps single-run cost at $10k. |
| `tokens_input` | `integer` | |
| `tokens_output` | `integer` | |
| `tokens_cache_read` | `integer` | |
| `tokens_cache_write` | `integer` | |

All five columns are nullable. Existing rows have no telemetry; pipelines that don't track cost (or fail before they can attribute) continue to land NULL.

### Pieces

1. **Migration** `0223_qua_1012_pipeline_runs_cost_columns.sql` — plain `ADD COLUMN IF NOT EXISTS`. The `pipeline_runs` table just shipped in 0222 and is small / mostly empty, so no `NOT VALID` dance needed. The `apply_audit_trigger` from 0222 picks the new columns up automatically.
2. **`apps/wiki-server/src/schema.ts`** — `pipelineRuns` Drizzle definition mirrors the columns.
3. **`EndPipelineRunSchema`** (in `api-types.ts`):
   - `MAX_COST_USD = 10_000` and `MAX_TOKENS = 2_000_000_000` are exported so the typed client (and any other consumer) can reference the canonical cap rather than restating the literal in JSDoc — that drifts.
   - `costUsd` chain: `nonnegative + finite + max(MAX_COST_USD) + multipleOf(0.0001)`. The `.multipleOf` rejects values with more precision than the `numeric(10,4)` column can store, so what the caller submits is what gets persisted (no silent PG-side rounding that returns a different value).
   - Token chain: extracted as `TokenCountSchema` so the four token fields share one Zod chain. A future drop of `.int()` from one field can no longer silently weaken just that field.
4. **`PATCH /:id/end`** route persists the fields. Each is conditionally spread into `.set()` (`d.field !== undefined ? {...} : {}`) so on a retry-after-partial-failure, omitting a field on the second `/end` preserves whatever was recorded on the first `/end`. Passing the field explicitly — including `null` — overwrites it. The route does not gate on terminal status, so re-`/end` is allowed and replaces fields the caller chose to re-send.
5. **`endPipelineRun` typed-client input** — five new optional fields. JSDoc references `MAX_COST_USD` / `MAX_TOKENS` symbolically, no hardcoded numerics.

### Tests

Pipeline-runs route now has 26 tests (was 16). New coverage:
- Persists `costUsd` + token counts when supplied.
- Leaves cost telemetry NULL when omitted.
- Rejects negative / non-integer / over-cap on every token field via parameterized loop (not just `tokensInput`).
- Rejects `costUsd` over the 10k cap and `tokensInput` over the 2B cap.
- Rejects `costUsd` with more than 4 decimal places.
- **Idempotency on retry**: first `/end` records cost+tokens with `partial_failure`; second `/end` omits those fields → prior values preserved.
- **Explicit-null semantics**: passing `costUsd: null` on the second `/end` overwrites the prior value (distinct from omitting).

### What this PR explicitly does NOT do

- No callers updated yet — that lands in QUA-1011 children #2 (improve pipeline) and #3 (source-check). This PR is intentionally schema-only so the umbrella wiring can proceed in parallel.
- No dashboard column added; `/internal/pipeline-runs` continues to render the existing fields. A follow-up will add cost columns to the dashboard once data starts arriving.

## Deploy Checklist

- [ ] migration: Verify migration 0223 applied on server start
- [ ] schema: Drizzle schema changed — verify wiki-server redeployed and schema is in sync

## Test plan

- [x] `npx vitest run apps/wiki-server/src/__tests__/pipeline-runs.test.ts` — 26/26 pass
- [x] `cd apps/wiki-server && npx vitest run` — 1666/1666 pass
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — 13 errors, all pre-existing (baseline 25)
- [x] `pnpm crux w validate gate --no-cache` — 68 checks pass, 2 pre-existing advisories
- [x] `/agent-review-pr` — 7/7 required phases recorded; 2 HIGH + 6 MEDIUM findings addressed in follow-up commit

Closes QUA-1012


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cost and token telemetry tracking for pipeline runs, enabling monitoring of execution expenses (in USD) and token consumption across input, output, and cache operations with validation constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->