### PR TITLE
QUA-1043: drop QUA-943 v5 framing from drift validator

### DIFF
--- a/crux/validate/.entity-schema-drift-allowlist.txt
+++ b/crux/validate/.entity-schema-drift-allowlist.txt
@@ -1,12 +1,13 @@
-# QUA-943: Files in apps/wiki-server/src/routes/tablebase/ allowed to contain
+# Files in apps/wiki-server/src/routes/tablebase/ allowed to contain
 # entity-schema drift markers (`const VALID_*` declarations or inline `z.enum([`
-# literals) pending migration to canonical entity schemas in
-# packages/entity-schemas (per Plan v2).
+# literals).
 #
-# This list is the QUA-943 closure metric. As routes migrate to canonical
-# schemas, remove entries from this file. The validator fails if a route NOT
-# on this list contains drift markers — preventing new drift from accumulating
-# while migration is in progress. Goal: this file is empty when QUA-943 closes.
+# The validator fails if a route NOT on this list contains drift markers —
+# preventing new drift from accumulating. Existing entries can be removed
+# when a route is migrated to a shared canonical schema. There is no active
+# plan driving the allowlist to zero (the QUA-943 v5 plan that originally
+# targeted this was rejected — see QUA-1043). Treat this as a guardrail
+# against new drift, not as a migration progress meter.
 #
 # Suppressing a single line (e.g., a legitimate query-string enum that should
 # not be migrated): add `// schema-drift-ok: <reason>` on the same line as the

--- a/crux/validate/validate-entity-schema-drift.ts
+++ b/crux/validate/validate-entity-schema-drift.ts
@@ -5,13 +5,17 @@
  *
  * Bans new `const VALID_*` declarations and inline `z.enum([...])` literals in
  * apps/wiki-server/src/routes/tablebase/ — both are markers of an entity wire
- * schema being hand-written in a sync route instead of imported from the
- * canonical schema package (target: packages/entity-schemas, per QUA-943).
+ * schema being hand-written in a sync route instead of imported from a
+ * canonical shared schema.
  *
  * The current baseline of files containing drift markers is recorded in
- * .entity-schema-drift-allowlist.txt. As routes migrate to canonical schemas
- * entries are removed from the allowlist. The file reaches zero entries when
- * QUA-943 closes.
+ * .entity-schema-drift-allowlist.txt. The validator fails if a NEW route adds
+ * drift markers without being added to the allowlist — preventing new drift
+ * from accumulating. Existing entries can be removed when a route is migrated
+ * to a shared schema, but there is no active plan driving the allowlist to
+ * zero (the QUA-943 v5 plan that originally drove this was rejected — see
+ * QUA-1043). Treat this as standalone hygiene against new drift, not as a
+ * migration progress meter.
  *
  * Suppression: add `// schema-drift-ok: <reason>` on the same line. The
  * reason is mandatory (matches the buildSuppressionRegex contract used by
@@ -226,7 +230,7 @@ export function runCheck(
   if (errors === 0) {
     console.log(`${c.green}No entity-schema drift outside allowlist (${filesWithDrift.size} files allowlisted, ${allFiles.length} files scanned)${c.reset}`);
     if (filesWithDrift.size > 0) {
-      console.log(`${c.dim}QUA-943 closure metric: ${filesWithDrift.size} files still need migration to canonical schemas${c.reset}`);
+      console.log(`${c.dim}${filesWithDrift.size} file(s) on the allowlist (no active plan to drive this to zero — see QUA-1043).${c.reset}`);
     }
   } else {
     if (newViolations.length > 0) {
@@ -236,7 +240,7 @@ export function runCheck(
         console.log(`  ${c.red}${v.file}:${v.line}${c.reset} [${v.kind}]`);
         console.log(`    ${c.dim}${v.text}${c.reset}`);
       }
-      console.log(`\n${c.dim}Fix: import the canonical schema from packages/entity-schemas (QUA-943) instead of hand-writing.${c.reset}`);
+      console.log(`\n${c.dim}Fix: import the schema from a shared canonical location instead of hand-writing it in the route.${c.reset}`);
       console.log(`${c.dim}Suppress a single legitimate use (e.g., query-string enum): add \`// ${SUPPRESSION_MARKER}: <reason>\` on the same line.${c.reset}`);
       console.log(`${c.dim}If migration to canonical schemas is not yet possible, add the file to ${relative(PROJECT_ROOT, allowlistPath)}.${c.reset}\n`);
     }

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -439,15 +439,16 @@ const PARALLEL_STEPS: Step[] = [
   },
   {
     id: 'entity-schema-drift',
-    name: 'Entity-schema drift in tablebase routes (QUA-943)',
+    name: 'Entity-schema drift in tablebase routes',
     command: 'npx',
     args: ['tsx', 'crux/validate/validate-entity-schema-drift.ts'],
     cwd: PROJECT_ROOT,
     // Blocking. Bans new `const VALID_*` and inline `z.enum([` in
     // apps/wiki-server/src/routes/tablebase/ outside the allowlist at
-    // crux/validate/.entity-schema-drift-allowlist.txt. The allowlist length
-    // is the QUA-943 closure metric — entries get removed as routes migrate
-    // to canonical schemas in packages/entity-schemas (Plan v2 PRs 5a/5b).
+    // crux/validate/.entity-schema-drift-allowlist.txt. Existing entries can
+    // be removed when a route is migrated to a shared canonical schema, but
+    // there is no active plan driving the allowlist to zero (the QUA-943 v5
+    // plan that originally drove this was rejected — see QUA-1043).
     // Suppress per-line legitimate uses (e.g., query enums) with
     // `// schema-drift-ok`.
   },


### PR DESCRIPTION
## Summary

Cleanup pass for QUA-1043: the QUA-943 v5 plan ("machine-write PG-primary transition" via TableBase Migration Kit, 22 shapes) was rejected after empirical investigation found only ~3 shapes are actually machine-written end-to-end and Class C bugs (Zod accepts but `toRow`/`conflictSet` drops a field) wouldn't be caught by the v5 design at all.

Most of QUA-1043 is Linear bookkeeping (cancel 14 stale tickets, post a project update). This PR carries the only code change: rewording the QUA-944 drift validator's docstrings, log messages, allowlist header, and gate-runner entry so they no longer claim to be "the QUA-943 closure metric driving toward zero." The validator stays — it still has standalone value preventing new inline `z.enum([...])` and `VALID_*` declarations in routes/tablebase/ — but the v5 framing is gone.

## Linear bookkeeping done outside this PR

- 12 v5 tickets canceled: QUA-1018 through QUA-1029.
- QUA-960 canceled (was repurposed as "v5 Phase 2: stakeholders cutover").
- QUA-984 canceled as stale (was a known QUA-960 blocker; no user-visible bug today since renderer reads YAML, not PG).
- Filed QUA-1049 to delete unused best-effort sync mode (`bestEffortAllowed: true` is set on zero production routes).
- Posted project update on Data Integrity announcing v5 rejected.

## Files changed

- `crux/validate/validate-entity-schema-drift.ts` — docstring + log-message rewording. Drops "QUA-943 closure metric" framing; references QUA-1043.
- `crux/validate/.entity-schema-drift-allowlist.txt` — header rewording, same intent.
- `crux/validate/validate-gate.ts` — gate entry name (was `"... (QUA-943)"`) + comment block. Caught by hostile-reviewer pass after the first commit; same closure-metric framing.

## Test plan

- [x] `npx tsx crux/validate/validate-entity-schema-drift.ts` — runs cleanly, reports 32 files allowlisted.
- [x] `npx vitest run crux/validate/validate-entity-schema-drift.test.ts` — all 28 tests pass.
- [x] Full `pnpm crux w validate gate --fix` — all 66 checks passed locally (pre-push hook).

Closes QUA-1043.
