### PR TITLE
feat(QUA-1003): adopt tabsLayout="vertical" on multi-tab entity profile pages

### DIFF
--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -242,55 +242,6 @@ export default async function AiModelDetailPage({
     </div>
   );
 
-  // Sidebar: Details + Tags. Capabilities moved into the Overview tab so
-  // the sidebar stays focused on canonical metadata.
-  const sidebar = (
-    <>
-      <section>
-        <h2 className="text-lg font-bold tracking-tight mb-4">Details</h2>
-        <div className="border border-border/60 rounded-xl bg-card">
-          <DetailRow label="Model Family" value={entity.modelFamily} />
-          <DetailRow label="Tier" value={entity.modelTier} capitalize />
-          <DetailRow label="Generation" value={entity.generation} />
-          <DetailRow label="Release Date" value={entity.releaseDate} />
-          <DetailRow label="Parameters" value={entity.parameterCount} />
-          <DetailRow
-            label="Context Window"
-            value={
-              entity.contextWindow != null
-                ? `${formatContext(entity.contextWindow)} tokens`
-                : undefined
-            }
-          />
-          <DetailRow label="Training Cutoff" value={entity.trainingCutoff} />
-          <DetailRow
-            label="Open Weight"
-            value={
-              entity.openWeight != null ? (entity.openWeight ? "Yes" : "No") : undefined
-            }
-          />
-          <DetailRow label="Safety Level" value={entity.safetyLevel} />
-        </div>
-      </section>
-
-      {entity.tags.length > 0 && (
-        <section>
-          <h2 className="text-lg font-bold tracking-tight mb-4">Tags</h2>
-          <div className="flex flex-wrap gap-1.5">
-            {entity.tags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-muted/50 text-muted-foreground"
-              >
-                {tag}
-              </span>
-            ))}
-          </div>
-        </section>
-      )}
-    </>
-  );
-
   return (
     <EntityProfileShell
       breadcrumbs={[
@@ -307,29 +258,7 @@ export default async function AiModelDetailPage({
       tabs={tabs}
       tabsAriaLabel="AI model sections"
       tabsLayout="vertical"
-      sidebar={sidebar}
     />
   );
 }
 
-function DetailRow({
-  label,
-  value,
-  capitalize,
-}: {
-  label: string;
-  value?: string | null;
-  capitalize?: boolean;
-}) {
-  if (!value) return null;
-  return (
-    <div className="px-4 py-2.5 border-b border-border/40 last:border-b-0 flex items-center justify-between gap-2">
-      <span className="text-xs text-muted-foreground">{label}</span>
-      <span
-        className={`text-sm font-medium ${capitalize ? "capitalize" : ""}`}
-      >
-        {value}
-      </span>
-    </div>
-  );
-}

--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -306,6 +306,7 @@ export default async function AiModelDetailPage({
       statCards={statCards}
       tabs={tabs}
       tabsAriaLabel="AI model sections"
+      tabsLayout="vertical"
       sidebar={sidebar}
     />
   );

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/page.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/page.tsx
@@ -298,6 +298,7 @@ export default async function FrameworkDetailPage({
       statCards={statCards}
       tabs={tabs}
       tabsAriaLabel="Framework sections"
+      tabsLayout="vertical"
       sidebar={sidebar}
     />
   );

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/page.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import Link from "next/link";
 import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
 import {
   fetchEntitySourcingSummary,
@@ -257,32 +256,6 @@ export default async function FrameworkDetailPage({
     </p>
   );
 
-  const sidebar = (
-    <section>
-      <h2 className="text-sm font-semibold text-muted-foreground mb-3 uppercase tracking-wide">
-        About this tracker
-      </h2>
-      <div className="text-xs text-muted-foreground space-y-2 leading-relaxed">
-        <p>
-          Each framework version is fetched, hashed, and archived. Capability
-          thresholds are LLM-extracted with mandatory source quotes; diffs
-          between consecutive versions are classified before any directional
-          summary is shown publicly.
-        </p>
-        <p>
-          See the{" "}
-          <Link
-            href="/frontier-safety-frameworks/methodology"
-            className="underline hover:text-primary"
-          >
-            methodology page
-          </Link>{" "}
-          for extraction, classification, and review-state details.
-        </p>
-      </div>
-    </section>
-  );
-
   return (
     <EntityProfileShell
       breadcrumbs={[
@@ -299,7 +272,6 @@ export default async function FrameworkDetailPage({
       tabs={tabs}
       tabsAriaLabel="Framework sections"
       tabsLayout="vertical"
-      sidebar={sidebar}
     />
   );
 }

--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -833,6 +833,7 @@ export default async function LegislationDetailPage({
       headerLinks={headerLinks}
       tabs={tabs}
       tabsAriaLabel="Legislation sections"
+      tabsLayout="vertical"
       sidebar={sidebar}
     />
   );

--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -771,49 +771,6 @@ export default async function LegislationDetailPage({
     </div>
   );
 
-  // Sidebar — Quick Facts, Position Summary, Tags
-  const sidebar = (
-    <>
-      <section className="rounded-xl border border-border p-4 space-y-3">
-        <h3 className="text-sm font-bold">Quick Facts</h3>
-        <dl className="space-y-2 text-sm">
-          {billNumber && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Bill Number</dt><dd className="font-semibold">{billNumber}</dd></div>}
-          {jurisdiction && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Jurisdiction</dt><dd>{jurisdiction}</dd></div>}
-          {entity.session && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Session</dt><dd>{entity.session}</dd></div>}
-          {author && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Author / Sponsor</dt><dd>{author}</dd></div>}
-          {introduced && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Introduced</dt><dd>{formatIntroducedDate(introduced)}</dd></div>}
-          {statusKey && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Status</dt><dd className="capitalize">{statusKey}</dd></div>}
-          {scope && <div><dt className="text-xs text-muted-foreground/70 uppercase tracking-wider">Scope</dt><dd>{scope}</dd></div>}
-        </dl>
-      </section>
-      {entity.stakeholders.length > 0 && (
-        <section className="rounded-xl border border-border p-4">
-          <h3 className="text-sm font-bold mb-3">Position Summary</h3>
-          <div className="space-y-2">
-            {supporters.length > 0 && <div className="flex items-center justify-between text-sm"><span className="text-green-700 dark:text-green-400 font-medium">Support</span><span className="tabular-nums font-semibold">{supporters.length}</span></div>}
-            {opponents.length > 0 && <div className="flex items-center justify-between text-sm"><span className="text-red-700 dark:text-red-400 font-medium">Oppose</span><span className="tabular-nums font-semibold">{opponents.length}</span></div>}
-            {mixed.length > 0 && <div className="flex items-center justify-between text-sm"><span className="text-amber-700 dark:text-amber-400 font-medium">Mixed</span><span className="tabular-nums font-semibold">{mixed.length}</span></div>}
-            <div className="flex rounded-full overflow-hidden h-2 mt-1">
-              {supporters.length > 0 && <div className="bg-green-500" style={{ width: `${(supporters.length / entity.stakeholders.length) * 100}%` }} />}
-              {mixed.length > 0 && <div className="bg-amber-500" style={{ width: `${(mixed.length / entity.stakeholders.length) * 100}%` }} />}
-              {opponents.length > 0 && <div className="bg-red-500" style={{ width: `${(opponents.length / entity.stakeholders.length) * 100}%` }} />}
-            </div>
-          </div>
-        </section>
-      )}
-      {entity.tags.length > 0 && (
-        <section className="rounded-xl border border-border p-4">
-          <h3 className="text-sm font-bold mb-3">Tags</h3>
-          <div className="flex flex-wrap gap-1.5">
-            {entity.tags.map((tag) => (
-              <span key={tag} className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-muted text-muted-foreground">{tag}</span>
-            ))}
-          </div>
-        </section>
-      )}
-    </>
-  );
-
   return (
     <EntityProfileShell
       breadcrumbs={[
@@ -834,7 +791,6 @@ export default async function LegislationDetailPage({
       tabs={tabs}
       tabsAriaLabel="Legislation sections"
       tabsLayout="vertical"
-      sidebar={sidebar}
     />
   );
 }

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -444,6 +444,7 @@ export default async function PersonProfilePage({
       statCards={statCards}
       tabs={tabs}
       tabsAriaLabel="Person sections"
+      tabsLayout="vertical"
       sidebar={sidebar}
     />
   );

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -14,10 +14,7 @@ import {
   getCareerHistory,
   getFundingConnectionsForPerson,
 } from "../people-utils";
-import {
-  getKBFacts,
-  getKBLatest,
-} from "@/data/factbase";
+import { getKBLatest } from "@/data/factbase";
 import {
   resolveEntityRef,
   formatAmount,
@@ -26,7 +23,6 @@ import {
 } from "@/lib/directory-utils";
 import {
   ProfileStatCard,
-  FactsPanel,
   type ProfileTab,
 } from "@/components/directory";
 import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
@@ -34,7 +30,6 @@ import { formatKBDate } from "@/components/wiki/factbase/format";
 import { getPersonEntityById, getTypedEntityById, isPerson } from "@/data";
 import type { Entity } from "@longterm-wiki/factbase";
 import { ExpertPositions } from "./expert-positions";
-import { SocialLinks } from "./social-links";
 import { CareerHistory } from "./career-history";
 import { EducationSection } from "./education-section";
 import { FundingConnections } from "./funding-connections";
@@ -188,20 +183,6 @@ export default async function PersonProfilePage({
   const netWorthFact = getKBLatest(entity.id, "net-worth");
   const educationFact = getKBLatest(entity.id, "education");
   const notableForFact = getKBLatest(entity.id, "notable-for");
-  const socialMediaFact = getKBLatest(entity.id, "social-media");
-  const websiteFact = getKBLatest(entity.id, "website");
-  const googleScholarFact = getKBLatest(entity.id, "google-scholar");
-  const githubFact = getKBLatest(entity.id, "github-profile");
-  const wikipediaFact = getKBLatest(entity.id, "wikipedia-url");
-
-  // Social links facts for the sidebar component
-  const socialLinkFacts = {
-    "website": websiteFact,
-    "social-media": socialMediaFact,
-    "github-profile": githubFact,
-    "google-scholar": googleScholarFact,
-    "wikipedia-url": wikipediaFact,
-  };
 
   // Expert positions from typed entity (consolidated from experts.yaml at build time)
   const personEntity = getPersonEntityById(slug);
@@ -233,11 +214,6 @@ export default async function PersonProfilePage({
     fetchCampaignFinance(entity.id),
     fetchPoliticalVotes(entity.id),
   ]);
-
-  // All facts for count
-  const allFacts = getKBFacts(entity.id).filter(
-    (f) => f.propertyId !== "description",
-  );
 
   // Resolve employer reference
   const employer =
@@ -416,15 +392,6 @@ export default async function PersonProfilePage({
     </div>
   );
 
-  const sidebar = (
-    <>
-      <SocialLinks facts={socialLinkFacts} />
-      {allFacts.length > 0 && (
-        <FactsPanel facts={allFacts} entityId={entity.id} />
-      )}
-    </>
-  );
-
   return (
     <EntityProfileShell
       breadcrumbs={[
@@ -445,7 +412,6 @@ export default async function PersonProfilePage({
       tabs={tabs}
       tabsAriaLabel="Person sections"
       tabsLayout="vertical"
-      sidebar={sidebar}
     />
   );
 }

--- a/docs/agent-rules/entity-profile-pages.md
+++ b/docs/agent-rules/entity-profile-pages.md
@@ -38,14 +38,15 @@ Adding a new "show on all entity pages" item is a one-line change inside
   `fetchEntitySourcingSummary()` + `rollupVerdictFromSummary()` for the
   sourcing rollup badge
 - Reference implementations:
-  - `apps/web/src/app/organizations/[slug]/page.tsx` (uses the shell with
-    `tabs` and no sidebar)
+  - `apps/web/src/app/organizations/[slug]/[[...tab]]/page.tsx` (canonical:
+    vertical tabs with `tabGroups`, path-based `tabRouting`, no sidebar)
   - `apps/web/src/app/organizations/[slug]/data/page.tsx` (uses the shell with
     `children` — the long-form data table — and the same slot-builder helper)
-  - `apps/web/src/app/people/[slug]/page.tsx` (uses `tabs` **and** `sidebar`
-    for the 2-column people layout)
-  - `apps/web/src/app/ai-models/[slug]/page.tsx` (uses `children` + `sidebar`
-    with no tabs)
+  - `apps/web/src/app/people/[slug]/page.tsx` (vertical tabs, no `tabGroups`)
+  - `apps/web/src/app/ai-models/[slug]/page.tsx` (vertical tabs)
+  - `apps/web/src/app/legislation/[slug]/page.tsx` (vertical tabs)
+  - `apps/web/src/app/projects/[slug]/page.tsx` (uses `children` only — no
+    tabs — so vertical layout doesn't apply)
 
 ## API at a glance
 
@@ -66,16 +67,32 @@ Adding a new "show on all entity pages" item is a one-line change inside
   statCards={<StatCardsGrid cards={cards} />}
   tabs={tabs}                         // ProfileTab[]
   tabsAriaLabel="Organization sections"
-  sidebar={<SidebarContent />}        // optional right-hand sidebar
+  tabsLayout="vertical"               // required when tabs has >1 entry — see below
+  tabGroups={tabGroups}               // optional — left-nav grouping (organization-style)
+  sidebar={<SidebarContent />}        // optional right-hand sidebar; ignored in vertical layout
 >
   {/* Optional children render inside the main column below tabs */}
 </EntityProfileShell>
 ```
 
+- **Multi-tab pages must use `tabsLayout="vertical"`.** Any page that passes
+  `tabs={...}` with more than one selectable tab is required to also pass
+  `tabsLayout="vertical"` so the tab nav renders on the left rail (the
+  `/organizations` look). Single-tab pages and pages that render their body
+  through `children` instead of `tabs` are exempt — `ProfileTabs` short-circuits
+  the layout choice in the single-tab case. The horizontal default is kept on
+  `EntityProfileShell` only as the fallback for the short-circuit path.
 - When `sidebar` is provided, the main column renders in a `lg:grid-cols-3`
-  2-column layout with the sidebar on the right.
+  2-column layout with the sidebar on the right. **In vertical-tabs mode the
+  `sidebar` slot is ignored** — the left nav takes the sidebar slot. If a page
+  has sidebar content that needs to remain visible, fold it into the Overview
+  tab content or add a dedicated tab.
 - When `tabs` is provided, `ProfileTabs` is rendered automatically — pages
   should not import `ProfileTabs` directly anymore.
+- `tabGroups` is optional. Use it on pages with many tabs that benefit from
+  labelled left-nav sections (see `ORG_TAB_GROUPS` in
+  `apps/web/src/app/organizations/[slug]/tabs.ts` for the canonical pattern).
+  Pages with 3-5 tabs typically don't need groups.
 - The sourcing rollup dot is **always** rendered in the header, using
   `SourcingDot` + `recordVerdictToStatus`, so every entity page has a
   consistent sourcing badge. Pass `verdict` as the raw verdict string

--- a/docs/agent-rules/entity-profile-pages.md
+++ b/docs/agent-rules/entity-profile-pages.md
@@ -39,7 +39,7 @@ Adding a new "show on all entity pages" item is a one-line change inside
   sourcing rollup badge
 - Reference implementations:
   - `apps/web/src/app/organizations/[slug]/[[...tab]]/page.tsx` (canonical:
-    vertical tabs with `tabGroups`, path-based `tabRouting`, no sidebar)
+    vertical tabs with `tabGroups`, path-based `tabRouting`)
   - `apps/web/src/app/organizations/[slug]/data/page.tsx` (uses the shell with
     `children` — the long-form data table — and the same slot-builder helper)
   - `apps/web/src/app/people/[slug]/page.tsx` (vertical tabs, no `tabGroups`)
@@ -78,10 +78,13 @@ Adding a new "show on all entity pages" item is a one-line change inside
 - **Multi-tab pages must use `tabsLayout="vertical"`.** Any page that passes
   `tabs={...}` with more than one selectable tab is required to also pass
   `tabsLayout="vertical"` so the tab nav renders on the left rail (the
-  `/organizations` look). Single-tab pages and pages that render their body
-  through `children` instead of `tabs` are exempt — `ProfileTabs` short-circuits
-  the layout choice in the single-tab case. The horizontal default is kept on
-  `EntityProfileShell` only as the fallback for the short-circuit path.
+  `/organizations` look). Pages with a single selectable tab don't need it —
+  `ProfileTabs` short-circuits to bare content (no tab chrome at all) before
+  the layout choice matters. Pages that render their body through `children`
+  instead of `tabs` are likewise exempt because `tabsLayout` is unused there.
+  The horizontal default on `EntityProfileShell` is retained for those cases
+  and for any future single-tab page that grows a second tab — at which point
+  the `tabsLayout="vertical"` requirement kicks in.
 - When `sidebar` is provided, the main column renders in a `lg:grid-cols-3`
   2-column layout with the sidebar on the right. **In vertical-tabs mode the
   `sidebar` slot is ignored** — the left nav takes the sidebar slot. If a page


### PR DESCRIPTION
## Summary

Sweeps the four remaining multi-tab entity profile pages onto `tabsLayout="vertical"` and drops their right-hand sidebars (which the vertical layout ignores). This finishes the migration started for `/organizations` and makes vertical tabs the canonical look for multi-tab profile pages.

Pages updated:

- `apps/web/src/app/ai-models/[slug]/page.tsx` — drops Details/Tags sidebar + the local `DetailRow` helper
- `apps/web/src/app/frontier-safety-frameworks/[slug]/page.tsx` — drops "About this tracker" sidebar + unused `Link` import
- `apps/web/src/app/legislation/[slug]/page.tsx` — drops Quick Facts/Position Summary/Tags sidebar
- `apps/web/src/app/people/[slug]/page.tsx` — drops Social Links + Facts panel sidebar (and the imports/fact-fetching they required)

Net: +33 / -186.

## Docs

`docs/agent-rules/entity-profile-pages.md` updated to:

- Require `tabsLayout="vertical"` for any page passing `tabs` with more than one selectable tab.
- Note that `sidebar` is ignored in vertical mode — sidebar content should fold into Overview or a dedicated tab.
- Refresh the reference-implementation list (canonical: `organizations/[slug]/[[...tab]]/page.tsx`; vertical: people, ai-models, legislation; exempt: projects, which uses `children` only).

## Test plan

- [x] Typecheck + gate clean (no new advisory failures)
- [ ] Spot-check each page renders correctly with the left-rail nav and no orphaned sidebar references

Fixes QUA-1003
