### PR TITLE
qua-1006: standardize cell formatting across directory tables

### DIFF
--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -11,8 +11,8 @@ import { resolveSlugAlias } from "@/data/factbase";
 import {
   DEVELOPER_COLORS,
   SAFETY_LEVEL_COLORS,
-  formatContext,
 } from "../ai-model-constants";
+import { formatCompactNumber } from "@/lib/format-compact";
 import { ProfileStatCard, type ProfileTab } from "@/components/directory";
 import {
   computeAiModelCoverage,
@@ -115,7 +115,7 @@ export default async function AiModelDetailPage({
   if (entity.contextWindow != null) {
     stats.push({
       label: "Context Window",
-      value: `${formatContext(entity.contextWindow)} tokens`,
+      value: `${formatCompactNumber(entity.contextWindow)} tokens`,
     });
   }
 
@@ -258,7 +258,7 @@ export default async function AiModelDetailPage({
             label="Context Window"
             value={
               entity.contextWindow != null
-                ? `${formatContext(entity.contextWindow)} tokens`
+                ? `${formatCompactNumber(entity.contextWindow)} tokens`
                 : undefined
             }
           />

--- a/apps/web/src/app/ai-models/ai-model-constants.ts
+++ b/apps/web/src/app/ai-models/ai-model-constants.ts
@@ -28,14 +28,3 @@ export const SAFETY_LEVEL_COLORS: Record<string, string> = {
   "ASL-4":
     "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
 };
-
-/**
- * Format a context window token count for display.
- * Values < 1,000 are shown as plain numbers (e.g., "512").
- * Values >= 1,000 are shown with K/M suffix (e.g., "8K", "128K", "1M").
- */
-export function formatContext(tokens: number): string {
-  if (tokens >= 1_000_000) return `${Math.floor(tokens / 1_000_000)}M`;
-  if (tokens >= 1_000) return `${Math.floor(tokens / 1_000)}K`;
-  return tokens.toLocaleString("en-US");
-}

--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -5,7 +5,8 @@ import Link from "next/link";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { PaginationControls } from "@/components/directory/PaginationControls";
-import { DEVELOPER_COLORS, SAFETY_LEVEL_COLORS, formatContext } from "./ai-model-constants";
+import { DEVELOPER_COLORS, SAFETY_LEVEL_COLORS } from "./ai-model-constants";
+import { formatCompactCurrency, formatCompactNumber } from "@/lib/format-compact";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeAiModelCoverage } from "@/components/coverage/coverage-score";
 
@@ -333,7 +334,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                 {/* Input Price */}
                 <td className="py-2.5 px-3 text-right tabular-nums">
                   {row.inputPrice != null ? (
-                    `$${row.inputPrice}`
+                    formatCompactCurrency(row.inputPrice)
                   ) : (
                     <span className="text-muted-foreground/40">&mdash;</span>
                   )}
@@ -342,7 +343,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                 {/* Output Price */}
                 <td className="py-2.5 px-3 text-right tabular-nums">
                   {row.outputPrice != null ? (
-                    `$${row.outputPrice}`
+                    formatCompactCurrency(row.outputPrice)
                   ) : (
                     <span className="text-muted-foreground/40">&mdash;</span>
                   )}
@@ -351,7 +352,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                 {/* Context Window */}
                 <td className="py-2.5 px-3 text-right tabular-nums whitespace-nowrap">
                   {row.contextWindow != null ? (
-                    formatContext(row.contextWindow)
+                    formatCompactNumber(row.contextWindow)
                   ) : (
                     <span className="text-muted-foreground/40">&mdash;</span>
                   )}

--- a/apps/web/src/app/data-sources/data-sources-table.tsx
+++ b/apps/web/src/app/data-sources/data-sources-table.tsx
@@ -2,6 +2,7 @@
 
 import type { ColumnDef } from "@tanstack/react-table";
 import { DataTable, SortableHeader } from "@/components/ui/data-table";
+import { formatCount } from "@/lib/format-compact";
 import { freshnessSortKey, type Freshness } from "@/app/data-sources/freshness";
 import {
   FORMAT_LABELS, FORMAT_COLORS,
@@ -228,11 +229,11 @@ const columns: ColumnDef<DataSourceRow>[] = [
             href={`/grants?dataSource=${id}`}
             className="text-xs tabular-nums text-accent-foreground hover:underline"
           >
-            {count.toLocaleString()}
+            {formatCount(count)}
           </Link>
         );
       }
-      return <span className="text-xs tabular-nums">{count.toLocaleString()}</span>;
+      return <span className="text-xs tabular-nums">{formatCount(count)}</span>;
     },
     size: 80,
   },

--- a/apps/web/src/app/divisions/divisions-table.tsx
+++ b/apps/web/src/app/divisions/divisions-table.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { ProfileStatCard } from "@/components/directory/ProfileStatCard";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeDivisionCoverage } from "@/components/coverage/coverage-score";
+import { formatCount } from "@/lib/format-compact";
 import type { RecordVerdict } from "@/data/tablebase";
 import { titleCase } from "@/components/wiki/factbase/format";
 import {
@@ -93,7 +94,7 @@ export function DivisionsTable({
       label: "With Data",
       value: String(divisionsWithData),
     },
-    { label: "Total", value: totalDivisions.toLocaleString() },
+    { label: "Total", value: formatCount(totalDivisions) },
     { label: "Organizations", value: String(uniqueOrgs) },
     { label: "Types", value: String(filteredTypeSummary.length) },
   ];

--- a/apps/web/src/app/factbase/factbase-facts-table.tsx
+++ b/apps/web/src/app/factbase/factbase-facts-table.tsx
@@ -16,6 +16,7 @@ import {
 import { Search, Columns3 } from "lucide-react";
 import { DataTable } from "@/components/ui/data-table";
 import { SortableHeader } from "@/components/ui/sortable-header";
+import { formatCompactCurrency } from "@/lib/format-compact";
 import type { FactRow } from "./factbase-facts-content";
 
 function truncate(s: string, max: number): string {
@@ -274,7 +275,7 @@ const allColumns: ColumnDef<FactRow>[] = [
       const v = row.original.usdEquivalent;
       return v != null ? (
         <span className="text-xs text-muted-foreground tabular-nums">
-          ${v.toLocaleString()}
+          {formatCompactCurrency(v)}
         </span>
       ) : (
         <span className="text-muted-foreground/40 text-xs">-</span>

--- a/apps/web/src/app/internal/funding-programs-dashboard/funding-programs-table.tsx
+++ b/apps/web/src/app/internal/funding-programs-dashboard/funding-programs-table.tsx
@@ -14,6 +14,7 @@ import {
 import { Search } from "lucide-react";
 import { DataTable } from "@/components/ui/data-table";
 import { SortableHeader } from "@/components/ui/sortable-header";
+import { formatCompactCurrency } from "@/lib/format-compact";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -44,13 +45,7 @@ export interface FundingProgramRow {
 
 function formatBudget(amount: number | null, currency: string): string {
   if (amount == null || amount === 0) return "-";
-  if (currency === "USD") {
-    if (amount >= 1_000_000_000) return `$${(amount / 1_000_000_000).toFixed(2)}B`;
-    if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(1)}M`;
-    if (amount >= 1_000) return `$${(amount / 1_000).toFixed(0)}K`;
-    return `$${amount.toLocaleString()}`;
-  }
-  return `${amount.toLocaleString()} ${currency}`;
+  return formatCompactCurrency(amount, currency);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/app/internal/grants-dashboard/grants-table.tsx
+++ b/apps/web/src/app/internal/grants-dashboard/grants-table.tsx
@@ -14,7 +14,7 @@ import {
 import { Search } from "lucide-react";
 import { DataTable } from "@/components/ui/data-table";
 import { SortableHeader } from "@/components/ui/sortable-header";
-import { safeHref } from "@/lib/format-compact";
+import { formatCompactCurrency, safeHref } from "@/lib/format-compact";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -44,12 +44,7 @@ export interface GrantRow {
 
 function formatAmount(amount: number | null, currency: string): string {
   if (amount == null) return "-";
-  if (currency === "USD") {
-    if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(1)}M`;
-    if (amount >= 1_000) return `$${(amount / 1_000).toFixed(0)}K`;
-    return `$${amount.toLocaleString()}`;
-  }
-  return `${amount.toLocaleString()} ${currency}`;
+  return formatCompactCurrency(amount, currency);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/app/politicians/politicians-table.tsx
+++ b/apps/web/src/app/politicians/politicians-table.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import { compareByValue, type SortDir } from "@/lib/sort-utils";
 import { SortHeader } from "@/components/directory/SortHeader";
+import { formatCompactCurrency } from "@/lib/format-compact";
 import { PoliticianScoresCell } from "@/components/political/politician-scores-cell";
 import type { PoliticalScore } from "@/components/political/types";
 import {
@@ -253,11 +254,7 @@ export function PoliticiansTable({ rows }: { rows: PoliticianRow[] }) {
                   <td className="py-2.5 px-3 text-right">
                     {row.totalRaised != null ? (
                       <span className="text-xs tabular-nums text-muted-foreground font-medium">
-                        ${row.totalRaised >= 1_000_000
-                          ? `${(row.totalRaised / 1_000_000).toFixed(1)}M`
-                          : row.totalRaised >= 1_000
-                            ? `${(row.totalRaised / 1_000).toFixed(0)}K`
-                            : row.totalRaised.toLocaleString()}
+                        {formatCompactCurrency(row.totalRaised)}
                       </span>
                     ) : (
                       <span className="text-muted-foreground/40">&mdash;</span>

--- a/apps/web/src/app/publications/publications-table.tsx
+++ b/apps/web/src/app/publications/publications-table.tsx
@@ -13,6 +13,7 @@ import {
 import { Search } from "lucide-react";
 import { SortableHeader } from "@/components/ui/sortable-header";
 import { CredibilityBadge } from "@/components/wiki/CredibilityBadge";
+import { formatCount } from "@/lib/format-compact";
 import { formatType } from "./publication-utils";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computePublicationCoverage } from "@/components/coverage/coverage-score";
@@ -271,8 +272,8 @@ export function PublicationsTable({
 
         <span className="text-xs text-muted-foreground whitespace-nowrap">
           {filtered === total
-            ? `${total.toLocaleString()} publications`
-            : `${filtered.toLocaleString()} of ${total.toLocaleString()} publications`}
+            ? `${formatCount(total)} publications`
+            : `${formatCount(filtered)} of ${formatCount(total)} publications`}
         </span>
       </div>
 

--- a/apps/web/src/app/races/races-table.tsx
+++ b/apps/web/src/app/races/races-table.tsx
@@ -9,6 +9,7 @@ import {
   AI_STANCE_LABELS,
   RACE_LEVEL_LABELS,
 } from "./races-constants";
+import { formatCompactCurrency } from "@/lib/format-compact";
 import { SourcingDot } from "@/components/sourcing/SourcingDot";
 import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
 
@@ -72,12 +73,6 @@ export function RacesTable({ rows }: { rows: RaceRow[] }) {
       return true;
     });
   }, [rows, statusFilter, levelFilter]);
-
-  function formatCurrency(amount: number): string {
-    if (amount >= 1_000_000) return `\$${(amount / 1_000_000).toFixed(1)}M`;
-    if (amount >= 1_000) return `\$${(amount / 1_000).toFixed(0)}K`;
-    return `\$${amount.toFixed(0)}`;
-  }
 
   return (
     <div>
@@ -282,7 +277,7 @@ export function RacesTable({ rows }: { rows: RaceRow[] }) {
                                 </td>
                                 <td className="py-1 pr-3 text-right">
                                   {c.pacAmount != null
-                                    ? formatCurrency(c.pacAmount)
+                                    ? formatCompactCurrency(c.pacAmount)
                                     : "—"}
                                 </td>
                                 <td className="py-1 pr-3 text-right">

--- a/apps/web/src/app/resources/resources-table.tsx
+++ b/apps/web/src/app/resources/resources-table.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 import { SortableHeader } from "@/components/ui/sortable-header";
 import { stripMarkdownFormatting } from "@/lib/inline-markdown";
+import { formatCount, formatCompactNumber } from "@/lib/format-compact";
 import {
   Table,
   TableBody,
@@ -281,7 +282,7 @@ function makeColumns(): ColumnDef<ResourceRow>[] {
         if (c != null) {
           return (
             <span className="text-xs tabular-nums text-muted-foreground" title={`${c} citations`}>
-              {c >= 1000 ? `${(c / 1000).toFixed(1)}k` : c}
+              {formatCompactNumber(c)}
             </span>
           );
         }
@@ -468,8 +469,8 @@ export function ResourcesTable({ rows }: { rows: ResourceRow[] }) {
 
         <span className="text-xs text-muted-foreground whitespace-nowrap">
           {filtered === total
-            ? `${total.toLocaleString()} resources`
-            : `${filtered.toLocaleString()} of ${total.toLocaleString()} resources`}
+            ? `${formatCount(total)} resources`
+            : `${formatCount(filtered)} of ${formatCount(total)} resources`}
         </span>
       </div>
 

--- a/apps/web/src/app/sourcing/sourcing-table.tsx
+++ b/apps/web/src/app/sourcing/sourcing-table.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ChevronRight } from "lucide-react";
 import type { RpcSourcingVerdictRow } from "@/lib/wiki-server";
+import { formatDateDeterministic } from "@/lib/format";
 import {
   VerdictBadge,
   formatRecordType,
@@ -83,7 +84,7 @@ export function SourcingTable({ verdicts, names, hrefs, claims }: SourcingTableP
                   <>
                     {(entityName || recordName) && <span>·</span>}
                     <span className="tabular-nums">
-                      {new Date(v.lastComputedAt).toLocaleDateString()}
+                      {formatDateDeterministic(v.lastComputedAt)}
                     </span>
                   </>
                 )}
@@ -209,7 +210,7 @@ export function SourcingTable({ verdicts, names, hrefs, claims }: SourcingTableP
                   <td className="py-2.5 pr-3">
                     {v.lastComputedAt ? (
                       <span className="text-xs text-muted-foreground tabular-nums">
-                        {new Date(v.lastComputedAt).toLocaleDateString()}
+                        {formatDateDeterministic(v.lastComputedAt)}
                       </span>
                     ) : (
                       <span className="text-xs text-muted-foreground">-</span>

--- a/apps/web/src/app/things/things-table.tsx
+++ b/apps/web/src/app/things/things-table.tsx
@@ -9,6 +9,8 @@ import { FilterChips } from "@/components/directory/FilterChips";
 import { PaginationControls } from "@/components/directory/PaginationControls";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeGenericCoverage } from "@/components/coverage/coverage-score";
+import { formatDateDeterministic } from "@/lib/format";
+import { formatCount } from "@/lib/format-compact";
 import { formatType } from "./types";
 import type { ThingRow, ThingsStatsResponse } from "./types";
 
@@ -18,20 +20,6 @@ interface ThingsTableProps {
   totalPages: number;
   stats: ThingsStatsResponse;
   pageSize: number;
-}
-
-/** Format an ISO date string to a short date. */
-function formatDate(iso: string | null): string {
-  if (!iso) return "\u2014";
-  try {
-    return new Date(iso).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-  } catch {
-    return iso;
-  }
 }
 
 const TYPE_COLORS: Record<string, string> = {
@@ -125,7 +113,7 @@ export function ThingsTable({
           </select>
         )}
         <span className="text-sm text-muted-foreground whitespace-nowrap tabular-nums">
-          {total.toLocaleString()} results
+          {formatCount(total)} results
         </span>
       </div>
 
@@ -234,7 +222,7 @@ export function ThingsTable({
                   )}
                 </td>
                 <td className="py-2.5 px-3 text-muted-foreground text-xs tabular-nums">
-                  {formatDate(row.updatedAt)}
+                  {row.updatedAt ? formatDateDeterministic(row.updatedAt) : "—"}
                 </td>
                 <td className="py-2.5 px-2 text-right">
                   <RecordStatusDots

--- a/apps/web/src/lib/__tests__/format-compact.test.ts
+++ b/apps/web/src/lib/__tests__/format-compact.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatCompactCurrency, formatCompactNumber, formatIntroducedDate } from "../format-compact";
+import {
+  formatCompactCurrency,
+  formatCompactNumber,
+  formatCount,
+  formatIntroducedDate,
+} from "../format-compact";
 
 describe("formatCompactCurrency", () => {
   it("formats trillions", () => {
@@ -64,6 +69,23 @@ describe("formatCompactCurrency", () => {
 
   it("handles negative values", () => {
     expect(formatCompactCurrency(-5e6)).toBe("$-5M");
+  });
+});
+
+describe("formatCount", () => {
+  it("returns empty for null/undefined/NaN/Infinity", () => {
+    expect(formatCount(null)).toBe("");
+    expect(formatCount(undefined)).toBe("");
+    expect(formatCount(NaN)).toBe("");
+    expect(formatCount(Infinity)).toBe("");
+  });
+
+  it("groups locale digits without compacting (status-line precision)", () => {
+    expect(formatCount(0)).toBe("0");
+    expect(formatCount(42)).toBe("42");
+    expect(formatCount(1500)).toBe("1,500");
+    expect(formatCount(12345)).toBe("12,345");
+    expect(formatCount(1000000)).toBe("1,000,000");
   });
 });
 

--- a/apps/web/src/lib/format-compact.ts
+++ b/apps/web/src/lib/format-compact.ts
@@ -47,6 +47,18 @@ export function formatCompactCurrency(n: number | null | undefined, currency?: s
   return `${sym}${n.toLocaleString()}`;
 }
 
+/**
+ * Format an integer count for status-line display, with locale grouping but
+ * no compact suffix. Use for "Showing N of M results" strings, stat cards,
+ * and other places where exact precision matters more than visual brevity.
+ * For column cell values (currency, big numbers), prefer formatCompactNumber
+ * or formatCompactCurrency instead.
+ */
+export function formatCount(n: number | null | undefined): string {
+  if (n == null || isNaN(n) || !isFinite(n)) return "";
+  return n.toLocaleString("en-US");
+}
+
 /** Format a number as compact: 1.2T, 850M, 6.6M, 42K (no currency symbol) */
 export function formatCompactNumber(n: number | null | undefined): string {
   if (n == null || isNaN(n) || !isFinite(n)) return "";

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -347,6 +347,17 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    // QUA-1006: directory tables must use shared formatters from
+    // @/lib/format-compact + @/lib/format. Prevents new ad-hoc
+    // .toLocaleString / Intl.NumberFormat / .toLocaleDateString calls
+    // from drifting back into *-table.tsx components.
+    id: 'table-formatting',
+    name: 'Directory tables use shared formatters (QUA-1006)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-table-formatting.ts'],
+    cwd: PROJECT_ROOT,
+  },
+  {
     // QUA-897: block the non-word "sourcinged" — a mass-rename artifact
     // from QUA-237 that surfaced on /divisions and 4 other pages.
     id: 'no-sourcinged',

--- a/crux/validate/validate-table-formatting.test.ts
+++ b/crux/validate/validate-table-formatting.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { runCheck } from './validate-table-formatting.ts';
+import { lineHasBannedFormatter, runCheck } from './validate-table-formatting.ts';
 
-describe('validate-table-formatting', () => {
+describe('validate-table-formatting — runCheck (regression guard)', () => {
   it('passes on the current codebase — directory tables use shared formatters', () => {
     // QUA-1006 regression guard: if someone adds new ad-hoc
     // .toLocaleString / .toLocaleDateString / Intl.NumberFormat calls to a
@@ -10,5 +10,83 @@ describe('validate-table-formatting', () => {
     const result = runCheck();
     expect(result.passed).toBe(true);
     expect(result.errors).toBe(0);
+  });
+});
+
+describe('lineHasBannedFormatter — banned patterns', () => {
+  it('flags .toLocaleString', () => {
+    const hit = lineHasBannedFormatter('  return n.toLocaleString();');
+    expect(hit?.label).toBe('.toLocaleString');
+  });
+
+  it('flags .toLocaleDateString', () => {
+    const hit = lineHasBannedFormatter('  return new Date(s).toLocaleDateString();');
+    expect(hit?.label).toBe('.toLocaleDateString');
+  });
+
+  it('flags Intl.NumberFormat', () => {
+    const hit = lineHasBannedFormatter('  const fmt = new Intl.NumberFormat();');
+    expect(hit?.label).toBe('Intl.NumberFormat');
+  });
+
+  it('flags Intl.DateTimeFormat', () => {
+    const hit = lineHasBannedFormatter('  const fmt = new Intl.DateTimeFormat();');
+    expect(hit?.label).toBe('Intl.DateTimeFormat');
+  });
+
+  it('returns null for clean lines', () => {
+    expect(lineHasBannedFormatter('  return formatCount(n);')).toBeNull();
+    expect(lineHasBannedFormatter('  const x = 42;')).toBeNull();
+    expect(lineHasBannedFormatter('')).toBeNull();
+  });
+});
+
+describe('lineHasBannedFormatter — comment + allow-marker handling', () => {
+  it('skips //-comment lines', () => {
+    expect(lineHasBannedFormatter('// example: n.toLocaleString()')).toBeNull();
+  });
+
+  it('skips /*-comment lines', () => {
+    expect(lineHasBannedFormatter('/* docstring with n.toLocaleString() */')).toBeNull();
+  });
+
+  it('skips *-prefixed JSDoc continuation lines', () => {
+    expect(lineHasBannedFormatter(' * docstring with n.toLocaleString()')).toBeNull();
+  });
+
+  it('honors same-line allow marker', () => {
+    const hit = lineHasBannedFormatter(
+      '  return n.toLocaleString(); // table-formatting-ok: legacy interop',
+    );
+    expect(hit).toBeNull();
+  });
+
+  it('honors previous-line allow marker', () => {
+    const hit = lineHasBannedFormatter(
+      '  return n.toLocaleString();',
+      '  // table-formatting-ok: legacy interop',
+    );
+    expect(hit).toBeNull();
+  });
+
+  it('does NOT honor an allow marker on a non-comment previous line', () => {
+    // A code line that mentions the marker as a string literal should not
+    // grant exemption to the next line. The marker is recognized only when
+    // it appears in a comment.
+    const hit = lineHasBannedFormatter(
+      '  return n.toLocaleString();',
+      '  const tag = "table-formatting-ok";',
+    );
+    expect(hit?.label).toBe('.toLocaleString');
+  });
+
+  it('reports the FIRST banned pattern when multiple appear on one line', () => {
+    // The implementation iterates patterns in BANNED_PATTERNS order and
+    // breaks on first match, so a line with both .toLocaleString AND
+    // Intl.NumberFormat reports only the toLocaleString hit.
+    const hit = lineHasBannedFormatter(
+      '  return n.toLocaleString() + new Intl.NumberFormat().format(0);',
+    );
+    expect(hit?.label).toBe('.toLocaleString');
   });
 });

--- a/crux/validate/validate-table-formatting.test.ts
+++ b/crux/validate/validate-table-formatting.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { runCheck } from './validate-table-formatting.ts';
+
+describe('validate-table-formatting', () => {
+  it('passes on the current codebase — directory tables use shared formatters', () => {
+    // QUA-1006 regression guard: if someone adds new ad-hoc
+    // .toLocaleString / .toLocaleDateString / Intl.NumberFormat calls to a
+    // user-facing *-table.tsx without the table-formatting-ok marker, this
+    // test will fail.
+    const result = runCheck();
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+  });
+});

--- a/crux/validate/validate-table-formatting.ts
+++ b/crux/validate/validate-table-formatting.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+/**
+ * QUA-1006: Standardize cell formatting across directory tables.
+ *
+ * Flags ad-hoc `.toLocaleString(...)`, `.toLocaleDateString(...)`, and
+ * `Intl.NumberFormat` calls in directory table components — anything under
+ * `apps/web/src/app/<directory>/*-table.tsx` (and the same suffix in nested
+ * dirs). Internal admin tables under `apps/web/src/app/internal/` are not
+ * in scope for this validator (they may have specialized formatting needs);
+ * the rule is enforced for user-facing directory tables only.
+ *
+ * The replacement is to import from `@/lib/format-compact` (formatCompactCurrency,
+ * formatCompactNumber, formatCount) or `@/lib/format` (formatDateDeterministic).
+ *
+ * Allow markers (place on the same line or the line above):
+ *   `// table-formatting-ok: <reason>` — explicit opt-out for cases where the
+ *   shared helpers don't fit (e.g. specialized rounding for context windows).
+ *
+ * Usage: npx tsx crux/validate/validate-table-formatting.ts
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { getColors } from '../lib/output.ts';
+
+const SCAN_ROOT = 'apps/web/src/app';
+
+/** Banned patterns and the suggested replacement helper. */
+const BANNED_PATTERNS: { pattern: RegExp; suggest: string; label: string }[] = [
+  {
+    pattern: /\.toLocaleString\s*\(/,
+    suggest: 'formatCount / formatCompactNumber from @/lib/format-compact',
+    label: '.toLocaleString',
+  },
+  {
+    pattern: /\.toLocaleDateString\s*\(/,
+    suggest: 'formatDateDeterministic from @/lib/format',
+    label: '.toLocaleDateString',
+  },
+  {
+    pattern: /\bIntl\.NumberFormat\b/,
+    suggest: 'formatCompactCurrency / formatCompactNumber from @/lib/format-compact',
+    label: 'Intl.NumberFormat',
+  },
+  {
+    pattern: /\bIntl\.DateTimeFormat\b/,
+    suggest: 'formatDateDeterministic from @/lib/format',
+    label: 'Intl.DateTimeFormat',
+  },
+];
+
+const ALLOW_MARKER = 'table-formatting-ok';
+
+interface Violation {
+  file: string;
+  line: number;
+  text: string;
+  label: string;
+  suggest: string;
+}
+
+/** Recursively collect *-table.tsx files under apps/web/src/app, excluding internal/. */
+function collectTableFiles(dir: string): string[] {
+  const results: string[] = [];
+
+  function walk(current: string, isUnderInternal: boolean): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(current);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(current, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      if (stat.isDirectory()) {
+        if (entry === 'node_modules' || entry === '__tests__') continue;
+        const nextInternal = isUnderInternal || entry === 'internal';
+        walk(fullPath, nextInternal);
+      } else if (
+        !isUnderInternal &&
+        (entry.endsWith('-table.tsx') || entry.endsWith('Table.tsx'))
+      ) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  walk(dir, false);
+  return results;
+}
+
+function isCommentLine(s: string): boolean {
+  const t = s.trimStart();
+  return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*');
+}
+
+function checkFile(filePath: string): Violation[] {
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+  const violations: Violation[] = [];
+  const relPath = relative(PROJECT_ROOT, filePath);
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (isCommentLine(line)) continue;
+
+    // Skip if this line carries an allow marker, or the previous line is a
+    // comment carrying the marker.
+    if (line.includes(ALLOW_MARKER)) continue;
+    const prev = i > 0 ? lines[i - 1] : '';
+    if (isCommentLine(prev) && prev.includes(ALLOW_MARKER)) continue;
+
+    for (const { pattern, suggest, label } of BANNED_PATTERNS) {
+      if (pattern.test(line)) {
+        violations.push({
+          file: relPath,
+          line: i + 1,
+          text: line.trim(),
+          label,
+          suggest,
+        });
+        break;
+      }
+    }
+  }
+
+  return violations;
+}
+
+export function runCheck(): { passed: boolean; errors: number; violations: Violation[] } {
+  const c = getColors();
+  console.log(`${c.blue}Checking directory table formatting (QUA-1006)...${c.reset}\n`);
+
+  const absDir = join(PROJECT_ROOT, SCAN_ROOT);
+  const files = collectTableFiles(absDir);
+
+  if (files.length === 0) {
+    console.log(`${c.dim}No directory table files found${c.reset}`);
+    return { passed: true, errors: 0, violations: [] };
+  }
+
+  const allViolations: Violation[] = [];
+  for (const file of files) {
+    allViolations.push(...checkFile(file));
+  }
+
+  if (allViolations.length === 0) {
+    console.log(
+      `${c.green}No ad-hoc formatters in directory tables (${files.length} files checked)${c.reset}`,
+    );
+  } else {
+    console.log(
+      `${c.red}Found ${allViolations.length} ad-hoc formatter call(s) in directory tables:${c.reset}\n`,
+    );
+    for (const v of allViolations) {
+      console.log(`  ${c.red}${v.file}:${v.line}${c.reset}  [${v.label}]`);
+      console.log(`    ${c.dim}${v.text}${c.reset}`);
+      console.log(`    ${c.dim}Fix: use ${v.suggest}${c.reset}`);
+      console.log(
+        `    ${c.dim}Or add a // ${ALLOW_MARKER}: <reason> marker on the same line or line above${c.reset}\n`,
+      );
+    }
+  }
+
+  return {
+    passed: allViolations.length === 0,
+    errors: allViolations.length,
+    violations: allViolations,
+  };
+}
+
+if (process.argv[1]?.includes('validate-table-formatting')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}

--- a/crux/validate/validate-table-formatting.ts
+++ b/crux/validate/validate-table-formatting.ts
@@ -51,7 +51,12 @@ const BANNED_PATTERNS: { pattern: RegExp; suggest: string; label: string }[] = [
   },
 ];
 
-const ALLOW_MARKER = 'table-formatting-ok';
+export const ALLOW_MARKER = 'table-formatting-ok';
+
+export interface BannedHit {
+  label: string;
+  suggest: string;
+}
 
 interface Violation {
   file: string;
@@ -59,6 +64,25 @@ interface Violation {
   text: string;
   label: string;
   suggest: string;
+}
+
+/**
+ * Pure helper: returns null if `line` is clean, or `{label, suggest}` for the
+ * first banned pattern it matches. Honors the same-line and previous-line
+ * `// table-formatting-ok` marker, plus comment-line skips. Exposed for unit
+ * tests so the matching logic can be exercised without filesystem setup.
+ */
+export function lineHasBannedFormatter(
+  line: string,
+  prevLine: string = '',
+): BannedHit | null {
+  if (isCommentLine(line)) return null;
+  if (line.includes(ALLOW_MARKER)) return null;
+  if (isCommentLine(prevLine) && prevLine.includes(ALLOW_MARKER)) return null;
+  for (const { pattern, suggest, label } of BANNED_PATTERNS) {
+    if (pattern.test(line)) return { label, suggest };
+  }
+  return null;
 }
 
 /** Recursively collect *-table.tsx files under apps/web/src/app, excluding internal/. */
@@ -111,26 +135,15 @@ function checkFile(filePath: string): Violation[] {
   const relPath = relative(PROJECT_ROOT, filePath);
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (isCommentLine(line)) continue;
-
-    // Skip if this line carries an allow marker, or the previous line is a
-    // comment carrying the marker.
-    if (line.includes(ALLOW_MARKER)) continue;
-    const prev = i > 0 ? lines[i - 1] : '';
-    if (isCommentLine(prev) && prev.includes(ALLOW_MARKER)) continue;
-
-    for (const { pattern, suggest, label } of BANNED_PATTERNS) {
-      if (pattern.test(line)) {
-        violations.push({
-          file: relPath,
-          line: i + 1,
-          text: line.trim(),
-          label,
-          suggest,
-        });
-        break;
-      }
+    const hit = lineHasBannedFormatter(lines[i], i > 0 ? lines[i - 1] : '');
+    if (hit) {
+      violations.push({
+        file: relPath,
+        line: i + 1,
+        text: lines[i].trim(),
+        label: hit.label,
+        suggest: hit.suggest,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

Apply the shared format helpers (`formatCompactCurrency`, `formatCompactNumber`, `formatCount`, `formatDateDeterministic`) to every user-facing `*-table.tsx` that renders currency, big integers, or dates. Replaces a long tail of one-off formatters and adds a gate-blocking validator so the rule sticks.

Closes QUA-1006.

## Acceptance criteria

- [x] Single helper module imported by ≥80% of `*-table.tsx` files that render numeric/date columns. The user-facing helpers live in `apps/web/src/lib/format-compact.ts` (compact currency/number, count, date) and `apps/web/src/lib/format.ts` (`formatDateDeterministic`). Of the 27 user-facing tables checked by the validator, all that render numeric/date columns now route through these helpers.
- [x] No new bespoke `Intl.NumberFormat` or `toLocaleString` calls in directory tables. Enforced by `crux/validate/validate-table-formatting.ts`, wired into the gate as the new `table-formatting` check (blocking).
- [x] `pnpm build` and `pnpm test` pass. (Pre-existing `wiki-server/snapshot-resources.test.ts` failures about resource enrichment thresholds are unrelated to this PR.)
- [x] Render-audit passes against prod (`PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com npx playwright test e2e/render-audit.spec.ts` — 48/48).

## What changed

### Helper module

- `apps/web/src/lib/format-compact.ts`: added `formatCount(n)` for status-line precision (`12,345 results`) — the existing compact helpers would lose precision (`12K`).
- `apps/web/src/lib/__tests__/format-compact.test.ts`: tests for `formatCount` covering null/undefined/NaN/Infinity and locale grouping.

### Tables updated (12 files)

User-facing tables that previously had ad-hoc formatters now import the shared helpers:

| File | Before | After |
|------|--------|-------|
| `things-table.tsx` | local `formatDate` using `toLocaleDateString` (hydration risk) + `total.toLocaleString()` | `formatDateDeterministic` + `formatCount` |
| `politicians-table.tsx` | inline `${(total/1e6).toFixed(1)}M` chain for `totalRaised` | `formatCompactCurrency` |
| `races-table.tsx` | local `formatCurrency` | `formatCompactCurrency` |
| `factbase-facts-table.tsx` | `${v.toLocaleString()}` for USD equivalent | `formatCompactCurrency` |
| `ai-models-table.tsx` | hand-rolled `$${row.inputPrice}` + custom `formatContext` (lossy `Math.floor`) | `formatCompactCurrency` + `formatCompactNumber` |
| `resources-table.tsx` | `c >= 1000 ? (c/1000).toFixed(1)k : c` for citations + `total.toLocaleString()` | `formatCompactNumber` + `formatCount` |
| `publications-table.tsx` | `total.toLocaleString()` status strings | `formatCount` |
| `divisions-table.tsx` | `totalDivisions.toLocaleString()` stat card | `formatCount` |
| `data-sources-table.tsx` | `count.toLocaleString()` cell value | `formatCount` |
| `sourcing-table.tsx` | `new Date(v.lastComputedAt).toLocaleDateString()` (hydration risk) | `formatDateDeterministic` |
| `internal/grants-dashboard/grants-table.tsx` | duplicate `formatAmount` (currency) | delegates to `formatCompactCurrency` |
| `internal/funding-programs-dashboard/funding-programs-table.tsx` | duplicate `formatBudget` (currency) | delegates to `formatCompactCurrency` |

Tables that already used the shared helpers (`organizations`, `grants`, `funding-programs`, `funding-rounds`, `legislation`) needed no changes.

### Visual changes (called out in review)

- **AI-model context windows** now display with one decimal of precision when below 10K (`8192 → "8.2K"` instead of `"8K"`). Round values like `128000 → "128K"` are unchanged. The detail page (`/ai-models/<id>`) is updated to use the same helper so the table and detail page agree on the same value.
- **Politicians' totalRaised** renders without trailing `.0` (`$5M` instead of `$5.0M`); amounts in [1K, 10K) range render with one decimal (`$4.5K` instead of `$5K`).
- **Race PAC amounts** under $10K now show one decimal (`$1.5K` instead of `$2K`).
- **Internal grants/funding-programs dashboards**: non-USD currencies switch from `1,500,000 EUR` (full digits, code suffix) to `€1.5M` or `EUR 1.5M` (compact, symbol prefix). For unmapped currency codes the format is `<CODE> <compact>` (e.g. `XYZ 1.5M`).
- **Internal grants ≥ $1B** previously rendered as M (`$3500.0M`); now compact to B (`$3.5B`).
- **Sourcing and things tables**: dates render server-deterministically (`May 1, 2026`) instead of locale-dependent (`5/1/2026`), eliminating React hydration mismatches in client components.

### Validator

- `crux/validate/validate-table-formatting.ts`: scans `apps/web/src/app/**/*-table.tsx` (excluding `internal/`) for `.toLocaleString` / `.toLocaleDateString` / `Intl.NumberFormat` / `Intl.DateTimeFormat`. Supports a `// table-formatting-ok: <reason>` escape hatch on the same line or line above. Exposes `lineHasBannedFormatter(line, prevLine)` as a pure helper for unit tests.
- `crux/validate/validate-table-formatting.test.ts`: 13 tests covering each banned pattern, comment-line skipping, same-line + previous-line allow-marker handling, the "marker-as-string-literal does not exempt next line" case, multi-pattern-on-one-line precedence, plus a regression guard against the live codebase.
- Wired into `crux/validate/validate-gate.ts` as a blocking parallel check.

Verified by injecting a synthetic violation (`x.toLocaleString()` in a temp file under `apps/web/src/app/grants/`) — the validator caught it and exited 1 with a fix suggestion.

## Out of scope

- Internal admin tables under `apps/web/src/app/internal/*` (other than the two that had near-duplicate currency helpers): `groundskeeper-runs-table`, `agent-activity/sessions-table`, `system-health-table`, etc. still use `toLocaleDateString()`. These are admin-only and have specialized formatting needs; addressing them is a follow-up if needed.
- The QUA-767 helper module `apps/web/src/app/internal/entity-profile/format-cell-value.ts` is specialized for the Database Records tab (numeric strings with magnitude floor). It's intentionally not lifted to `lib/` since the directory tables use the broader compact helpers directly.

## Test plan

- [x] `pnpm crux w validate gate --fix` — 71/71 checks passed (including the new `table-formatting` check)
- [x] `pnpm build` — succeeds
- [x] `pnpm test` — passes for affected files; pre-existing `snapshot-resources` failures unrelated
- [x] `npx tsc --noEmit` — clean
- [x] `PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com npx playwright test e2e/render-audit.spec.ts` — 48/48 passed
- [x] Validator catches synthetic violation when injected; passes on clean tree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized number, currency, and date formatting across all data tables throughout the application for consistent presentation and visual alignment.

* **Tests**
  * Added validation suite to enforce consistent formatting patterns across table components and prevent regression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->