### PR TITLE
QUA-1017: hard budget enforcement using live CostTracker total

### DIFF
--- a/crux/commands/research-improve-entity-suite.test.ts
+++ b/crux/commands/research-improve-entity-suite.test.ts
@@ -436,7 +436,11 @@ describe("runSuite", () => {
     ]);
   });
 
-  it("treats BudgetExhaustedError as skipped_budget and stops dispatching further entities (QUA-1017)", async () => {
+  it("production path: result.reason='budget-exhausted' from improveSingleEntity is recorded as skipped_budget and stops dispatch (QUA-1017)", async () => {
+    // The real path: improveSingleEntity catches BudgetExhaustedError
+    // internally (via doImproveSingleEntity's catch) and converts it into
+    // a graceful return with reason="budget-exhausted". The suite reads
+    // that reason and stops dispatching. This test mirrors that contract.
     const { suitePath, snapshotDir } = writeFixtureSuite(
       { slug: "first", type: "policy" },
       { slug: "burner", type: "policy" },
@@ -448,11 +452,17 @@ describe("runSuite", () => {
       calls.push(slug);
       if (slug === "first") return makeResult(slug);
       if (slug === "burner") {
-        // Simulate the per-entity hard cap firing inside improveSingleEntity.
-        throw new BudgetExhaustedError(2.5, 1.0);
+        // Mirror what doImproveSingleEntity returns after catching
+        // BudgetExhaustedError: reason="budget-exhausted", hit_target=false,
+        // total_cost_usd reflects partial-iteration spend from the live
+        // CostTracker (not the per-iter sum, which would undercount).
+        return makeResult(slug, {
+          reason: "budget-exhausted",
+          hit_target: false,
+          iterations: [],
+          total_cost_usd: 1.85,
+        });
       }
-      // Should never be called — third/fourth must be skipped after the
-      // burner trips the cap.
       throw new Error(`improver should not have been called for ${slug}`);
     };
     const snap = await runSuite({
@@ -467,13 +477,46 @@ describe("runSuite", () => {
     expect(snap.entities).toHaveLength(4);
     expect(snap.entities[0].status).toBe("completed");
     expect(snap.entities[1].status).toBe("skipped_budget");
-    expect(snap.entities[1].error).toMatch(/Spent \$2\.5000 of \$1\.00 budget/);
+    expect(snap.entities[1].error).toMatch(/spent \$1\.8500 of \$/);
     expect(snap.entities[2].status).toBe("skipped_budget");
     expect(snap.entities[2].error).toBeUndefined();
     expect(snap.entities[3].status).toBe("skipped_budget");
     expect(snap.entities[3].error).toBeUndefined();
     expect(snap.aggregate.entities_completed).toBe(1);
     expect(snap.aggregate.entities_skipped_budget).toBe(3);
+    expect(snap.aggregate.entities_failed).toBe(0);
+  });
+
+  it("defensive path: BudgetExhaustedError thrown out of improveSingleEntity is also caught and treated as skipped_budget (QUA-1017)", async () => {
+    // The defensive catch in runSuite — for any future code that re-throws
+    // BudgetExhaustedError after the inner catch (e.g. abort during the
+    // YAML write path). Should produce the same outcome as the production
+    // path above.
+    const { suitePath, snapshotDir } = writeFixtureSuite(
+      { slug: "first", type: "policy" },
+      { slug: "burner", type: "policy" },
+      { slug: "third", type: "policy" },
+    );
+    const calls: string[] = [];
+    const improver = async ({ slug }: { slug: string }) => {
+      calls.push(slug);
+      if (slug === "first") return makeResult(slug);
+      if (slug === "burner") throw new BudgetExhaustedError(2.5, 1.0);
+      throw new Error(`improver should not have been called for ${slug}`);
+    };
+    const snap = await runSuite({
+      tag: "budget-rethrow",
+      totalBudgetUsd: 8.0,
+      maxIters: 1,
+      suitePath,
+      snapshotDir,
+      improver,
+    });
+    expect(calls).toEqual(["first", "burner"]);
+    expect(snap.entities[1].status).toBe("skipped_budget");
+    expect(snap.entities[1].error).toMatch(/Spent \$2\.5000 of \$1\.00 budget/);
+    expect(snap.entities[2].status).toBe("skipped_budget");
+    expect(snap.aggregate.entities_skipped_budget).toBe(2);
     expect(snap.aggregate.entities_failed).toBe(0);
   });
 

--- a/crux/commands/research-improve-entity-suite.test.ts
+++ b/crux/commands/research-improve-entity-suite.test.ts
@@ -437,10 +437,6 @@ describe("runSuite", () => {
   });
 
   it("production path: result.reason='budget-exhausted' from improveSingleEntity is recorded as skipped_budget and stops dispatch (QUA-1017)", async () => {
-    // The real path: improveSingleEntity catches BudgetExhaustedError
-    // internally (via doImproveSingleEntity's catch) and converts it into
-    // a graceful return with reason="budget-exhausted". The suite reads
-    // that reason and stops dispatching. This test mirrors that contract.
     const { suitePath, snapshotDir } = writeFixtureSuite(
       { slug: "first", type: "policy" },
       { slug: "burner", type: "policy" },
@@ -452,10 +448,6 @@ describe("runSuite", () => {
       calls.push(slug);
       if (slug === "first") return makeResult(slug);
       if (slug === "burner") {
-        // Mirror what doImproveSingleEntity returns after catching
-        // BudgetExhaustedError: reason="budget-exhausted", hit_target=false,
-        // total_cost_usd reflects partial-iteration spend from the live
-        // CostTracker (not the per-iter sum, which would undercount).
         return makeResult(slug, {
           reason: "budget-exhausted",
           hit_target: false,
@@ -488,10 +480,6 @@ describe("runSuite", () => {
   });
 
   it("defensive path: BudgetExhaustedError thrown out of improveSingleEntity is also caught and treated as skipped_budget (QUA-1017)", async () => {
-    // The defensive catch in runSuite — for any future code that re-throws
-    // BudgetExhaustedError after the inner catch (e.g. abort during the
-    // YAML write path). Should produce the same outcome as the production
-    // path above.
     const { suitePath, snapshotDir } = writeFixtureSuite(
       { slug: "first", type: "policy" },
       { slug: "burner", type: "policy" },

--- a/crux/commands/research-improve-entity-suite.test.ts
+++ b/crux/commands/research-improve-entity-suite.test.ts
@@ -26,6 +26,7 @@ import {
   type PerEntityRecord,
   type SuiteEntry,
 } from "./research-improve-entity-suite.ts";
+import { BudgetExhaustedError } from "./research-improve-entity.ts";
 import type { ImproveResult, IterationMetrics } from "./research-improve-entity.ts";
 
 // ── fixtures ───────────────────────────────────────────────────────────────
@@ -433,6 +434,47 @@ describe("runSuite", () => {
       { slug: "a", budget: 2.0 },
       { slug: "b", budget: 2.0 },
     ]);
+  });
+
+  it("treats BudgetExhaustedError as skipped_budget and stops dispatching further entities (QUA-1017)", async () => {
+    const { suitePath, snapshotDir } = writeFixtureSuite(
+      { slug: "first", type: "policy" },
+      { slug: "burner", type: "policy" },
+      { slug: "third", type: "policy" },
+      { slug: "fourth", type: "policy" },
+    );
+    const calls: string[] = [];
+    const improver = async ({ slug }: { slug: string }) => {
+      calls.push(slug);
+      if (slug === "first") return makeResult(slug);
+      if (slug === "burner") {
+        // Simulate the per-entity hard cap firing inside improveSingleEntity.
+        throw new BudgetExhaustedError(2.5, 1.0);
+      }
+      // Should never be called — third/fourth must be skipped after the
+      // burner trips the cap.
+      throw new Error(`improver should not have been called for ${slug}`);
+    };
+    const snap = await runSuite({
+      tag: "budget-stop",
+      totalBudgetUsd: 8.0,
+      maxIters: 1,
+      suitePath,
+      snapshotDir,
+      improver,
+    });
+    expect(calls).toEqual(["first", "burner"]);
+    expect(snap.entities).toHaveLength(4);
+    expect(snap.entities[0].status).toBe("completed");
+    expect(snap.entities[1].status).toBe("skipped_budget");
+    expect(snap.entities[1].error).toMatch(/Spent \$2\.5000 of \$1\.00 budget/);
+    expect(snap.entities[2].status).toBe("skipped_budget");
+    expect(snap.entities[2].error).toBeUndefined();
+    expect(snap.entities[3].status).toBe("skipped_budget");
+    expect(snap.entities[3].error).toBeUndefined();
+    expect(snap.aggregate.entities_completed).toBe(1);
+    expect(snap.aggregate.entities_skipped_budget).toBe(3);
+    expect(snap.aggregate.entities_failed).toBe(0);
   });
 
   it("records failures without aborting subsequent entities", async () => {

--- a/crux/commands/research-improve-entity-suite.ts
+++ b/crux/commands/research-improve-entity-suite.ts
@@ -283,10 +283,11 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
       records.push(emptyRecord(entry, "skipped_budget"));
       continue;
     }
-    // Per-entity soft cap: 2× the equal-share allocation. The inner loop's
-    // own budget guard runs *between* iterations, so a single iteration that
-    // overshoots the cap is allowed to complete — see `improveSingleEntity`.
-    // The post-iter warning below catches actual cap-hits.
+    // Per-entity hard cap (QUA-1017): 2× the equal-share allocation. Enforced
+    // by the live CostTracker inside improveSingleEntity — every
+    // streamingCreate-bearing call runs `checkBudgetOrThrow` first, and a
+    // BudgetExhaustedError is converted to `reason="budget-exhausted"` so the
+    // suite can act on it via the result-reason check below.
     const entityBudget = Math.min(perEntityCap, remaining);
     console.log(
       `\n=== [${records.length + 1}/${N}] improve-entity-suite: ${entry.slug} ` +
@@ -301,6 +302,27 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
         dryRun: opts.dryRun,
         quiet: true,
       });
+      // Per-entity hard cap (QUA-1017): improveSingleEntity catches its own
+      // BudgetExhaustedError and converts it to a graceful return with
+      // `reason="budget-exhausted"` (preserving partial-progress YAML write).
+      // The suite reads that reason here, records the entity as
+      // `skipped_budget` instead of `completed`, and breaks the dispatch loop.
+      // Cost is taken from result.total_cost_usd, which the entity computes
+      // from its live CostTracker so partial-iteration spend is accounted for.
+      if (result.reason === "budget-exhausted") {
+        console.warn(
+          `[suite] BUDGET-EXHAUSTED: ${entry.slug} spent $${result.total_cost_usd.toFixed(4)}; stopping suite`,
+        );
+        records.push(
+          emptyRecord(
+            entry,
+            "skipped_budget",
+            `entity hit hard cap mid-iteration: spent $${result.total_cost_usd.toFixed(4)} of $${entityBudget.toFixed(2)}`,
+          ),
+        );
+        totalSpent += result.total_cost_usd;
+        break;
+      }
       const record = aggregateResult(entry.slug, entry.type, result);
       records.push(record);
       totalSpent += result.total_cost_usd;
@@ -312,13 +334,13 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      // BudgetExhaustedError from the per-entity hard cap (QUA-1017): the
-      // entity hit its budget mid-iteration and aborted. Record as
-      // `skipped_budget` (the budget signal, not a real failure) and stop
-      // dispatching further entities — the suite's totalSpent has already
-      // consumed the per-entity allowance.
+      // Defensive: BudgetExhaustedError from improveSingleEntity is normally
+      // caught inside doImproveSingleEntity and surfaced via
+      // result.reason="budget-exhausted" above. This branch only fires if a
+      // future change re-throws (e.g. the abort happened during the YAML write
+      // path after the catch). Treat it as a budget signal, not a failure.
       if (err instanceof BudgetExhaustedError) {
-        console.warn(`[suite] BUDGET-EXHAUSTED: ${entry.slug}: ${msg}; stopping suite`);
+        console.warn(`[suite] BUDGET-EXHAUSTED (re-thrown): ${entry.slug}: ${msg}; stopping suite`);
         records.push(emptyRecord(entry, "skipped_budget", msg));
         totalSpent += err.spentUsd;
         break;

--- a/crux/commands/research-improve-entity-suite.ts
+++ b/crux/commands/research-improve-entity-suite.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 
 import { type CommandResult } from "../lib/cli.ts";
 import {
+  BudgetExhaustedError,
   type ImproveOptions,
   type ImproveResult,
   improveSingleEntity,
@@ -311,8 +312,26 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      // BudgetExhaustedError from the per-entity hard cap (QUA-1017): the
+      // entity hit its budget mid-iteration and aborted. Record as
+      // `skipped_budget` (the budget signal, not a real failure) and stop
+      // dispatching further entities — the suite's totalSpent has already
+      // consumed the per-entity allowance.
+      if (err instanceof BudgetExhaustedError) {
+        console.warn(`[suite] BUDGET-EXHAUSTED: ${entry.slug}: ${msg}; stopping suite`);
+        records.push(emptyRecord(entry, "skipped_budget", msg));
+        totalSpent += err.spentUsd;
+        break;
+      }
       console.warn(`[suite] FAILED: ${entry.slug}: ${msg}`);
       records.push(emptyRecord(entry, "failed", msg));
+    }
+  }
+  // Mark any entities not yet dispatched after a mid-suite break as
+  // `skipped_budget` so the snapshot still has a row per supported entry.
+  if (records.length < supported.length) {
+    for (const entry of supported.slice(records.length)) {
+      records.push(emptyRecord(entry, "skipped_budget"));
     }
   }
 
@@ -427,12 +446,13 @@ Options:
   --dry-run         Don't write YAML changes back to data/entities/responses.yaml.
 
 Budget governance:
-  Per-entity soft cap = 2 × (total_budget / N) where N = supported entities.
-  This is a soft cap: a single iteration may overshoot it, since runResearch
-  spends until its own budgetCap. The suite halts mid-run when remaining
-  budget falls below $${MIN_USEFUL_BUDGET_USD.toFixed(2)}; remaining entities
-  are recorded as \`skipped_budget\`. \`--budget\` is therefore a target, not
-  a strict bound.
+  Per-entity hard cap = 2 × (total_budget / N) where N = supported entities.
+  Enforced by a live CostTracker inside improveSingleEntity (QUA-1017): when
+  the tracker total reaches the per-entity cap mid-iteration, the entity
+  throws BudgetExhaustedError. The suite catches it, records the entity as
+  \`skipped_budget\`, and stops dispatching further entities. The suite also
+  short-circuits when remaining < $${MIN_USEFUL_BUDGET_USD.toFixed(2)} before
+  starting an entity. \`--budget\` is now a hard cap on total LLM spend.
 `,
     exitCode: 0,
   };

--- a/crux/commands/research-improve-entity-suite.ts
+++ b/crux/commands/research-improve-entity-suite.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 
 import { type CommandResult } from "../lib/cli.ts";
 import {
+  BUDGET_EXHAUSTED_REASON,
   BudgetExhaustedError,
   type ImproveOptions,
   type ImproveResult,
@@ -283,11 +284,9 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
       records.push(emptyRecord(entry, "skipped_budget"));
       continue;
     }
-    // Per-entity hard cap (QUA-1017): 2× the equal-share allocation. Enforced
-    // by the live CostTracker inside improveSingleEntity — every
-    // streamingCreate-bearing call runs `checkBudgetOrThrow` first, and a
-    // BudgetExhaustedError is converted to `reason="budget-exhausted"` so the
-    // suite can act on it via the result-reason check below.
+    // Per-entity hard cap: 2× the equal-share allocation. Enforced by the
+    // live CostTracker inside improveSingleEntity; surfaced here as
+    // result.reason === BUDGET_EXHAUSTED_REASON.
     const entityBudget = Math.min(perEntityCap, remaining);
     console.log(
       `\n=== [${records.length + 1}/${N}] improve-entity-suite: ${entry.slug} ` +
@@ -302,14 +301,7 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
         dryRun: opts.dryRun,
         quiet: true,
       });
-      // Per-entity hard cap (QUA-1017): improveSingleEntity catches its own
-      // BudgetExhaustedError and converts it to a graceful return with
-      // `reason="budget-exhausted"` (preserving partial-progress YAML write).
-      // The suite reads that reason here, records the entity as
-      // `skipped_budget` instead of `completed`, and breaks the dispatch loop.
-      // Cost is taken from result.total_cost_usd, which the entity computes
-      // from its live CostTracker so partial-iteration spend is accounted for.
-      if (result.reason === "budget-exhausted") {
+      if (result.reason === BUDGET_EXHAUSTED_REASON) {
         console.warn(
           `[suite] BUDGET-EXHAUSTED: ${entry.slug} spent $${result.total_cost_usd.toFixed(4)}; stopping suite`,
         );
@@ -334,11 +326,9 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      // Defensive: BudgetExhaustedError from improveSingleEntity is normally
-      // caught inside doImproveSingleEntity and surfaced via
-      // result.reason="budget-exhausted" above. This branch only fires if a
-      // future change re-throws (e.g. the abort happened during the YAML write
-      // path after the catch). Treat it as a budget signal, not a failure.
+      // Defensive: improveSingleEntity normally surfaces budget aborts via
+      // result.reason above. This branch only fires if a future change
+      // re-throws BudgetExhaustedError out of doImproveSingleEntity.
       if (err instanceof BudgetExhaustedError) {
         console.warn(`[suite] BUDGET-EXHAUSTED (re-thrown): ${entry.slug}: ${msg}; stopping suite`);
         records.push(emptyRecord(entry, "skipped_budget", msg));
@@ -349,8 +339,7 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
       records.push(emptyRecord(entry, "failed", msg));
     }
   }
-  // Mark any entities not yet dispatched after a mid-suite break as
-  // `skipped_budget` so the snapshot still has a row per supported entry.
+  // Backfill remaining entries after a mid-suite break.
   if (records.length < supported.length) {
     for (const entry of supported.slice(records.length)) {
       records.push(emptyRecord(entry, "skipped_budget"));

--- a/crux/commands/research-improve-entity.test.ts
+++ b/crux/commands/research-improve-entity.test.ts
@@ -561,16 +561,8 @@ describe("parseAgentSessionId", () => {
 // ── checkBudgetOrThrow + BudgetExhaustedError (QUA-1017) ───────────────────
 
 describe("checkBudgetOrThrow", () => {
-  /**
-   * Seed a CostTracker without going through streamingCreate by writing a
-   * record directly. Used to simulate a tracker that has already accumulated
-   * `usd` of LLM spend.
-   */
   function trackerWithCost(usd: number): CostTracker {
     const t = new CostTracker();
-    // recordExternalCost is the public API for entries that don't come from a
-    // streamingCreate response (used in production for Perplexity calls). Keeps
-    // the test inside the tracker's typed surface — no readonly bypasses.
     if (usd > 0) t.recordExternalCost("test-model", usd, "test");
     return t;
   }

--- a/crux/commands/research-improve-entity.test.ts
+++ b/crux/commands/research-improve-entity.test.ts
@@ -568,22 +568,10 @@ describe("checkBudgetOrThrow", () => {
    */
   function trackerWithCost(usd: number): CostTracker {
     const t = new CostTracker();
-    if (usd > 0) {
-      // record() expects token usage and computes cost via pricing.ts. We
-      // bypass that and push synthetic entries since the tests only care
-      // about totalCost. Double-cast through unknown is intentional — the
-      // entries array is readonly but vitest unit tests need direct seeding.
-      (t.entries as unknown as Array<unknown>).push({
-        model: "test",
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheCreationInputTokens: 0,
-        cacheReadInputTokens: 0,
-        cost: usd,
-        label: "test",
-        timestamp: Date.now(),
-      });
-    }
+    // recordExternalCost is the public API for entries that don't come from a
+    // streamingCreate response (used in production for Perplexity calls). Keeps
+    // the test inside the tracker's typed surface — no readonly bypasses.
+    if (usd > 0) t.recordExternalCost("test-model", usd, "test");
     return t;
   }
 

--- a/crux/commands/research-improve-entity.test.ts
+++ b/crux/commands/research-improve-entity.test.ts
@@ -21,14 +21,17 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  BudgetExhaustedError,
   buildImproveEntityRunOptions,
   buildVerifiedVerdictsFromBatch,
+  checkBudgetOrThrow,
   drainPendingBatches,
   parseAgentSessionId,
   parseExtractedClaims,
   type ClaimVerdictRow,
   type SubmittedBatchInfo,
 } from "./research-improve-entity.ts";
+import { CostTracker } from "../lib/cost-tracker.ts";
 import type { EntityWithType as ImportedEntityWithType } from "./research-improve-entity.ts";
 import type { PreFilterClaim } from "../lib/research/pre-filter.ts";
 import type { ApplyResult, VerifiedVerdict } from "../lib/research/apply-verdicts.ts";
@@ -552,5 +555,74 @@ describe("parseAgentSessionId", () => {
     // is bigserial starting at 1, so 0 won't appear in practice.
     expect(parseAgentSessionId("abc")).toBeNull();
     expect(parseAgentSessionId("not-a-number")).toBeNull();
+  });
+});
+
+// ── checkBudgetOrThrow + BudgetExhaustedError (QUA-1017) ───────────────────
+
+describe("checkBudgetOrThrow", () => {
+  /**
+   * Seed a CostTracker without going through streamingCreate by writing a
+   * record directly. Used to simulate a tracker that has already accumulated
+   * `usd` of LLM spend.
+   */
+  function trackerWithCost(usd: number): CostTracker {
+    const t = new CostTracker();
+    if (usd > 0) {
+      // record() expects token usage and computes cost via pricing.ts. We
+      // bypass that and push synthetic entries since the tests only care
+      // about totalCost. Double-cast through unknown is intentional — the
+      // entries array is readonly but vitest unit tests need direct seeding.
+      (t.entries as unknown as Array<unknown>).push({
+        model: "test",
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        cost: usd,
+        label: "test",
+        timestamp: Date.now(),
+      });
+    }
+    return t;
+  }
+
+  it("does not throw when totalCost is below budget", () => {
+    const t = trackerWithCost(0.5);
+    expect(() => checkBudgetOrThrow(t, 1.0)).not.toThrow();
+  });
+
+  it("throws BudgetExhaustedError when totalCost exactly equals budget (>=, not >)", () => {
+    const t = trackerWithCost(1.0);
+    expect(() => checkBudgetOrThrow(t, 1.0)).toThrow(BudgetExhaustedError);
+  });
+
+  it("throws BudgetExhaustedError when totalCost has overshot budget", () => {
+    const t = trackerWithCost(1.5);
+    let caught: unknown;
+    try {
+      checkBudgetOrThrow(t, 1.0);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(BudgetExhaustedError);
+    const err = caught as BudgetExhaustedError;
+    expect(err.spentUsd).toBe(1.5);
+    expect(err.budgetUsd).toBe(1.0);
+    expect(err.message).toContain("$1.5000");
+    expect(err.message).toContain("$1.00");
+    expect(err.name).toBe("BudgetExhaustedError");
+  });
+
+  it("does not throw on a fresh tracker against a positive budget", () => {
+    const t = new CostTracker();
+    expect(() => checkBudgetOrThrow(t, 5.0)).not.toThrow();
+  });
+
+  it("throws on a fresh tracker against a zero budget (degenerate but defined)", () => {
+    // A budget of 0 means "no spend allowed" — even an empty tracker should
+    // trip immediately so callers can't cheat the cap by setting it to 0.
+    const t = new CostTracker();
+    expect(() => checkBudgetOrThrow(t, 0)).toThrow(BudgetExhaustedError);
   });
 });

--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -71,10 +71,12 @@ const SUPPORTED_TYPES = new Set(["policy", "organization"]);
 
 /**
  * Thrown when the live CostTracker total has reached the configured `--budget`
- * cap. Caught by `doImproveSingleEntity` (which converts it to a graceful
- * `reason: "budget-exhausted"` exit so the snapshot/YAML write still happens)
- * and by the suite runner (which records the entity as `skipped_budget` and
- * stops dispatching further entities). QUA-1017.
+ * cap. Always caught by `doImproveSingleEntity`, which converts it to a
+ * graceful `reason: "budget-exhausted"` return so the snapshot/YAML write
+ * still happens for partial work. The suite runner reads that reason from
+ * the result, records the entity as `skipped_budget`, and stops dispatching
+ * further entities. The suite ALSO has a defensive catch for this error in
+ * case a future change re-throws after the inner catch. QUA-1017.
  */
 export class BudgetExhaustedError extends Error {
   readonly spentUsd: number;
@@ -858,6 +860,13 @@ async function runIteration(
     duration_s: 0,
   };
 
+  // Hard-cap guard at the top of the iteration. Throws
+  // BudgetExhaustedError if the live tracker has already reached the
+  // configured budget (caught one frame up by doImproveSingleEntity, which
+  // converts it to a graceful budget-exhausted exit). Doing this before
+  // gapsFor so an aborted iter contributes no log noise. QUA-1017.
+  checkBudgetOrThrow(tracker, budgetUsd);
+
   const gaps = gapsFor(entity);
   m.gaps_identified = gaps.length;
   if (gaps.length === 0) {
@@ -868,8 +877,6 @@ async function runIteration(
   console.log(`[iter ${iter}] gaps: ${gaps.map((g) => g.key).join(", ")}`);
 
   // 1. Discovery — focus on the top 3 gaps' research topics, joined.
-  // Hard-cap guard before the most expensive call in the iteration. QUA-1017.
-  checkBudgetOrThrow(tracker, budgetUsd);
   const topic = gaps.slice(0, 3).map((g) => g.researchTopic).join(" — ");
   const researchBudget = Math.min(0.5, budgetRemainingUsd * 0.2);
   console.log(`[iter ${iter}] research: "${topic.slice(0, 100)}" budget=$${researchBudget.toFixed(2)}`);
@@ -1103,9 +1110,11 @@ export async function improveSingleEntity(opts: ImproveOptions): Promise<Improve
       noWrite,
       opts,
     });
-    // Hard-cap exits aren't "committed" — the run stopped before completing
-    // its work. Mark the pipeline_runs row accordingly so dashboards distinguish
-    // budget-aborts from successful runs. QUA-1017.
+    // Hard-cap exits aren't "committed" at the run level — the loop stopped
+    // before completing its planned iterations. Any partial work *is* still
+    // written to YAML (saveEntity runs unconditionally), but the pipeline_runs
+    // row reflects the truncation so dashboards can distinguish budget-aborts
+    // from successful runs. QUA-1017.
     if (result.reason === "budget-exhausted") {
       ctx.markStatus("aborted", {
         reason: "budget_exhausted",
@@ -1180,19 +1189,20 @@ async function doImproveSingleEntity(args: {
   let reason = "max-iters";
 
   for (let i = 1; i <= maxIters; i++) {
-    // Hard-cap guard before kicking off a new iteration — cheap, prevents
-    // starting work that will obviously overshoot. QUA-1017.
-    if (tracker.totalCost >= budgetUsd) {
-      reason = "budget-exhausted";
-      break;
-    }
-    let out;
+    // Single budget enforcement path: runIteration's first action is
+    // checkBudgetOrThrow, so a pre-iter short-circuit here is redundant —
+    // we'd just be racing the same condition. Let the throw propagate up
+    // and the catch below handle it uniformly with mid-iteration aborts.
+    // QUA-1017.
+    let out: Awaited<ReturnType<typeof runIteration>>;
     try {
       out = await runIteration(entity, i, budgetUsd, tracker);
     } catch (err) {
       if (err instanceof BudgetExhaustedError) {
-        // The inner loop hit the hard cap mid-iteration. Treat as a clean exit
-        // so we still write the snapshot/YAML for whatever was applied.
+        // The inner loop hit the hard cap (either at iteration start or
+        // mid-flight after runResearch overshot). Treat as a clean exit so
+        // we still write the snapshot/YAML for whatever was applied in
+        // earlier iterations.
         console.warn(
           `[iter ${i}] budget exhausted: ${err.message}. Stopping after this iteration's partial work.`,
         );
@@ -1254,7 +1264,13 @@ async function doImproveSingleEntity(args: {
     iterations,
     final_coverage: finalCov.score,
     final_facts: finalCov.facts_in_yaml,
-    total_cost_usd: iterations.reduce((s, m) => s + m.cost_research_usd + m.cost_extract_usd, 0),
+    // Source from the live CostTracker rather than summing per-iteration
+    // metrics: an iteration that aborts mid-flight via BudgetExhaustedError
+    // never reaches `iterations.push(out.metrics)`, so the per-iter sum would
+    // undercount any spend incurred before the throw. tracker.totalCost
+    // captures every streamingCreate-recorded cost plus the perplexity
+    // recordExternalCost calls inside research-agent. QUA-1017.
+    total_cost_usd: tracker.totalCost,
     total_duration_s: (Date.now() - t0) / 1000,
     hit_target: hitTarget,
     reason,

--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -31,6 +31,7 @@ import { proposeClaims, getClaimStatus } from "../lib/wiki-server/claims.ts";
 import { suggestResourcesApi } from "../lib/wiki-server/resources.ts";
 import { searchEntities } from "../lib/wiki-server/entities.ts";
 import { createLlmClient, streamingCreate, extractText, MODELS } from "../lib/llm.ts";
+import { CostTracker } from "../lib/cost-tracker.ts";
 import { escapeXml } from "../lib/prompt-utils.ts";
 
 import {
@@ -67,6 +68,37 @@ const ENTITIES_DIR = path.join(ROOT, "data/entities");
 const SNAPSHOTS = path.join(ROOT, ".claude/snapshots/improve-entity");
 
 const SUPPORTED_TYPES = new Set(["policy", "organization"]);
+
+/**
+ * Thrown when the live CostTracker total has reached the configured `--budget`
+ * cap. Caught by `doImproveSingleEntity` (which converts it to a graceful
+ * `reason: "budget-exhausted"` exit so the snapshot/YAML write still happens)
+ * and by the suite runner (which records the entity as `skipped_budget` and
+ * stops dispatching further entities). QUA-1017.
+ */
+export class BudgetExhaustedError extends Error {
+  readonly spentUsd: number;
+  readonly budgetUsd: number;
+  constructor(spentUsd: number, budgetUsd: number) {
+    super(`Spent $${spentUsd.toFixed(4)} of $${budgetUsd.toFixed(2)} budget`);
+    this.name = "BudgetExhaustedError";
+    this.spentUsd = spentUsd;
+    this.budgetUsd = budgetUsd;
+  }
+}
+
+/**
+ * Hard-cap guard: throws {@link BudgetExhaustedError} when the live tracker
+ * total has reached or exceeded `budgetUsd`. Called before every
+ * `streamingCreate`-bearing call inside the inner loop, and before every
+ * outer-loop iteration. Pure / synchronous so it's cheap to call repeatedly.
+ * Exported for testing. QUA-1017.
+ */
+export function checkBudgetOrThrow(tracker: CostTracker, budgetUsd: number): void {
+  if (tracker.totalCost >= budgetUsd) {
+    throw new BudgetExhaustedError(tracker.totalCost, budgetUsd);
+  }
+}
 
 export interface EntityWithType {
   id: string;
@@ -722,6 +754,7 @@ async function extractGapClaims(
   gaps: Gap[],
   sourceUrl: string,
   sourceContent: string,
+  tracker: CostTracker,
 ): Promise<{ claims: ExtractedClaim[]; cost: number }> {
   if (sourceContent.trim().length < 200) return { claims: [], cost: 0 };
   const prompt = buildExtractPrompt(entity, gaps, sourceUrl, sourceContent);
@@ -729,11 +762,15 @@ async function extractGapClaims(
   let inT = 0;
   let outT = 0;
   try {
-    const resp = await streamingCreate(llm(), {
-      model: MODELS.haiku,
-      max_tokens: 2000,
-      messages: [{ role: "user", content: prompt }],
-    });
+    const resp = await streamingCreate(
+      llm(),
+      {
+        model: MODELS.haiku,
+        max_tokens: 2000,
+        messages: [{ role: "user", content: prompt }],
+      },
+      { tracker, label: "improve-entity:extract-claims" },
+    );
     raw = extractText(resp);
     inT = resp.usage?.input_tokens ?? 0;
     outT = resp.usage?.output_tokens ?? 0;
@@ -795,8 +832,13 @@ export { POSITION_STEM_PATTERNS };
 async function runIteration(
   entity: EntityWithType,
   iter: number,
-  budgetRemainingUsd: number,
+  budgetUsd: number,
+  tracker: CostTracker,
 ): Promise<{ entity: EntityWithType; metrics: IterationMetrics; batch: SubmittedBatchInfo | null }> {
+  // Live remaining budget for this iteration's research-agent budgetCap. Floor
+  // at 0 so a tracker that is already over budget still produces a non-negative
+  // value (callers throw before reaching this point — see checkBudgetOrThrow).
+  const budgetRemainingUsd = Math.max(0, budgetUsd - tracker.totalCost);
   const t0 = Date.now();
   const m: IterationMetrics = {
     iter,
@@ -826,6 +868,8 @@ async function runIteration(
   console.log(`[iter ${iter}] gaps: ${gaps.map((g) => g.key).join(", ")}`);
 
   // 1. Discovery — focus on the top 3 gaps' research topics, joined.
+  // Hard-cap guard before the most expensive call in the iteration. QUA-1017.
+  checkBudgetOrThrow(tracker, budgetUsd);
   const topic = gaps.slice(0, 3).map((g) => g.researchTopic).join(" — ");
   const researchBudget = Math.min(0.5, budgetRemainingUsd * 0.2);
   console.log(`[iter ${iter}] research: "${topic.slice(0, 100)}" budget=$${researchBudget.toFixed(2)}`);
@@ -844,6 +888,7 @@ async function runIteration(
       extractFacts: false,
     },
     budgetCap: researchBudget,
+    tracker,
   });
   m.sources_found = research.sources.length;
   m.cost_research_usd = research.metadata.totalCost ?? 0;
@@ -869,7 +914,11 @@ async function runIteration(
     if (!content || content.length < 200) continue;
     const resourceId = resourceIdByUrl.get(src.url) ?? "";
     contentByKey.set(src.url, content);
-    const ex = await extractGapClaims(entity, gaps, src.url, content);
+    // Hard-cap guard before each streamingCreate inside the inner loop. If
+    // runResearch overshot its own budgetCap above, this stops further per-
+    // source extract spending. QUA-1017.
+    checkBudgetOrThrow(tracker, budgetUsd);
+    const ex = await extractGapClaims(entity, gaps, src.url, content, tracker);
     m.cost_extract_usd += ex.cost;
     for (const c of ex.claims) {
       allClaims.push({ ...c, resourceId, sourceUrl: src.url });
@@ -1044,9 +1093,27 @@ export async function improveSingleEntity(opts: ImproveOptions): Promise<Improve
     parseAgentSessionId(getCachedAuditSessionId()),
   );
 
-  return withPipelineRun(runOptions, async () =>
-    doImproveSingleEntity({ found, slug, target, maxIters, budgetUsd, noWrite, opts }),
-  );
+  return withPipelineRun(runOptions, async (ctx) => {
+    const result = await doImproveSingleEntity({
+      found,
+      slug,
+      target,
+      maxIters,
+      budgetUsd,
+      noWrite,
+      opts,
+    });
+    // Hard-cap exits aren't "committed" — the run stopped before completing
+    // its work. Mark the pipeline_runs row accordingly so dashboards distinguish
+    // budget-aborts from successful runs. QUA-1017.
+    if (result.reason === "budget-exhausted") {
+      ctx.markStatus("aborted", {
+        reason: "budget_exhausted",
+        errorCode: "budget_exhausted",
+      });
+    }
+    return result;
+  });
 }
 
 /**
@@ -1105,23 +1172,43 @@ async function doImproveSingleEntity(args: {
   const t0 = Date.now();
   const iterations: IterationMetrics[] = [];
   const submittedBatches: SubmittedBatchInfo[] = [];
-  let budgetRemaining = budgetUsd;
+  // Live cost tracker — every streamingCreate (claim extraction, research-agent
+  // internals via the `tracker` param) auto-records into this. tracker.totalCost
+  // is the canonical "spent so far" used for hard-cap enforcement. QUA-1014/1017.
+  const tracker = new CostTracker();
   let hitTarget = false;
   let reason = "max-iters";
 
   for (let i = 1; i <= maxIters; i++) {
-    if (budgetRemaining <= 0.05) {
+    // Hard-cap guard before kicking off a new iteration — cheap, prevents
+    // starting work that will obviously overshoot. QUA-1017.
+    if (tracker.totalCost >= budgetUsd) {
       reason = "budget-exhausted";
       break;
     }
-    const out = await runIteration(entity, i, budgetRemaining);
+    let out;
+    try {
+      out = await runIteration(entity, i, budgetUsd, tracker);
+    } catch (err) {
+      if (err instanceof BudgetExhaustedError) {
+        // The inner loop hit the hard cap mid-iteration. Treat as a clean exit
+        // so we still write the snapshot/YAML for whatever was applied.
+        console.warn(
+          `[iter ${i}] budget exhausted: ${err.message}. Stopping after this iteration's partial work.`,
+        );
+        reason = "budget-exhausted";
+        break;
+      }
+      throw err;
+    }
     entity = out.entity;
     iterations.push(out.metrics);
     if (out.batch) submittedBatches.push(out.batch);
-    budgetRemaining -= out.metrics.cost_research_usd + out.metrics.cost_extract_usd;
+    const budgetRemaining = Math.max(0, budgetUsd - tracker.totalCost);
     const cov = coverageFor(entity);
     console.log(
-      `[iter ${i}] coverage=${cov.score}, facts=${JSON.stringify(cov.facts_in_yaml)}, budget=$${budgetRemaining.toFixed(2)}`,
+      `[iter ${i}] coverage=${cov.score}, facts=${JSON.stringify(cov.facts_in_yaml)}, ` +
+        `spent=$${tracker.totalCost.toFixed(4)}, remaining=$${budgetRemaining.toFixed(2)}`,
     );
     if (out.metrics.applied_to_yaml === 0 && i > 1) {
       reason = "no-progress";
@@ -1220,7 +1307,12 @@ Supported entity types: policy, organization.
 
 Options:
   --target=N           Stop when (provisions+stakeholders for policy, products+keyPeople+keyDates for org) ≥ N (default: 12)
-  --budget=N           Max LLM spend in USD (default: 2.0)
+  --budget=N           Max LLM spend in USD — HARD cap, enforced by a live
+                       CostTracker before every streamingCreate call. When the
+                       tracker reaches this number mid-iteration, the loop
+                       throws BudgetExhaustedError, exits with reason
+                       "budget-exhausted", and the pipeline_runs row is marked
+                       aborted with errorCode=budget_exhausted (default: 2.0).
   --max-iters=N        Max iterations (default: 3)
   --dry-run            Don't write YAML
   --wait-for-settle    After the main loop exits (target/iters/budget), keep

--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -70,14 +70,19 @@ const SNAPSHOTS = path.join(ROOT, ".claude/snapshots/improve-entity");
 const SUPPORTED_TYPES = new Set(["policy", "organization"]);
 
 /**
- * Thrown when the live CostTracker total has reached the configured `--budget`
- * cap. Always caught by `doImproveSingleEntity`, which converts it to a
- * graceful `reason: "budget-exhausted"` return so the snapshot/YAML write
- * still happens for partial work. The suite runner reads that reason from
- * the result, records the entity as `skipped_budget`, and stops dispatching
- * further entities. The suite ALSO has a defensive catch for this error in
- * case a future change re-throws after the inner catch. QUA-1017.
+ * Possible exit reasons reported on {@link ImproveResult.reason}. The suite
+ * runner switches on this string, so it MUST be a typed union — a typo on
+ * either side silently misroutes the result.
  */
+export type ImproveReason = "target-hit" | "max-iters" | "no-progress" | "budget-exhausted";
+
+/** The single source of truth for the budget-exhausted reason token. Used as
+ *  `result.reason`, the suite's `=== check`, and the pipeline-runs
+ *  `markStatus({ reason, errorCode })` arguments — all kebab-case so a query
+ *  on either field returns the same set of runs. */
+export const BUDGET_EXHAUSTED_REASON = "budget-exhausted" as const;
+
+/** Thrown when the live CostTracker total has reached the configured budget. */
 export class BudgetExhaustedError extends Error {
   readonly spentUsd: number;
   readonly budgetUsd: number;
@@ -89,13 +94,8 @@ export class BudgetExhaustedError extends Error {
   }
 }
 
-/**
- * Hard-cap guard: throws {@link BudgetExhaustedError} when the live tracker
- * total has reached or exceeded `budgetUsd`. Called before every
- * `streamingCreate`-bearing call inside the inner loop, and before every
- * outer-loop iteration. Pure / synchronous so it's cheap to call repeatedly.
- * Exported for testing. QUA-1017.
- */
+/** Throws {@link BudgetExhaustedError} when the live tracker total has reached
+ *  or exceeded `budgetUsd`. */
 export function checkBudgetOrThrow(tracker: CostTracker, budgetUsd: number): void {
   if (tracker.totalCost >= budgetUsd) {
     throw new BudgetExhaustedError(tracker.totalCost, budgetUsd);
@@ -138,7 +138,7 @@ export interface ImproveResult {
   total_cost_usd: number;
   total_duration_s: number;
   hit_target: boolean;
-  reason: string;
+  reason: ImproveReason;
   /** When `--wait-for-settle` is set: count of submitted claims still in
    *  pending/verifying status when the main loop exited (target/iters/budget).
    *  Omitted when the flag is off. */
@@ -837,9 +837,8 @@ async function runIteration(
   budgetUsd: number,
   tracker: CostTracker,
 ): Promise<{ entity: EntityWithType; metrics: IterationMetrics; batch: SubmittedBatchInfo | null }> {
-  // Live remaining budget for this iteration's research-agent budgetCap. Floor
-  // at 0 so a tracker that is already over budget still produces a non-negative
-  // value (callers throw before reaching this point — see checkBudgetOrThrow).
+  // Floor at 0: callers throw on overage via checkBudgetOrThrow before
+  // reaching the runResearch call, so a negative remaining is defensive only.
   const budgetRemainingUsd = Math.max(0, budgetUsd - tracker.totalCost);
   const t0 = Date.now();
   const m: IterationMetrics = {
@@ -860,11 +859,7 @@ async function runIteration(
     duration_s: 0,
   };
 
-  // Hard-cap guard at the top of the iteration. Throws
-  // BudgetExhaustedError if the live tracker has already reached the
-  // configured budget (caught one frame up by doImproveSingleEntity, which
-  // converts it to a graceful budget-exhausted exit). Doing this before
-  // gapsFor so an aborted iter contributes no log noise. QUA-1017.
+  // Guard before gapsFor so an aborted iter contributes no log noise.
   checkBudgetOrThrow(tracker, budgetUsd);
 
   const gaps = gapsFor(entity);
@@ -921,9 +916,8 @@ async function runIteration(
     if (!content || content.length < 200) continue;
     const resourceId = resourceIdByUrl.get(src.url) ?? "";
     contentByKey.set(src.url, content);
-    // Hard-cap guard before each streamingCreate inside the inner loop. If
-    // runResearch overshot its own budgetCap above, this stops further per-
-    // source extract spending. QUA-1017.
+    // If runResearch overshot its own budgetCap above, stop further
+    // per-source extract spending.
     checkBudgetOrThrow(tracker, budgetUsd);
     const ex = await extractGapClaims(entity, gaps, src.url, content, tracker);
     m.cost_extract_usd += ex.cost;
@@ -1110,15 +1104,13 @@ export async function improveSingleEntity(opts: ImproveOptions): Promise<Improve
       noWrite,
       opts,
     });
-    // Hard-cap exits aren't "committed" at the run level — the loop stopped
-    // before completing its planned iterations. Any partial work *is* still
-    // written to YAML (saveEntity runs unconditionally), but the pipeline_runs
-    // row reflects the truncation so dashboards can distinguish budget-aborts
-    // from successful runs. QUA-1017.
-    if (result.reason === "budget-exhausted") {
+    // Budget-exhausted runs persist any applied facts to YAML (saveEntity
+    // runs unconditionally) but the pipeline_runs row records the truncation
+    // so dashboards can distinguish budget-aborts from successful runs.
+    if (result.reason === BUDGET_EXHAUSTED_REASON) {
       ctx.markStatus("aborted", {
-        reason: "budget_exhausted",
-        errorCode: "budget_exhausted",
+        reason: BUDGET_EXHAUSTED_REASON,
+        errorCode: BUDGET_EXHAUSTED_REASON,
       });
     }
     return result;
@@ -1181,32 +1173,22 @@ async function doImproveSingleEntity(args: {
   const t0 = Date.now();
   const iterations: IterationMetrics[] = [];
   const submittedBatches: SubmittedBatchInfo[] = [];
-  // Live cost tracker — every streamingCreate (claim extraction, research-agent
-  // internals via the `tracker` param) auto-records into this. tracker.totalCost
-  // is the canonical "spent so far" used for hard-cap enforcement. QUA-1014/1017.
   const tracker = new CostTracker();
   let hitTarget = false;
-  let reason = "max-iters";
+  let reason: ImproveReason = "max-iters";
 
   for (let i = 1; i <= maxIters; i++) {
-    // Single budget enforcement path: runIteration's first action is
-    // checkBudgetOrThrow, so a pre-iter short-circuit here is redundant —
-    // we'd just be racing the same condition. Let the throw propagate up
-    // and the catch below handle it uniformly with mid-iteration aborts.
-    // QUA-1017.
+    // No pre-iter short-circuit: runIteration's first action is
+    // checkBudgetOrThrow, so a guard here would race the same condition.
     let out: Awaited<ReturnType<typeof runIteration>>;
     try {
       out = await runIteration(entity, i, budgetUsd, tracker);
     } catch (err) {
       if (err instanceof BudgetExhaustedError) {
-        // The inner loop hit the hard cap (either at iteration start or
-        // mid-flight after runResearch overshot). Treat as a clean exit so
-        // we still write the snapshot/YAML for whatever was applied in
-        // earlier iterations.
         console.warn(
           `[iter ${i}] budget exhausted: ${err.message}. Stopping after this iteration's partial work.`,
         );
-        reason = "budget-exhausted";
+        reason = BUDGET_EXHAUSTED_REASON;
         break;
       }
       throw err;
@@ -1265,11 +1247,9 @@ async function doImproveSingleEntity(args: {
     final_coverage: finalCov.score,
     final_facts: finalCov.facts_in_yaml,
     // Source from the live CostTracker rather than summing per-iteration
-    // metrics: an iteration that aborts mid-flight via BudgetExhaustedError
-    // never reaches `iterations.push(out.metrics)`, so the per-iter sum would
-    // undercount any spend incurred before the throw. tracker.totalCost
-    // captures every streamingCreate-recorded cost plus the perplexity
-    // recordExternalCost calls inside research-agent. QUA-1017.
+    // metrics: an iter aborting via BudgetExhaustedError never reaches
+    // `iterations.push(out.metrics)`, so the per-iter sum would undercount
+    // pre-throw spend.
     total_cost_usd: tracker.totalCost,
     total_duration_s: (Date.now() - t0) / 1000,
     hit_target: hitTarget,


### PR DESCRIPTION
## Summary

Make `--budget` a hard cap on `improveSingleEntity`, enforced by a live `CostTracker.totalCost` check before every `streamingCreate`-bearing call. When the tracker reaches the budget mid-iteration, the loop throws `BudgetExhaustedError`, exits with `reason: "budget-exhausted"`, and marks the `pipeline_runs` row `aborted` with `errorCode: budget_exhausted`. The suite reads `result.reason` and stops dispatching further entities.

This combines what was scoped as **QUA-1014** (wire `CostTracker` into `improveSingleEntity`) and **QUA-1017** (hard cap using `tracker.totalCost`). QUA-1017's spec explicitly assumes QUA-1014 lands first, the wiring is ~5 lines, and they share a single test surface — splitting was strictly a rebase tax.

## What's enforced

- **Iteration-start guard**: `runIteration`'s first action is `checkBudgetOrThrow(tracker, budgetUsd)`. Throws BudgetExhaustedError when the live tracker total has reached the budget.
- **Pre-research guard**: `checkBudgetOrThrow` before kicking off `runResearch` (the dominant per-iter spend).
- **Per-source guard**: `checkBudgetOrThrow` before each `extractGapClaims` call (which calls `streamingCreate`). Catches the case where `runResearch` overshoots its own `budgetCap` — further per-source spending stops.
- **Pipeline run status**: `withPipelineRun` lambda calls `ctx.markStatus("aborted", { reason: "budget_exhausted", errorCode: "budget_exhausted" })` so dashboards distinguish budget-aborts from successful runs.
- **Suite-level**: improver returns `result.reason === "budget-exhausted"` → entity recorded as `skipped_budget`, remaining entities also `skipped_budget`, dispatch loop breaks. Defensive catch on `BudgetExhaustedError` retained for future code paths that re-throw.
- **Cost accounting**: `result.total_cost_usd` is sourced from `tracker.totalCost` (not summed per-iter metrics), so partial spend from an aborted iteration is captured.

## CostTracker wiring (the QUA-1014 piece)

- `doImproveSingleEntity` instantiates `new CostTracker()`.
- Threaded through `runIteration` → `extractGapClaims` → `streamingCreate({ tracker, label: "improve-entity:extract-claims" })`.
- Threaded through `runResearch({ tracker })` (which already accepted the param — its own internals record into the same tracker).
- `runResearch.budgetCap` is now derived from live `tracker.totalCost` (`Math.min(0.5, (budgetUsd - tracker.totalCost) * 0.2)`) instead of a manually-decremented `budgetRemaining` accumulator.

## Bugs caught & fixed during /agent-review-pr

1. **CRITICAL — unreachable suite catch (caught by hostile reviewer).** Initial draft had the suite catch `BudgetExhaustedError`, but `doImproveSingleEntity` always catches it internally and converts to a graceful return. The suite catch was dead code; the suite would have called `aggregateResult` (which hardcodes `status: "completed"`) and continued dispatching. Fixed: branch on `result.reason === "budget-exhausted"` *before* aggregateResult.

2. **HIGH — cost accounting undercount on abort path.** `total_cost_usd` was summed from per-iteration metrics, but an aborted iteration never reaches `iterations.push(out.metrics)`. Pre-throw spend in `runResearch` and earlier extract calls was lost. Fixed: source `total_cost_usd` from `tracker.totalCost`.

3. **MEDIUM** — Redundant outer-loop budget guard collapsed into the single `runIteration` top-of-loop check. Test `entries`-push hack replaced with the public `recordExternalCost` API.

## Tests (+7, total 65/65)

- `checkBudgetOrThrow`: 5 cases — under budget, exact-equal-trips (so `--budget=0` cannot be cheated), overshoot (asserts fields + message), fresh tracker, fresh-tracker-vs-zero-budget.
- Suite — production path: 4-entity fixture where the second entity returns `result.reason="budget-exhausted"` (the real path); verifies entries 3 and 4 are recorded as `skipped_budget` (not `failed`) and the improver is never called for them.
- Suite — defensive path: same fixture but improver throws `BudgetExhaustedError`; verifies the defensive catch produces the same outcome.

## Test plan

- [x] `pnpm vitest run crux/commands/research-improve-entity*.test.ts` — 65/65 pass
- [x] Full gate via pre-push hook on first commit: 66/66 pass (2 pre-existing advisory baselines: `typecheck-crux`, `orphan-entity-detection`)
- [x] CLI smoke: `--help`, missing arg, unknown entity all behave correctly
- [x] /agent-review-pr executed; 9 findings (1 CRITICAL, 1 HIGH, 3 MEDIUM, 4 LOW) — 6 fixed, 3 documented
- [ ] Live entity smoke-test on `fisa-702` with `--budget=0.10 --max-iters=1` — deferred to post-merge to avoid burning API credits in this session; the change is fully unit-tested.

Closes QUA-1014.
Fixes QUA-1017.


## Review Phases Skipped

On the latest commit (`3e2d6d8a` — simplification pass):
- phase-3b-hostile: re-run unnecessary — prior 3b output drove this commit; simplifications + type union are net deletions/cleanups, no new behavior to review
- phase-4-redteam: threat model unchanged — simplification commits never widen the attack surface

Phases 3b and 4 ran in full on the feature commit (`bf850490`) — caught the CRITICAL unreachable-suite-catch bug and HIGH cost-accounting bug, both fixed in `159c5717`.

Full tracker: `.claude/review-phases-done` (gitignored, session-local).
