### PR TITLE
feat(build-data): replace pagination with /bulk endpoints (QUA-1040)

### DIFF
--- a/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
+++ b/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
@@ -10,6 +10,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   fetchJsonWithRetry,
+  fetchBulkItems,
   fetchRecordVerdicts,
   fetchPaginatedItems,
   setFullBuildMode,
@@ -158,6 +159,219 @@ describe('fetchJsonWithRetry', () => {
       backoffMs: 100,
     });
     expect(sleeps).toEqual([100, 200]); // 100ms before attempt 2, 200ms before attempt 3
+  });
+});
+
+describe('fetchBulkItems — QUA-1040', () => {
+  const noSleep = async () => {};
+
+  it('returns the items array on a successful single fetch', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({
+        ok: true,
+        json: { grants: [{ id: 'g1' }, { id: 'g2' }, { id: 'g3' }] },
+      }),
+    ]);
+    const result = await fetchBulkItems('http://x/api/grants/bulk', 'grants', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.items).toHaveLength(3);
+    expect(result.items[0].id).toBe('g1');
+    expect(calls).toHaveLength(1);
+  });
+
+  it('makes a SINGLE round-trip — no pagination', async () => {
+    const items = Array.from({ length: 1000 }, (_, i) => ({ id: `g${i}` }));
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { grants: items } }),
+    ]);
+    const result = await fetchBulkItems('http://x/api/grants/bulk', 'grants', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.items).toHaveLength(1000);
+    // The whole point of /bulk: one HTTP call regardless of dataset size.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe('http://x/api/grants/bulk');
+  });
+
+  it('inherits retry behavior from fetchJsonWithRetry on transient 500', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 500 }),
+      mockResponse({ ok: true, json: { items: [{ id: 1 }] } }),
+    ]);
+    const result = await fetchBulkItems('http://x/api/items/bulk', 'items', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('returns structured failure when the response key is missing', async () => {
+    // /bulk handlers must put rows under the documented key — anything else
+    // is a server-side regression that the caller should surface, not silently
+    // treat as "0 rows".
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { wrongKey: [{ id: 1 }] } }),
+    ]);
+    const result = await fetchBulkItems('http://x/api/grants/bulk', 'grants', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/missing array/i);
+  });
+
+  it('returns structured failure when the response key is not an array', async () => {
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { grants: 'oops' } }),
+    ]);
+    const result = await fetchBulkItems('http://x/api/grants/bulk', 'grants', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/missing array/i);
+  });
+
+  it('returns structured failure after exhausting retries', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+    ]);
+    const result = await fetchBulkItems('http://x/api/grants/bulk', 'grants', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+      attempts: 3,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(503);
+    expect(calls).toHaveLength(3);
+  });
+
+  it('returns empty items array when the server returns an empty result', async () => {
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { grants: [], total: 0 } }),
+    ]);
+    const result = await fetchBulkItems('http://x/api/grants/bulk', 'grants', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.items).toEqual([]);
+  });
+
+  it('falls back to paginated /all when /bulk returns 404 (deploy ordering)', async () => {
+    // Simulate older wiki-server: /bulk → 404, /all paginates normally.
+    const firstPage = Array.from({ length: 200 }, (_, i) => ({ id: `g${i}` }));
+    const lastPage = [{ id: 'g-last' }];
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 404 }),
+      mockResponse({ ok: true, json: { grants: firstPage } }),
+      mockResponse({ ok: true, json: { grants: lastPage } }),
+    ]);
+    const result = await fetchBulkItems('http://x/api/grants/bulk', 'grants', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+      paginatedFallbackUrl: 'http://x/api/grants/all',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.items).toHaveLength(201);
+    expect(calls[0]).toBe('http://x/api/grants/bulk');
+    expect(calls[1]).toContain('offset=0');
+    expect(calls[2]).toContain('offset=200');
+  });
+
+  it('does NOT fall back on 5xx — surfaces the error (so a real outage is not masked)', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+    ]);
+    const result = await fetchBulkItems('http://x/api/grants/bulk', 'grants', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+      paginatedFallbackUrl: 'http://x/api/grants/all',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(503);
+    // 3 attempts on /bulk, no fallback to /all — fallback is only for 404.
+    expect(calls).toHaveLength(3);
+    expect(calls.every((c) => c.includes('/bulk'))).toBe(true);
+  });
+
+  it('does NOT fall back on 404 when no fallback URL is configured', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 404 }),
+    ]);
+    const result = await fetchBulkItems('http://x/api/grants/bulk', 'grants', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe('fetchPaginatedItems — QUA-1040 deploy-ordering fallback', () => {
+  const noSleep = async () => {};
+
+  it('paginates with limit/offset and concatenates pages', async () => {
+    const page0 = Array.from({ length: 200 }, (_, i) => ({ id: `g${i}` }));
+    const page1 = Array.from({ length: 100 }, (_, i) => ({ id: `g${200 + i}` }));
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { grants: page0 } }),
+      mockResponse({ ok: true, json: { grants: page1 } }),
+    ]);
+    const { fetchPaginatedItems } = await import('../wiki-server-data.mjs');
+    const result = await fetchPaginatedItems('http://x/api/grants/all', 'grants', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.items).toHaveLength(300);
+    // Each page got its own AbortSignal via fetchJsonWithRetry — that's the QUA-1000 fix.
+    expect(calls[0]).toBe('http://x/api/grants/all?limit=200&offset=0');
+    expect(calls[1]).toBe('http://x/api/grants/all?limit=200&offset=200');
+  });
+
+  it('stops when a page comes back short (last page)', async () => {
+    const page0 = [{ id: 'a' }, { id: 'b' }];
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { items: page0 } }),
+    ]);
+    const { fetchPaginatedItems } = await import('../wiki-server-data.mjs');
+    const result = await fetchPaginatedItems('http://x/api/items/all', 'items', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+      pageSize: 200, // page came back with 2 < 200, so we stop
+    });
+    expect(result.ok).toBe(true);
+    expect(result.items).toEqual(page0);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('surfaces failure with offset context', async () => {
+    const page0 = Array.from({ length: 200 }, (_, i) => ({ id: i }));
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { items: page0 } }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+    ]);
+    const { fetchPaginatedItems } = await import('../wiki-server-data.mjs');
+    const result = await fetchPaginatedItems('http://x/api/items/all', 'items', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/offset=200/);
   });
 });
 
@@ -353,6 +567,11 @@ describe('fetchRecordVerdicts — QUA-421 strict-mode behavior (QUA-448: no env-
 });
 
 describe('fetchPaginatedItems — QUA-1000 per-page timeout regression', () => {
+  // QUA-1040 changed the return shape from `T[] | null` to
+  // `{ok: true, items: T[]} | {ok: false, reason, status}`. The QUA-1000
+  // regression contract (per-page fresh signals, no shared budget across
+  // pages or parallel callers) still applies — these tests are kept and
+  // updated to the new shape.
   const noSleep = async () => {};
 
   it('paginates correctly across multiple full pages', async () => {
@@ -367,15 +586,18 @@ describe('fetchPaginatedItems — QUA-1000 per-page timeout regression', () => {
       fetchImpl: fetcher,
       sleepImpl: noSleep,
     });
-    expect(result).toHaveLength(407);
+    expect(result.ok).toBe(true);
+    expect(result.items).toHaveLength(407);
     expect(calls[0]).toContain('limit=200&offset=0');
     expect(calls[1]).toContain('limit=200&offset=200');
     expect(calls[2]).toContain('limit=200&offset=400');
   });
 
-  it('returns null when a mid-pagination page exhausts retries', async () => {
-    // Matches the legacy contract: callers fall back to YAML-only data on
-    // partial pagination failures rather than ship a half-set.
+  it('returns failure when a mid-pagination page exhausts retries', async () => {
+    // QUA-1040: the legacy contract was `null` on partial failure; the new
+    // contract is `{ok: false, reason, status}` so callers can surface the
+    // reason instead of swallowing it. mergeCollection still treats this as
+    // "no data" and falls back to YAML-only — same downstream behavior.
     const { fetcher } = makeQueueFetcher([
       mockResponse({ ok: true, json: { items: Array.from({ length: 200 }, (_, i) => ({ id: i })) } }),
       mockResponse({ ok: false, status: 503 }),
@@ -386,7 +608,9 @@ describe('fetchPaginatedItems — QUA-1000 per-page timeout regression', () => {
       fetchImpl: fetcher,
       sleepImpl: noSleep,
     });
-    expect(result).toBeNull();
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(503);
+    expect(result.reason).toMatch(/offset=200/);
   });
 
   it('retries transient 5xx within a page and continues', async () => {
@@ -399,7 +623,8 @@ describe('fetchPaginatedItems — QUA-1000 per-page timeout regression', () => {
       fetchImpl: fetcher,
       sleepImpl: noSleep,
     });
-    expect(result).toHaveLength(201);
+    expect(result.ok).toBe(true);
+    expect(result.items).toHaveLength(201);
     expect(calls).toHaveLength(3);
   });
 
@@ -466,10 +691,14 @@ describe('fetchPaginatedItems — QUA-1000 per-page timeout regression', () => {
       fetchImpl: fetcher,
       sleepImpl: noSleep,
     });
-    expect(result).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.items).toEqual([]);
   });
 
-  it('treats missing itemsKey as empty (does not crash)', async () => {
+  it('treats a missing itemsKey as a structural failure (does not silently return [])', async () => {
+    // QUA-1040 contract change: the legacy version returned [] on a missing
+    // key, which silently masked server-side regressions. The new version
+    // surfaces the failure so callers (and `mergeCollection`) log a warning.
     const { fetcher } = makeQueueFetcher([
       mockResponse({ ok: true, json: { /* no items key */ } }),
     ]);
@@ -477,6 +706,7 @@ describe('fetchPaginatedItems — QUA-1000 per-page timeout regression', () => {
       fetchImpl: fetcher,
       sleepImpl: noSleep,
     });
-    expect(result).toEqual([]);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/missing array/i);
   });
 });

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -203,56 +203,135 @@ export async function fetchJsonWithRetry(url, opts = {}) {
 }
 
 /**
- * Fetch all pages of a paginated wiki-server endpoint.
+ * Fetch every row from a wiki-server `/bulk` endpoint in a single round-trip.
  *
- * Each page gets its own AbortSignal via {@link fetchJsonWithRetry} — there is
- * no shared signal across pages or parallel callers, and each page benefits
- * from the retry helper's exponential-backoff on transient 5xx/429/network
- * errors. Returns `null` on failure (matches the legacy contract: callers
- * usually fall back to YAML-only data).
+ * Use this for build-data (and other server-side consumers) that want the
+ * full row set. Pagination is the wrong shape for that caller (N round-trips,
+ * COUNT(*) per page, OFFSET cliff at the deepest page). UI/dashboard callers
+ * keep using the paginated `/all` endpoints.
  *
- * QUA-1000: pre-fix, the inner `fetchAllPages` helper inside
- * `mergePGRecordsIntoKB` shared a single 30s `AbortSignal.timeout` across
- * all 11 parallel paginated fetchers AND across every sequential page fetch
- * within each fetcher. The 30s timer was a wall-clock budget for the entire
- * parallel fanout — once it fired, every in-flight request aborted, including
- * the slowest endpoint (grants), which is what blocked CI.
+ * Wraps `fetchJsonWithRetry`, so each call has its own AbortSignal and gets
+ * the same exponential-backoff retry on transient 5xx/429/network errors.
  *
- * @param {string} baseUrl - full URL up to the path; no query string
- * @param {string} itemsKey - response field containing the array
+ * **Graceful deploy ordering** (QUA-1040): if the /bulk endpoint returns
+ * HTTP 404 — i.e. we're talking to an older wiki-server that doesn't have
+ * /bulk yet — and `paginatedFallbackUrl` is provided, the helper falls back
+ * to fetching all pages from the legacy `/all?limit=N&offset=M` endpoint.
+ * This lets the build-data and wiki-server changes ship in a single PR
+ * without a hard deploy ordering. Once /bulk is on prod everywhere, the
+ * fallback can be removed in a cleanup PR.
+ *
+ * Returns:
+ *   - { ok: true, items: T[] }            on success
+ *   - { ok: false, reason: string, ... }  on terminal failure
+ *
+ * @param {string} url          Full URL ending in `/bulk` (no `?limit=...`).
+ * @param {string} itemsKey     Response field containing the array, e.g. "grants".
  * @param {object} [opts]
- * @param {number} [opts.pageSize=200]
- * @param {number} [opts.timeoutMs=60_000] - per-page timeout
  * @param {HeadersInit} [opts.headers]
- * @param {typeof fetch} [opts.fetchImpl] - test override
- * @param {(ms: number) => Promise<void>} [opts.sleepImpl] - test override
- * @returns {Promise<any[] | null>}
+ * @param {number} [opts.timeoutMs]   Per-attempt timeout (default 60s — bulk
+ *                                    payloads are larger than a 200-row page).
+ * @param {number} [opts.attempts]    Total attempts (default 3).
+ * @param {string} [opts.paginatedFallbackUrl]  Full URL of the legacy
+ *                                    paginated endpoint (e.g. `.../all`). If
+ *                                    /bulk returns 404, fall back to fetching
+ *                                    pages from this URL (no query string).
+ * @param {number} [opts.fallbackPageSize]  Page size for the fallback path
+ *                                    (default 200).
+ * @param {typeof fetch} [opts.fetchImpl]   Test override.
+ * @param {(ms: number) => Promise<void>} [opts.sleepImpl]   Test override.
+ * @returns {Promise<{ok: true, items: any[]} | {ok: false, reason: string, status?: number}>}
  */
-export async function fetchPaginatedItems(baseUrl, itemsKey, opts = {}) {
-  const {
-    pageSize = 200,
-    timeoutMs = 60_000,
-    headers,
-    fetchImpl,
-    sleepImpl,
-  } = opts;
-  let allItems = [];
-  let offset = 0;
-  while (true) {
-    const url = `${baseUrl}?limit=${pageSize}&offset=${offset}`;
-    const result = await fetchJsonWithRetry(url, {
-      headers,
+export async function fetchBulkItems(url, itemsKey, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const attempts = opts.attempts ?? 3;
+
+  const result = await fetchJsonWithRetry(url, {
+    headers: opts.headers,
+    timeoutMs,
+    attempts,
+    fetchImpl: opts.fetchImpl,
+    sleepImpl: opts.sleepImpl,
+  });
+
+  if (result.ok) {
+    const items = result.data[itemsKey];
+    if (!Array.isArray(items)) {
+      return {
+        ok: false,
+        reason: `bulk response missing array at "${itemsKey}" (got ${typeof items})`,
+      };
+    }
+    return { ok: true, items };
+  }
+
+  // /bulk not deployed on this server yet → fall back to paginated /all.
+  // QUA-1040: lets this PR ship before the wiki-server deploys.
+  if (result.status === 404 && opts.paginatedFallbackUrl) {
+    return fetchPaginatedItems(opts.paginatedFallbackUrl, itemsKey, {
+      headers: opts.headers,
       timeoutMs,
-      fetchImpl,
-      sleepImpl,
+      attempts,
+      pageSize: opts.fallbackPageSize ?? 200,
+      fetchImpl: opts.fetchImpl,
+      sleepImpl: opts.sleepImpl,
     });
-    if (!result.ok) return null;
-    const items = result.data[itemsKey] || [];
-    allItems = allItems.concat(items);
+  }
+
+  return { ok: false, reason: result.reason, status: result.status };
+}
+
+/**
+ * Fetch every row from a paginated `/all?limit=N&offset=M` endpoint, page by
+ * page. Each page gets its own AbortSignal via `fetchJsonWithRetry` (no
+ * shared signal across pages — that's the QUA-1000 failure mode).
+ *
+ * Used as the deploy-ordering fallback for `fetchBulkItems`. New callers
+ * should prefer /bulk; this stays around so old wiki-servers keep working.
+ *
+ * @param {string} url          Full URL of `.../all` (no query string).
+ * @param {string} itemsKey     Response field containing the array.
+ * @param {object} [opts]
+ * @param {HeadersInit} [opts.headers]
+ * @param {number} [opts.timeoutMs]
+ * @param {number} [opts.attempts]
+ * @param {number} [opts.pageSize]
+ * @param {typeof fetch} [opts.fetchImpl]
+ * @param {(ms: number) => Promise<void>} [opts.sleepImpl]
+ * @returns {Promise<{ok: true, items: any[]} | {ok: false, reason: string, status?: number}>}
+ */
+export async function fetchPaginatedItems(url, itemsKey, opts = {}) {
+  const pageSize = opts.pageSize ?? 200;
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const attempts = opts.attempts ?? 3;
+  const allItems = [];
+  let offset = 0;
+
+  while (true) {
+    const pageUrl = `${url}?limit=${pageSize}&offset=${offset}`;
+    const result = await fetchJsonWithRetry(pageUrl, {
+      headers: opts.headers,
+      timeoutMs,
+      attempts,
+      fetchImpl: opts.fetchImpl,
+      sleepImpl: opts.sleepImpl,
+    });
+    if (!result.ok) {
+      return { ok: false, reason: `${result.reason} at offset=${offset}`, status: result.status };
+    }
+    const items = result.data[itemsKey];
+    if (!Array.isArray(items)) {
+      return {
+        ok: false,
+        reason: `paginated response missing array at "${itemsKey}" (got ${typeof items}) at offset=${offset}`,
+      };
+    }
+    allItems.push(...items);
     if (items.length < pageSize) break;
     offset += pageSize;
   }
-  return allItems;
+
+  return { ok: true, items: allItems };
 }
 
 /**
@@ -653,32 +732,26 @@ export async function fetchResearchAreas() {
 
   const headers = buildHeaders();
 
-  try {
-    const pageSize = 200;
-    let allItems = [];
-    let offset = 0;
-    while (true) {
-      // Per-page fresh AbortSignal + retries on transient failures (QUA-1000).
-      const url = `${serverUrl}/api/research-areas/enriched?limit=${pageSize}&offset=${offset}`;
-      const result = await fetchJsonWithRetry(url, { headers, timeoutMs: 60_000 });
-      if (!result.ok) {
-        logWikiServerWarning('research-areas', result.reason);
-        return [];
-      }
-      const items = result.data.researchAreas || [];
-      allItems = allItems.concat(items);
-      if (items.length < pageSize) break;
-      offset += pageSize;
-    }
+  // QUA-1040: single /enriched/bulk round-trip instead of paginating.
+  // Falls back to paginated /enriched if the server doesn't have /enriched/bulk yet.
+  const result = await fetchBulkItems(
+    `${serverUrl}/api/research-areas/enriched/bulk`,
+    'researchAreas',
+    {
+      headers,
+      paginatedFallbackUrl: `${serverUrl}/api/research-areas/enriched`,
+    },
+  );
 
-    if (allItems.length > 0) {
-      console.log(`  research-areas: ${allItems.length} enriched areas fetched from PG`);
-    }
-    return allItems;
-  } catch (err) {
-    logWikiServerWarning('research-areas', err instanceof Error ? err.message : String(err));
+  if (!result.ok) {
+    logWikiServerWarning('research-areas', result.reason);
     return [];
   }
+
+  if (result.items.length > 0) {
+    console.log(`  research-areas: ${result.items.length} enriched areas fetched from PG`);
+  }
+  return result.items;
 }
 
 /**
@@ -1512,8 +1585,22 @@ export async function mergePGRecordsIntoKB(kb) {
 
   if (!kb.records) kb.records = {};
 
-  const fetchAllPages = (endpoint, itemsKey) =>
-    fetchPaginatedItems(`${serverUrl}${endpoint}`, itemsKey, { headers });
+  // Fetch every record type via the per-table /bulk endpoints (QUA-1040).
+  // Each fetcher gets its own AbortSignal via fetchJsonWithRetry, so a slow
+  // bulk call can't share-cancel the parallel siblings (the QUA-1000 failure
+  // mode). /bulk returns all rows in a single round-trip — no pagination
+  // overhead, no OFFSET cliff at the deepest page.
+  /**
+   * @param {string} bulkPath        Path ending in /bulk (no query string).
+   * @param {string} paginatedPath   Path ending in /all (used as fallback if /bulk returns 404).
+   * @param {string} itemsKey        Response field containing the array.
+   */
+  function fetchBulk(bulkPath, paginatedPath, itemsKey) {
+    return fetchBulkItems(`${serverUrl}${bulkPath}`, itemsKey, {
+      headers,
+      paginatedFallbackUrl: `${serverUrl}${paginatedPath}`,
+    });
+  }
 
   const [
     personnelResult,
@@ -1528,17 +1615,17 @@ export async function mergePGRecordsIntoKB(kb) {
     entityAssessmentsResult,
     publicationsResult,
   ] = await Promise.allSettled([
-    fetchAllPages('/api/personnel/all', 'personnel'),
-    fetchAllPages('/api/grants/all', 'grants'),
-    fetchAllPages('/api/funding-rounds/all', 'fundingRounds'),
-    fetchAllPages('/api/investments/all', 'investments'),
-    fetchAllPages('/api/equity-positions/all', 'equityPositions'),
-    fetchAllPages('/api/divisions/all', 'divisions'),
-    fetchAllPages('/api/funding-programs/all', 'fundingPrograms'),
-    fetchAllPages('/api/division-personnel/all', 'divisionPersonnel'),
-    fetchAllPages('/api/entity-events/all', 'events'),
-    fetchAllPages('/api/entity-assessments/all', 'assessments'),
-    fetchAllPages('/api/publications/all', 'publications'),
+    fetchBulk('/api/personnel/bulk', '/api/personnel/all', 'personnel'),
+    fetchBulk('/api/grants/bulk', '/api/grants/all', 'grants'),
+    fetchBulk('/api/funding-rounds/bulk', '/api/funding-rounds/all', 'fundingRounds'),
+    fetchBulk('/api/investments/bulk', '/api/investments/all', 'investments'),
+    fetchBulk('/api/equity-positions/bulk', '/api/equity-positions/all', 'equityPositions'),
+    fetchBulk('/api/divisions/bulk', '/api/divisions/all', 'divisions'),
+    fetchBulk('/api/funding-programs/bulk', '/api/funding-programs/all', 'fundingPrograms'),
+    fetchBulk('/api/division-personnel/bulk', '/api/division-personnel/all', 'divisionPersonnel'),
+    fetchBulk('/api/entity-events/bulk', '/api/entity-events/all', 'events'),
+    fetchBulk('/api/entity-assessments/bulk', '/api/entity-assessments/all', 'assessments'),
+    fetchBulk('/api/publications/bulk', '/api/publications/all', 'publications'),
   ]);
 
   /**
@@ -1552,10 +1639,22 @@ export async function mergePGRecordsIntoKB(kb) {
    * @returns {number} count of records merged
    */
   function mergeCollection(label, result, yamlCollections, getEntityKey, getCollectionName, rowToEntry) {
-    const rows = result.status === 'fulfilled' ? result.value : null;
+    let rows = null;
+    if (result.status === 'fulfilled') {
+      const r = result.value;
+      if (r && r.ok) {
+        rows = r.items;
+      } else if (r) {
+        // Bulk fetcher returned a structured failure. Surface the reason.
+        logWikiServerWarning(`kb-pg ${label}`, r.reason || 'server unavailable');
+        return 0;
+      }
+    } else {
+      logWikiServerWarning(`kb-pg ${label}`, result.reason?.message || 'server unavailable');
+      return 0;
+    }
     if (!rows) {
-      const reason = result.status === 'rejected' ? result.reason?.message : 'no data';
-      logWikiServerWarning(`kb-pg ${label}`, reason || 'server unavailable');
+      logWikiServerWarning(`kb-pg ${label}`, 'no data');
       return 0;
     }
     if (rows.length === 0) return 0;
@@ -1626,8 +1725,12 @@ export async function mergePGRecordsIntoKB(kb) {
   // same company at different dates) are NOT duplicates — they are distinct
   // funding events that happen to share a name.
   let dedupedFundingRoundsResult = fundingRoundsResult;
-  if (fundingRoundsResult.status === 'fulfilled' && fundingRoundsResult.value) {
-    const rows = fundingRoundsResult.value;
+  if (
+    fundingRoundsResult.status === 'fulfilled' &&
+    fundingRoundsResult.value &&
+    fundingRoundsResult.value.ok
+  ) {
+    const rows = fundingRoundsResult.value.items;
     // Index: "entityKey|name" → { stableIdRows, legacyRows[] }
     const groups = new Map();
     for (const row of rows) {
@@ -1657,7 +1760,10 @@ export async function mergePGRecordsIntoKB(kb) {
     if (dropIds.size > 0) {
       const deduped = rows.filter(row => !dropIds.has(row.id));
       console.log(`  kb-pg funding-rounds: deduplicated ${dropIds.size} legacy duplicate(s)`);
-      dedupedFundingRoundsResult = { status: 'fulfilled', value: deduped };
+      dedupedFundingRoundsResult = {
+        status: 'fulfilled',
+        value: { ok: true, items: deduped },
+      };
     }
   }
   fundingRoundsCount = mergeCollection(
@@ -1966,46 +2072,32 @@ export async function fetchAllEntityStableIds() {
   if (!serverUrl) return null;
   const headers = buildHeaders();
 
-  // Dedupe at the source — offset-based pagination + concurrent inserts can
-  // return the same row twice or skip rows. The downstream Set-merge in
-  // build-data also handles dups, but doing it here keeps the function name
-  // honest and avoids surfacing duplicate counts to callers.
-  const stableIds = new Set();
-  const pageSize = 500;
-  const SAFETY_BOUND = 50_000; // hard cap — log a warning if approached
-  let offset = 0;
-  try {
-    while (true) {
-      // Per-page fresh AbortSignal + retries on transient failures (QUA-1000).
-      const url = `${serverUrl}/api/entities?limit=${pageSize}&offset=${offset}`;
-      const result = await fetchJsonWithRetry(url, { headers, timeoutMs: 60_000 });
-      if (!result.ok) {
-        // Mid-pagination failure → return null (matches the surrounding
-        // fetchAllPages pattern). Caller falls back to the YAML-only set;
-        // partial results would be worse than nothing because validators
-        // would mis-flag late-page entities as orphans.
-        logWikiServerWarning('allEntityStableIds', `${result.reason} at offset=${offset}`);
-        return null;
-      }
-      const items = result.data.entities || [];
-      for (const e of items) {
-        if (e.stableId) stableIds.add(e.stableId);
-      }
-      if (items.length < pageSize) break;
-      offset += pageSize;
-      if (offset >= SAFETY_BOUND) {
-        // Loud failure — silent truncation would let validators flag
-        // legitimate Tier 2 entities as orphans with no discoverable cause.
-        logWikiServerWarning(
-          'allEntityStableIds',
-          `safety-bound ${SAFETY_BOUND} reached — entities past offset ${offset} not loaded; raise SAFETY_BOUND in fetchAllEntityStableIds`,
-        );
-        break;
-      }
-    }
-  } catch (err) {
-    logWikiServerWarning('allEntityStableIds', err instanceof Error ? err.message : String(err));
+  // QUA-1040: single /bulk round-trip. Returns null on failure (caller
+  // falls back to YAML-only set; partial results would be worse than
+  // nothing because validators would mis-flag late entities as orphans).
+  // Falls back to paginated /api/entities if /bulk is not yet deployed.
+  const result = await fetchBulkItems(
+    `${serverUrl}/api/entities/bulk`,
+    'entities',
+    {
+      headers,
+      timeoutMs: 90_000, // entities is the largest table; allow extra time
+      paginatedFallbackUrl: `${serverUrl}/api/entities`,
+      fallbackPageSize: 500,
+    },
+  );
+
+  if (!result.ok) {
+    logWikiServerWarning('allEntityStableIds', result.reason);
     return null;
+  }
+
+  // Dedupe — concurrent writers can in theory produce duplicates and the
+  // downstream Set-merge would handle them anyway, but doing it here keeps
+  // the function name honest.
+  const stableIds = new Set();
+  for (const e of result.items) {
+    if (e.stableId) stableIds.add(e.stableId);
   }
   return [...stableIds];
 }

--- a/apps/wiki-server/src/__tests__/bulk-query.test.ts
+++ b/apps/wiki-server/src/__tests__/bulk-query.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { bulkQuery } from "../routes/shared/bulk-query.js";
+
+describe("bulkQuery (QUA-1040)", () => {
+  it("awaits the query and returns rows + total = rows.length", async () => {
+    const rows = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const result = await bulkQuery({ query: Promise.resolve(rows) });
+    expect(result.rows).toEqual(rows);
+    expect(result.total).toBe(3);
+  });
+
+  it("returns total = 0 for an empty result", async () => {
+    const result = await bulkQuery({ query: Promise.resolve([]) });
+    expect(result.rows).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("applies formatRow to every row", async () => {
+    const raw = [{ id: 1, hidden: "secret" }, { id: 2, hidden: "secret" }];
+    const result = await bulkQuery({
+      query: Promise.resolve(raw),
+      formatRow: (r) => ({ id: r.id }),
+    });
+    expect(result.rows).toEqual([{ id: 1 }, { id: 2 }]);
+    // Confirm raw shape was mapped, not leaked through
+    expect((result.rows[0] as Record<string, unknown>).hidden).toBeUndefined();
+  });
+
+  it("preserves order from the underlying query", async () => {
+    const raw = [{ id: "c" }, { id: "a" }, { id: "b" }];
+    const { rows } = await bulkQuery({ query: Promise.resolve(raw) });
+    expect(rows.map((r) => (r as { id: string }).id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("propagates query errors", async () => {
+    const err = new Error("DB exploded");
+    await expect(
+      bulkQuery({ query: Promise.reject(err) }),
+    ).rejects.toThrow("DB exploded");
+  });
+
+  it("logs a soft-limit warning when row count exceeds threshold", async () => {
+    // Spy on the logger module so we don't depend on its actual implementation.
+    const loggerModule = await import("../logger.js");
+    const warnSpy = vi.spyOn(loggerModule.logger, "warn").mockImplementation(() => undefined);
+
+    try {
+      const big = Array.from({ length: 11 }, (_, i) => ({ id: i }));
+      await bulkQuery({
+        query: Promise.resolve(big),
+        routeName: "test/bulk",
+        softLimit: 10,
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [meta] = warnSpy.mock.calls[0];
+      expect(meta).toMatchObject({ route: "test/bulk", rows: 11, softLimit: 10 });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does NOT warn when row count is at or below the soft limit", async () => {
+    const loggerModule = await import("../logger.js");
+    const warnSpy = vi.spyOn(loggerModule.logger, "warn").mockImplementation(() => undefined);
+
+    try {
+      const small = Array.from({ length: 10 }, (_, i) => ({ id: i }));
+      await bulkQuery({
+        query: Promise.resolve(small),
+        routeName: "test/bulk",
+        softLimit: 10,
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/apps/wiki-server/src/__tests__/bulk-routes.test.ts
+++ b/apps/wiki-server/src/__tests__/bulk-routes.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { mockDbModule } from "./test-utils.js";
+
+// QUA-1040 — /bulk endpoints. End-to-end tests against a representative
+// route (publications) to verify:
+//   1. /bulk returns { <key>: rows, total } shape.
+//   2. /bulk's row query carries NO LIMIT/OFFSET clause (the structural
+//      property we just added — pagination is the wrong shape for the build-data
+//      caller).
+//   3. /bulk does NOT issue a separate COUNT(*) query.
+//   4. Empty tables return rows: [], total: 0 cleanly.
+//
+// These are the regression contracts the rest of the build-data system
+// depends on. If a future refactor reintroduces pagination behind /bulk,
+// these tests fail loudly.
+
+interface PubRow {
+  id: string;
+  entity_id: string;
+  entity_display_name: string | null;
+  resource_id: string | null;
+  title: string;
+  authors: string | null;
+  url: string | null;
+  venue: string | null;
+  published_date: string | null;
+  publication_type: string;
+  citation_count: number | null;
+  is_flagship: boolean;
+  abstract: string | null;
+  source: string | null;
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+let publicationsStore: PubRow[];
+let dispatchedQueries: Array<{ query: string; params: unknown[] }>;
+
+function resetStores() {
+  publicationsStore = [];
+  dispatchedQueries = [];
+}
+
+function makePub(overrides: Partial<PubRow>): PubRow {
+  const now = new Date();
+  return {
+    id: "a".repeat(10),
+    entity_id: "sid_testentity",
+    entity_display_name: null,
+    resource_id: null,
+    title: "Untitled",
+    authors: null,
+    url: null,
+    venue: null,
+    published_date: "2024-01",
+    publication_type: "paper",
+    citation_count: null,
+    is_flagship: false,
+    abstract: null,
+    source: null,
+    notes: null,
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  };
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  dispatchedQueries.push({ query, params: [...params] });
+  const q = query.toLowerCase();
+
+  if (q.startsWith("select") && q.includes("count(") && q.includes('"publications"')) {
+    return [{ count: publicationsStore.length }];
+  }
+
+  if (q.startsWith("select") && q.includes('from "publications"')) {
+    return [...publicationsStore];
+  }
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+interface DrizzlePubRow {
+  id: string;
+  entityId: string;
+  publicationType: string;
+}
+
+describe("publications GET /bulk (QUA-1040)", () => {
+  beforeEach(async () => {
+    resetStores();
+    vi.resetModules();
+  });
+
+  it("returns { publications: [...], total } shape", async () => {
+    for (let i = 0; i < 10; i++) {
+      publicationsStore.push(makePub({ id: `pub${i}` }));
+    }
+
+    const { publicationsRoute } = await import("../routes/tablebase/publications.js");
+    const app = new Hono().route("/api/publications", publicationsRoute);
+
+    const res = await app.request("/api/publications/bulk");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      publications: DrizzlePubRow[];
+      total: number;
+    };
+    expect(body.publications).toHaveLength(10);
+    expect(body.total).toBe(10);
+    // No "limit" / "offset" leaked into the response — those are paginated-route fields.
+    expect(body).not.toHaveProperty("limit");
+    expect(body).not.toHaveProperty("offset");
+  });
+
+  it("does NOT add LIMIT or OFFSET to the row query (the QUA-1040 structural fix)", async () => {
+    publicationsStore.push(makePub({ id: "p1" }));
+    publicationsStore.push(makePub({ id: "p2" }));
+
+    const { publicationsRoute } = await import("../routes/tablebase/publications.js");
+    const app = new Hono().route("/api/publications", publicationsRoute);
+
+    const res = await app.request("/api/publications/bulk");
+    expect(res.status).toBe(200);
+
+    // Find the row query (SELECT ... FROM "publications" with no count())
+    const rowQuery = dispatchedQueries.find(
+      (d) =>
+        d.query.toLowerCase().includes('from "publications"') &&
+        !d.query.toLowerCase().includes("count("),
+    );
+    expect(rowQuery, "expected a row SELECT query against publications").toBeDefined();
+    // Pagination is the wrong shape for /bulk — explicitly assert there's
+    // no LIMIT/OFFSET. If a future change re-adds pagination, this fails loudly.
+    expect(rowQuery!.query.toLowerCase()).not.toMatch(/\blimit\s+\$/);
+    expect(rowQuery!.query.toLowerCase()).not.toMatch(/\boffset\s+\$/);
+  });
+
+  it("does NOT issue a separate COUNT(*) query (total comes from rows.length)", async () => {
+    publicationsStore.push(makePub({ id: "p1" }));
+    publicationsStore.push(makePub({ id: "p2" }));
+
+    const { publicationsRoute } = await import("../routes/tablebase/publications.js");
+    const app = new Hono().route("/api/publications", publicationsRoute);
+
+    const res = await app.request("/api/publications/bulk");
+    expect(res.status).toBe(200);
+
+    const countQueries = dispatchedQueries.filter(
+      (d) =>
+        d.query.toLowerCase().includes("count(") &&
+        d.query.toLowerCase().includes('"publications"'),
+    );
+    // /bulk should not issue a separate COUNT — `rows.length` is authoritative.
+    expect(countQueries).toHaveLength(0);
+  });
+
+  it("returns empty result cleanly when the table is empty", async () => {
+    const { publicationsRoute } = await import("../routes/tablebase/publications.js");
+    const app = new Hono().route("/api/publications", publicationsRoute);
+
+    const res = await app.request("/api/publications/bulk");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      publications: DrizzlePubRow[];
+      total: number;
+    };
+    expect(body.publications).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+});

--- a/apps/wiki-server/src/routes/shared/bulk-query.ts
+++ b/apps/wiki-server/src/routes/shared/bulk-query.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared helper for /bulk endpoints that return all rows in a single response.
+ *
+ * Companion to `paginatedQuery`. /bulk endpoints exist for build-data and other
+ * server-side consumers that want every row at once — pagination is pure
+ * overhead in that context (N round-trips, repeated COUNT(*), deepest-page
+ * OFFSET cliff). See QUA-1040 / QUA-1000.
+ *
+ * Usage:
+ *   .get("/bulk", async (c) => {
+ *     const db = getDrizzleDb();
+ *     const { rows, total } = await bulkQuery({
+ *       query: db.select(joinedSelect).from(table).leftJoin(...).orderBy(...),
+ *       formatRow,
+ *     });
+ *     return c.json({ myRecords: rows, total });
+ *   })
+ *
+ * The helper:
+ *   - Awaits the query (no COUNT, no LIMIT/OFFSET).
+ *   - Maps rows through optional `formatRow`.
+ *   - Logs a soft warning if the result exceeds `softLimit` (default 50k) so
+ *     unbounded growth is visible before it becomes a memory/payload problem.
+ *
+ * The caller builds the c.json() response itself (computed property keys
+ * preserve Hono RPC type inference).
+ */
+
+import { logger } from "../../logger.js";
+
+export interface BulkQueryOptions<TRow, TFormatted = TRow> {
+  /** The data query (no .limit()/.offset() — fetches all rows). */
+  query: PromiseLike<TRow[]>;
+  /** Optional row formatter. If omitted, raw rows are returned. */
+  formatRow?: (row: TRow) => TFormatted;
+  /** Identifier used in soft-limit warnings. Defaults to "<unknown>". */
+  routeName?: string;
+  /** Row count above which a warning is logged. Default 50_000. */
+  softLimit?: number;
+}
+
+export interface BulkQueryResult<T> {
+  rows: T[];
+  total: number;
+}
+
+/**
+ * Execute a query that returns every row, with no pagination and no separate
+ * COUNT.
+ */
+export async function bulkQuery<TRow, TFormatted = TRow>(
+  opts: BulkQueryOptions<TRow, TFormatted>,
+): Promise<BulkQueryResult<TFormatted>> {
+  const rawRows = await opts.query;
+  const rows = opts.formatRow
+    ? rawRows.map(opts.formatRow)
+    : (rawRows as unknown as TFormatted[]); // as-any-ok: TRow === TFormatted when no formatRow provided
+
+  const softLimit = opts.softLimit ?? 50_000;
+  if (rows.length > softLimit) {
+    logger.warn(
+      { route: opts.routeName ?? "<unknown>", rows: rows.length, softLimit },
+      "bulk endpoint returned more rows than soft limit — consider adding filtering or paginating downstream callers",
+    );
+  }
+
+  return { rows, total: rows.length };
+}

--- a/apps/wiki-server/src/routes/tablebase/division-personnel.ts
+++ b/apps/wiki-server/src/routes/tablebase/division-personnel.ts
@@ -8,6 +8,7 @@ import {
   zv,
 } from "../shared/utils.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 import { createSyncHandler } from "./sync-factory.js";
 
 // ---- Query schemas ----
@@ -84,6 +85,21 @@ const divisionPersonnelApp = new Hono()
       limit,
       offset,
     });
+  })
+
+  // ---- GET /bulk ----
+  // Returns every division-personnel row in a single response. QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows, total } = await bulkQuery({
+      query: db
+        .select()
+        .from(divisionPersonnel)
+        .orderBy(desc(divisionPersonnel.syncedAt), desc(divisionPersonnel.id)),
+      formatRow,
+      routeName: "division-personnel/bulk",
+    });
+    return c.json({ divisionPersonnel: rows, total });
   })
 
   // ---- GET /by-division/:divisionId ----

--- a/apps/wiki-server/src/routes/tablebase/divisions.ts
+++ b/apps/wiki-server/src/routes/tablebase/divisions.ts
@@ -13,6 +13,7 @@ import { InlineSourcingSchema } from "./sourcing-schema.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { createSyncHandler } from "./sync-factory.js";
 import { paginatedQuery } from "../shared/paginated-query.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 
 // ---- Constants ----
 
@@ -151,6 +152,21 @@ const divisionsApp = new Hono()
       formatRow,
     });
     return c.json({ divisions: rows, total, limit, offset });
+  })
+
+  // ---- GET /bulk ----
+  // Returns every division in a single response. QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows, total } = await bulkQuery({
+      query: db
+        .select()
+        .from(divisions)
+        .orderBy(desc(divisions.syncedAt), desc(divisions.id)),
+      formatRow,
+      routeName: "divisions/bulk",
+    });
+    return c.json({ divisions: rows, total });
   })
 
   // ---- GET /by-org/:orgId ----

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -21,6 +21,7 @@ import {
   SyncEntitiesBatchSchema,
 } from "../../api-types.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 import { applyAuditContext } from "../../middleware/audit-context.js";
 import {
   buildSearchCondition,
@@ -960,6 +961,33 @@ const entitiesApp = new Hono()
     const total = countResult[0].count;
 
     return c.json({ entities: rows, total, limit, offset });
+  })
+
+  // ---- GET /bulk — all entities, no pagination ----
+  // For build-data and other server-side consumers that need the full list
+  // in one round-trip. UI/dashboard callers stay on GET / (paginated).
+  // QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows, total } = await bulkQuery({
+      query: db
+        .select({
+          id: entities.id,
+          wikiId: entities.wikiId,
+          stableId: entities.stableId,
+          entityType: entities.entityType,
+          title: entities.title,
+          description: entities.description,
+          website: entities.website,
+          tags: entities.tags,
+          status: entities.status,
+          lastUpdated: entities.lastUpdated,
+        })
+        .from(entities)
+        .orderBy(asc(entities.id)),
+      routeName: "entities/bulk",
+    });
+    return c.json({ entities: rows, total });
   })
 
   // ---- POST /sync ----

--- a/apps/wiki-server/src/routes/tablebase/entity-assessments.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-assessments.ts
@@ -13,6 +13,7 @@ import {
 } from "../shared/resolve-entity-middleware.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { paginatedQuery } from "../shared/paginated-query.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 import { createSyncHandler } from "./sync-factory.js";
 
 // ---- Constants ----
@@ -72,6 +73,20 @@ const entityAssessmentsApp = new Hono<{ Variables: ResolvedEntityVars }>()
       countQuery: db.select({ count: count() }).from(entityAssessments),
     });
     return c.json({ assessments, total, limit, offset });
+  })
+
+  // ---- GET /bulk ----
+  // Returns every entity assessment in a single response. QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows: assessments, total } = await bulkQuery({
+      query: db
+        .select()
+        .from(entityAssessments)
+        .orderBy(entityAssessments.entityId, entityAssessments.dimension),
+      routeName: "entity-assessments/bulk",
+    });
+    return c.json({ assessments, total });
   })
 
   .get(

--- a/apps/wiki-server/src/routes/tablebase/entity-events.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-events.ts
@@ -13,6 +13,7 @@ import {
 } from "../shared/resolve-entity-middleware.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { paginatedQuery } from "../shared/paginated-query.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 import { createSyncHandler } from "./sync-factory.js";
 
 // ---- Constants ----
@@ -84,6 +85,20 @@ const entityEventsApp = new Hono<{ Variables: ResolvedEntityVars }>()
       countQuery: db.select({ count: count() }).from(entityEvents),
     });
     return c.json({ events, total, limit, offset });
+  })
+
+  // ---- GET /bulk ----
+  // Returns every entity event in a single response. QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows: events, total } = await bulkQuery({
+      query: db
+        .select()
+        .from(entityEvents)
+        .orderBy(desc(entityEvents.date), entityEvents.id),
+      routeName: "entity-events/bulk",
+    });
+    return c.json({ events, total });
   })
 
   .get(

--- a/apps/wiki-server/src/routes/tablebase/equity-positions.ts
+++ b/apps/wiki-server/src/routes/tablebase/equity-positions.ts
@@ -9,6 +9,7 @@ import {
   parseRange,
   clampedLimit,
 } from "../shared/utils.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-entity-middleware.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
@@ -148,6 +149,23 @@ const equityPositionsApp = new Hono<{ Variables: ResolvedEntityVars }>()
       limit,
       offset,
     });
+  })
+
+  // ---- GET /bulk ----
+  // Returns every equity position in a single response. QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows, total } = await bulkQuery({
+      query: db
+        .select(joinedSelect)
+        .from(equityPositions)
+        .leftJoin(holderEntity, eq(equityPositions.holderEntityId, holderEntity.stableId))
+        .leftJoin(companyEntity, eq(equityPositions.companyEntityId, companyEntity.stableId))
+        .orderBy(desc(equityPositions.syncedAt), equityPositions.id),
+      formatRow,
+      routeName: "equity-positions/bulk",
+    });
+    return c.json({ equityPositions: rows, total });
   })
 
   // ---- GET /by-entity/:entityId (positions in a company) ----

--- a/apps/wiki-server/src/routes/tablebase/funding-programs.ts
+++ b/apps/wiki-server/src/routes/tablebase/funding-programs.ts
@@ -10,6 +10,7 @@ import {
   zv,
 } from "../shared/utils.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 import { createSyncHandler } from "./sync-factory.js";
 import { InlineSourcingSchema } from "./sourcing-schema.js";
 
@@ -162,6 +163,21 @@ const fundingProgramsApp = new Hono()
       limit,
       offset,
     });
+  })
+
+  // ---- GET /bulk ----
+  // Returns every funding program in a single response. QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows, total } = await bulkQuery({
+      query: db
+        .select()
+        .from(fundingPrograms)
+        .orderBy(desc(fundingPrograms.syncedAt), desc(fundingPrograms.id)),
+      formatRow,
+      routeName: "funding-programs/bulk",
+    });
+    return c.json({ fundingPrograms: rows, total });
   })
 
   // ---- GET /by-org/:orgId ----

--- a/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
+++ b/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
@@ -10,6 +10,7 @@ import {
   noDuplicateIds,
   clampedLimit,
 } from "../shared/utils.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-entity-middleware.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
 import { InlineSourcingSchema } from "./sourcing-schema.js";
@@ -165,6 +166,23 @@ const fundingRoundsApp = new Hono<{ Variables: ResolvedEntityVars }>()
       limit,
       offset,
     });
+  })
+
+  // ---- GET /bulk ----
+  // Returns every funding round in a single response. QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows, total } = await bulkQuery({
+      query: db
+        .select(joinedSelect)
+        .from(fundingRounds)
+        .leftJoin(companyEntity, eq(fundingRounds.companyEntityId, companyEntity.stableId))
+        .leftJoin(leadInvestorEntity, eq(fundingRounds.leadInvestorEntityId, leadInvestorEntity.stableId))
+        .orderBy(desc(fundingRounds.syncedAt), fundingRounds.id),
+      formatRow,
+      routeName: "funding-rounds/bulk",
+    });
+    return c.json({ fundingRounds: rows, total });
   })
 
   // ---- GET /by-entity/:entityId ----

--- a/apps/wiki-server/src/routes/tablebase/grants.ts
+++ b/apps/wiki-server/src/routes/tablebase/grants.ts
@@ -22,6 +22,7 @@ import {
   clampedLimit,
 } from "../shared/utils.js";
 import { parseSort, buildSearchCondition } from "../shared/query-helpers.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 import { formatMoney } from "../shared/format-currency.js";
 import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-entity-middleware.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
@@ -243,6 +244,27 @@ const grantsApp = new Hono<{ Variables: ResolvedEntityVars }>()
       limit,
       offset,
     });
+  })
+
+  // ---- GET /bulk ----
+  // Returns every row in a single response. For build-data and other
+  // server-side consumers; UI/dashboard callers stay on /all (paginated).
+  // Skips per-row field verdicts (callers don't need them) and the COUNT(*).
+  // QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows, total } = await bulkQuery({
+      query: db
+        .select(joinedSelect)
+        .from(grants)
+        .leftJoin(granteeEntity, eq(grants.granteeEntityId, granteeEntity.stableId))
+        .leftJoin(orgEntity, eq(grants.orgEntityId, orgEntity.stableId))
+        .leftJoin(sourceVerdicts, verdictJoinCondition("grant", grants.id))
+        .orderBy(desc(grants.syncedAt), grants.id),
+      formatRow,
+      routeName: "grants/bulk",
+    });
+    return c.json({ grants: rows, total });
   })
 
   // ---- GET /by-entity/:entityId ----

--- a/apps/wiki-server/src/routes/tablebase/investments.ts
+++ b/apps/wiki-server/src/routes/tablebase/investments.ts
@@ -10,6 +10,7 @@ import {
   noDuplicateIds,
   clampedLimit,
 } from "../shared/utils.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-entity-middleware.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
 import { InlineSourcingSchema } from "./sourcing-schema.js";
@@ -168,6 +169,23 @@ const investmentsApp = new Hono<{ Variables: ResolvedEntityVars }>()
       limit,
       offset,
     });
+  })
+
+  // ---- GET /bulk ----
+  // Returns every investment in a single response. QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows, total } = await bulkQuery({
+      query: db
+        .select(joinedSelect)
+        .from(investments)
+        .leftJoin(investorEntity, eq(investments.investorEntityId, investorEntity.stableId))
+        .leftJoin(companyEntity, eq(investments.companyEntityId, companyEntity.stableId))
+        .orderBy(desc(investments.syncedAt), investments.id),
+      formatRow,
+      routeName: "investments/bulk",
+    });
+    return c.json({ investments: rows, total });
   })
 
   // ---- GET /by-entity/:entityId (investments in a company) ----

--- a/apps/wiki-server/src/routes/tablebase/personnel.ts
+++ b/apps/wiki-server/src/routes/tablebase/personnel.ts
@@ -18,6 +18,7 @@ import {
   noDuplicateIds,
   clampedLimit,
 } from "../shared/utils.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-entity-middleware.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
 import { logAuditEntries } from "./audit-log.js";
@@ -206,6 +207,26 @@ const personnelApp = new Hono<{ Variables: ResolvedEntityVars }>()
       limit,
       offset,
     });
+  })
+
+  // ---- GET /bulk ----
+  // Returns every personnel row in a single response. For build-data and
+  // server-side consumers; UI/dashboard callers stay on /all (paginated).
+  // QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows, total } = await bulkQuery({
+      query: db
+        .select(joinedSelect)
+        .from(personnel)
+        .leftJoin(personEntity, eq(personnel.personEntityId, personEntity.stableId))
+        .leftJoin(orgEntity, eq(personnel.orgEntityId, orgEntity.stableId))
+        .leftJoin(sourceVerdicts, verdictJoinCondition("personnel", personnel.id))
+        .orderBy(desc(personnel.syncedAt), personnel.id),
+      formatRow,
+      routeName: "personnel/bulk",
+    });
+    return c.json({ personnel: rows, total });
   })
 
   // ---- GET /by-entity/:entityId ----

--- a/apps/wiki-server/src/routes/tablebase/publications.ts
+++ b/apps/wiki-server/src/routes/tablebase/publications.ts
@@ -14,6 +14,7 @@ import {
 } from "../shared/resolve-entity-middleware.js";
 import { InlineSourcingSchema } from "./sourcing-schema.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 import { createSyncHandler } from "./sync-factory.js";
 
 // ---- Constants ----
@@ -121,6 +122,20 @@ const publicationsApp = new Hono<{ Variables: ResolvedEntityVars }>()
       limit,
       offset,
     });
+  })
+
+  // ---- GET /bulk ----
+  // Returns every publication in a single response. QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows, total } = await bulkQuery({
+      query: db
+        .select()
+        .from(publications)
+        .orderBy(desc(publications.publishedDate), publications.id),
+      routeName: "publications/bulk",
+    });
+    return c.json({ publications: rows, total });
   })
 
   .get(

--- a/apps/wiki-server/src/routes/tablebase/research-areas.ts
+++ b/apps/wiki-server/src/routes/tablebase/research-areas.ts
@@ -12,6 +12,7 @@ import {
 } from "../shared/utils.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { bulkQuery } from "../shared/bulk-query.js";
 import { createSyncHandler } from "./sync-factory.js";
 import {
   researchAreas,
@@ -316,6 +317,101 @@ const researchAreasApp = new Hono()
     });
 
     return c.json({ researchAreas: enriched });
+  })
+
+  // ---- GET /enriched/bulk — all enriched areas, no pagination ----
+  // For build-data / server-side consumers; UI callers stay on /enriched
+  // (paginated). QUA-1040.
+  .get("/enriched/bulk", async (c) => {
+    const db = getDrizzleDb();
+
+    // Same parallel fanout as /enriched, minus the limit/offset.
+    const [rows, orgCounts, paperCounts, grantStats, riskCounts] = await Promise.all([
+      db
+        .select()
+        .from(researchAreas)
+        .orderBy(researchAreas.cluster, researchAreas.title),
+      db
+        .select({
+          researchAreaId: researchAreaOrganizations.researchAreaId,
+          count: count(),
+        })
+        .from(researchAreaOrganizations)
+        .groupBy(researchAreaOrganizations.researchAreaId),
+      db
+        .select({
+          researchAreaId: researchAreaPapers.researchAreaId,
+          count: count(),
+        })
+        .from(researchAreaPapers)
+        .groupBy(researchAreaPapers.researchAreaId),
+      db
+        .select({
+          researchAreaId: grantResearchAreas.researchAreaId,
+          grantCount: count(),
+          totalFunding: sql<string>`COALESCE(SUM(${grants.amount}::numeric), 0)`,
+        })
+        .from(grantResearchAreas)
+        .leftJoin(grants, eq(grantResearchAreas.grantId, grants.id))
+        .groupBy(grantResearchAreas.researchAreaId),
+      db
+        .select({
+          researchAreaId: researchAreaRisks.researchAreaId,
+          count: count(),
+        })
+        .from(researchAreaRisks)
+        .groupBy(researchAreaRisks.researchAreaId),
+    ]);
+
+    const directOrgCountMap = new Map(orgCounts.map((r) => [r.researchAreaId, r.count]));
+    const directPaperCountMap = new Map(paperCounts.map((r) => [r.researchAreaId, r.count]));
+    const grantStatsMap = new Map(
+      grantStats.map((r) => [
+        r.researchAreaId,
+        { grantCount: r.grantCount, totalFunding: r.totalFunding },
+      ])
+    );
+    const riskCountMap = new Map(riskCounts.map((r) => [r.researchAreaId, r.count]));
+
+    const getEffectiveCount = (
+      directMap: Map<string, number>,
+      areaId: string,
+      parentAreaId: string | null
+    ): number => {
+      const own = directMap.get(areaId) ?? 0;
+      const inherited = parentAreaId ? (directMap.get(parentAreaId) ?? 0) : 0;
+      return own + inherited;
+    };
+
+    const enriched = rows.map((r) => {
+      const gs = grantStatsMap.get(r.id);
+      return {
+        ...formatRow(r),
+        orgCount: getEffectiveCount(directOrgCountMap, r.id, r.parentAreaId),
+        paperCount: getEffectiveCount(directPaperCountMap, r.id, r.parentAreaId),
+        grantCount: gs?.grantCount ?? 0,
+        totalFunding: gs?.totalFunding ?? "0",
+        riskCount: riskCountMap.get(r.id) ?? 0,
+      };
+    });
+
+    return c.json({ researchAreas: enriched, total: enriched.length });
+  })
+
+  // ---- GET /bulk — all areas without enrichment ----
+  // Lighter alternative to /enriched/bulk for callers that don't need
+  // computed stats. QUA-1040.
+  .get("/bulk", async (c) => {
+    const db = getDrizzleDb();
+    const { rows, total } = await bulkQuery({
+      query: db
+        .select()
+        .from(researchAreas)
+        .orderBy(researchAreas.cluster, researchAreas.title),
+      formatRow,
+      routeName: "research-areas/bulk",
+    });
+    return c.json({ researchAreas: rows, total });
   })
 
   // ---- GET /:id ----


### PR DESCRIPTION
## Summary

Closes [QUA-1040](https://linear.app/quantifieduncertainty/issue/QUA-1040) — pagination is the wrong shape for `build-data.mjs`.

QUA-1000 fixed the immediate timeout in `mergePGRecordsIntoKB` by giving each page its own `AbortSignal`. This PR removes the failure class entirely by adding `/bulk` endpoints that return all rows in a single round-trip. Pagination exists to protect browsers (latency, memory, scrolling UX). The caller is a Node process running in CI talking to k8s over HTTP, with no UI — N round-trips, COUNT(*) per page, and the OFFSET cliff at the deepest page are pure overhead in that context.

## What changed

### Server side

* **New `bulkQuery` helper** in `apps/wiki-server/src/routes/shared/bulk-query.ts` — companion to the existing `paginatedQuery` helper. Skips COUNT (`rows.length` is authoritative) and emits a soft-limit warning at 50k rows so unbounded growth doesn't sneak in.
* **New `.get("/bulk", …)` handler on each of the 13 affected routes**: `personnel`, `grants`, `funding-rounds`, `investments`, `equity-positions`, `divisions`, `funding-programs`, `division-personnel`, `entity-events`, `entity-assessments`, `publications`, `research-areas` (`/bulk` + `/enriched/bulk`), `entities`. Each handler reuses the route's existing `joinedSelect` + joins + `formatRow` — no DB shape duplication. Existing `/all` routes are unchanged (UI/dashboard callers keep paginating).

### Client side (`apps/web/scripts/lib/wiki-server-data.mjs`)

* **`fetchBulkItems(url, key, opts)`** — wraps `fetchJsonWithRetry` for a single round-trip with exponential-backoff retry on 5xx/429/network errors, and `Array.isArray` validation on the documented response key.
* **`fetchPaginatedItems(url, key, opts)`** — deploy-ordering fallback: if `/bulk` returns 404 (older wiki-server), `fetchBulkItems` automatically retries via `/all?limit=N&offset=M`. **5xx errors do NOT trigger fallback** — they surface as failures so a real outage isn't masked.
* Replaced 13 paginated callsites in `mergePGRecordsIntoKB`, `fetchResearchAreas`, and `fetchAllEntityStableIds`.

## Why the fallback exists

Prod wiki-server is deployed via `wiki-server-docker.yml` on push to the `production` branch — but CI for this PR runs against the current prod, which doesn't yet have `/bulk`. Without the fallback, `build-data` in CI would 404 immediately. With it, the deploy ordering is invisible: old prod → `/all` paginated, new prod → `/bulk` single round-trip. After the wiki-server deploys, `paginatedFallbackUrl` and `fetchPaginatedItems` can be removed in a small cleanup PR.

## Test plan

- [x] Wiki-server unit + integration: `pnpm --filter wiki-server exec vitest run` → **1667 tests pass** (added 7 unit + 4 integration: response shape, no LIMIT/OFFSET in SQL, no separate COUNT, empty-result handling).
- [x] Build-data: `pnpm exec vitest run apps/web/scripts/lib/__tests__/` → **225 tests pass** (added 7 `fetchBulkItems` + 4 deploy-fallback + 3 `fetchPaginatedItems`: empty result, missing key, non-array, exhausted retries, 404→fallback, 503 no fallback).
- [x] Gate: ✅ All 5 gate checks passed (104.3s).
- [x] Smoke test: `WIKI_SERVER_ENV=prod pnpm sync:data` against current prod → 0 wiki-server warnings, `kb-pg: 1699 personnel, 5876 grants, 100 funding rounds, 67 investments, 13 equity positions, 124 divisions, 61 funding programs, 100 events, 83 assessments, 185 publications merged from PG`. Since prod doesn't yet have `/bulk`, this exercised the 404→`/all` fallback path end-to-end — exactly the deploy-ordering safety net.
- [ ] CI passes on this PR.
- [ ] After release PR ships the wiki-server with `/bulk`: open the cleanup PR to remove `paginatedFallbackUrl` and `fetchPaginatedItems`.

## Notes for reviewer

* `mergeCollection` was updated to unwrap the new `{ ok, items }` shape and surface structured failure reasons — previously it just got a raw array or `null`.
* The funding-rounds dedup block (legacy numeric companyId vs sid_) was also updated for the new shape.
* `bulkQuery` mirrors `paginatedQuery` deliberately. Each `.get("/bulk", …)` handler stays inline (~6 lines per route) so Hono RPC type inference works per-route — a generic handler factory would lose the literal property keys.

Fixes QUA-1040


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk API endpoints to fetch complete datasets without pagination across research areas, entities, personnel, publications, grants, investments, funding programs, assessments, and other data types
  * Implemented automatic fallback and retry mechanisms for improved reliability and compatibility with server versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->