### PR TITLE
feat(improve-entity): single-instance mutex via pipeline_runs (QUA-1032)

### DIFF
--- a/crux/commands/research-improve-entity-lifecycle.test.ts
+++ b/crux/commands/research-improve-entity-lifecycle.test.ts
@@ -24,6 +24,12 @@ vi.mock("../lib/pipeline-runs/lifecycle.ts", () => ({
 // Suppress the "improve-entity result" stdout from a real run.
 const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
+// QUA-1032: keep the mutex check from making real network calls. These tests
+// don't exercise the mutex; they care about the lifecycle wrapper.
+const NOOP_MUTEX_OVERRIDES = {
+  list: vi.fn().mockResolvedValue({ ok: true, data: { runs: [], count: 0 } }),
+};
+
 describe("improveSingleEntity wraps its body with withPipelineRun (QUA-957)", () => {
   // A real policy entity from `data/entities/responses.yaml` so `findEntity`
   // resolves without needing fs mocks. Stable test fixture — the slug
@@ -68,6 +74,7 @@ describe("improveSingleEntity wraps its body with withPipelineRun (QUA-957)", ()
       budgetUsd: 0.01,
       dryRun: true,
       quiet: true,
+      mutexCheckOverrides: NOOP_MUTEX_OVERRIDES,
     });
 
     expect(mockWithPipelineRun).toHaveBeenCalledTimes(1);
@@ -93,6 +100,7 @@ describe("improveSingleEntity wraps its body with withPipelineRun (QUA-957)", ()
         budgetUsd: 0.01,
         dryRun: true,
         quiet: true,
+        mutexCheckOverrides: NOOP_MUTEX_OVERRIDES,
       }),
     ).rejects.toThrow(/target must be a positive integer/);
 
@@ -111,9 +119,93 @@ describe("improveSingleEntity wraps its body with withPipelineRun (QUA-957)", ()
         budgetUsd: 0.01,
         dryRun: true,
         quiet: true,
+        mutexCheckOverrides: NOOP_MUTEX_OVERRIDES,
       }),
     ).rejects.toThrow(/Entity not found/);
 
     expect(mockWithPipelineRun).not.toHaveBeenCalled();
+  });
+
+  // ── QUA-1032 mutex wiring ────────────────────────────────────────────────
+
+  it("does NOT invoke withPipelineRun when the mutex check finds a fresh running run", async () => {
+    mockWithPipelineRun.mockReset();
+    const { improveSingleEntity } = await import("./research-improve-entity.ts");
+    const { ImproveEntityMutexError } = await import(
+      "../lib/improve-entity/mutex.ts"
+    );
+
+    const NOW = Date.parse("2026-05-01T20:00:00.000Z");
+    const fakeRunningRow = {
+      runId: "other-run",
+      pipelineName: "improve-entity",
+      agentSessionId: 99,
+      status: "running",
+      startedAt: new Date(NOW).toISOString(),
+      heartbeatAt: new Date(NOW).toISOString(),
+    };
+    const list = vi
+      .fn()
+      .mockResolvedValue({ ok: true, data: { runs: [fakeRunningRow], count: 1 } });
+
+    await expect(
+      improveSingleEntity({
+        slug: FIXTURE_SLUG,
+        target: 1,
+        maxIters: 1,
+        budgetUsd: 0.01,
+        dryRun: true,
+        quiet: true,
+        mutexCheckOverrides: { list, nowMs: () => NOW },
+      }),
+    ).rejects.toBeInstanceOf(ImproveEntityMutexError);
+
+    expect(mockWithPipelineRun).not.toHaveBeenCalled();
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
+  it("--force bypasses the mutex check even when a conflict exists", async () => {
+    mockWithPipelineRun.mockReset();
+    mockWithPipelineRun.mockResolvedValue({
+      entity_slug: FIXTURE_SLUG,
+      entity_id: FIXTURE_STABLE_ID,
+      entity_type: "policy",
+      iterations: [],
+      final_coverage: 0,
+      final_facts: {},
+      total_cost_usd: 0,
+      total_duration_s: 0,
+      hit_target: false,
+      reason: "test-stub",
+    });
+    const { improveSingleEntity } = await import("./research-improve-entity.ts");
+
+    const NOW = Date.parse("2026-05-01T20:00:00.000Z");
+    const fakeRunningRow = {
+      runId: "other-run",
+      pipelineName: "improve-entity",
+      agentSessionId: 99,
+      status: "running",
+      startedAt: new Date(NOW).toISOString(),
+      heartbeatAt: new Date(NOW).toISOString(),
+    };
+    const list = vi
+      .fn()
+      .mockResolvedValue({ ok: true, data: { runs: [fakeRunningRow], count: 1 } });
+
+    await improveSingleEntity({
+      slug: FIXTURE_SLUG,
+      target: 1,
+      maxIters: 1,
+      budgetUsd: 0.01,
+      dryRun: true,
+      quiet: true,
+      force: true,
+      mutexCheckOverrides: { list, nowMs: () => NOW },
+    });
+
+    // --force should short-circuit BEFORE the API call.
+    expect(list).not.toHaveBeenCalled();
+    expect(mockWithPipelineRun).toHaveBeenCalledTimes(1);
   });
 });

--- a/crux/commands/research-improve-entity-suite.test.ts
+++ b/crux/commands/research-improve-entity-suite.test.ts
@@ -7,7 +7,7 @@
  * SuiteRunOptions.improver — no LLM, no YAML writes, no network.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -28,6 +28,34 @@ import {
 } from "./research-improve-entity-suite.ts";
 import { BudgetExhaustedError } from "./research-improve-entity.ts";
 import type { ImproveResult, IterationMetrics } from "./research-improve-entity.ts";
+import {
+  IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+  ImproveEntityMutexError,
+} from "../lib/improve-entity/mutex.ts";
+import type { CheckMutexOptions } from "../lib/improve-entity/mutex.ts";
+
+// QUA-1032: every runSuite call needs an injected mutex `list` to avoid
+// network calls to `/api/pipeline-runs`. This default returns "no running
+// rows" so the suite proceeds normally.
+function noopMutexOverrides(): Pick<CheckMutexOptions, "list" | "nowMs"> {
+  return {
+    list: vi.fn().mockResolvedValue({ ok: true, data: { runs: [], count: 0 } }),
+    nowMs: () => Date.parse("2026-05-01T20:00:00.000Z"),
+  };
+}
+
+// Wrap runSuite to inject the no-op mutex override by default. Tests that
+// want to exercise the mutex pass `mutexCheckOverrides` themselves.
+// Spread `opts` first so a caller-supplied mutexCheckOverrides wins; otherwise
+// fall back to the no-op.
+async function runSuiteForTest(
+  opts: Parameters<typeof runSuite>[0],
+): Promise<Awaited<ReturnType<typeof runSuite>>> {
+  return runSuite({
+    ...opts,
+    mutexCheckOverrides: opts.mutexCheckOverrides ?? noopMutexOverrides(),
+  });
+}
 
 // ── fixtures ───────────────────────────────────────────────────────────────
 
@@ -326,7 +354,7 @@ describe("runSuite", () => {
         iterations: [makeIter({ cost_research_usd: 0.02, cost_extract_usd: 0.01 })],
       });
     };
-    const snap = await runSuite({
+    const snap = await runSuiteForTest({
       tag: "happy",
       totalBudgetUsd: 4.0,
       maxIters: 2,
@@ -364,7 +392,7 @@ describe("runSuite", () => {
       calls.push(slug);
       return makeResult(slug);
     };
-    const snap = await runSuite({
+    const snap = await runSuiteForTest({
       tag: "filter",
       totalBudgetUsd: 2.0,
       maxIters: 1,
@@ -394,7 +422,7 @@ describe("runSuite", () => {
     // Total = 0.10, per-entity cap = (0.10/3)*2 = 0.0667. spendthrift burns 0.0667.
     // Remaining after entity 1 = 0.10 - 0.0667 = 0.0333, which is below
     // MIN_USEFUL_BUDGET_USD ($0.05) → halt.
-    const snap = await runSuite({
+    const snap = await runSuiteForTest({
       tag: "halt",
       totalBudgetUsd: 0.1,
       maxIters: 1,
@@ -422,7 +450,7 @@ describe("runSuite", () => {
       return makeResult(slug, { iterations: [makeIter({ cost_research_usd: 0, cost_extract_usd: 0 })] });
     };
     // Total=$2, N=2 → per-entity cap = $2.
-    await runSuite({
+    await runSuiteForTest({
       tag: "cap",
       totalBudgetUsd: 2.0,
       maxIters: 1,
@@ -457,7 +485,7 @@ describe("runSuite", () => {
       }
       throw new Error(`improver should not have been called for ${slug}`);
     };
-    const snap = await runSuite({
+    const snap = await runSuiteForTest({
       tag: "budget-stop",
       totalBudgetUsd: 8.0,
       maxIters: 1,
@@ -492,7 +520,7 @@ describe("runSuite", () => {
       if (slug === "burner") throw new BudgetExhaustedError(2.5, 1.0);
       throw new Error(`improver should not have been called for ${slug}`);
     };
-    const snap = await runSuite({
+    const snap = await runSuiteForTest({
       tag: "budget-rethrow",
       totalBudgetUsd: 8.0,
       maxIters: 1,
@@ -517,7 +545,7 @@ describe("runSuite", () => {
       if (slug === "boom") throw new Error("synthetic blast");
       return makeResult(slug);
     };
-    const snap = await runSuite({
+    const snap = await runSuiteForTest({
       tag: "fail",
       totalBudgetUsd: 4.0,
       maxIters: 1,
@@ -539,7 +567,7 @@ describe("runSuite", () => {
       calls++;
       return makeResult("never-called");
     };
-    const snap = await runSuite({
+    const snap = await runSuiteForTest({
       tag: "empty",
       totalBudgetUsd: 1.0,
       maxIters: 1,
@@ -562,7 +590,7 @@ describe("runSuite", () => {
       return makeResult("alpha");
     };
     await expect(
-      runSuite({
+      runSuiteForTest({
         tag: "../etc/passwd",
         totalBudgetUsd: 4.0,
         maxIters: 1,
@@ -574,6 +602,86 @@ describe("runSuite", () => {
     expect(calls).toBe(0);
     // No snapshot file written.
     expect(fs.existsSync(snapshotDir) ? fs.readdirSync(snapshotDir) : []).toEqual([]);
+  });
+
+  // ── QUA-1032 mutex wiring ────────────────────────────────────────────────
+
+  it("refuses to start when another improve-entity-suite run is in flight", async () => {
+    const { suitePath, snapshotDir } = writeFixtureSuite({ slug: "alpha", type: "policy" });
+    const NOW = Date.parse("2026-05-01T20:00:00.000Z");
+    const fakeRunningRow = {
+      runId: "other-suite",
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      agentSessionId: 17,
+      status: "running",
+      startedAt: new Date(NOW - 60_000).toISOString(),
+      heartbeatAt: new Date(NOW - 30_000).toISOString(),
+    };
+    const list = vi
+      .fn()
+      .mockResolvedValue({ ok: true, data: { runs: [fakeRunningRow], count: 1 } });
+    let improverCalled = 0;
+    const improver = async () => {
+      improverCalled++;
+      return makeResult("alpha");
+    };
+    await expect(
+      runSuiteForTest({
+        tag: "blocked",
+        totalBudgetUsd: 2.0,
+        maxIters: 1,
+        suitePath,
+        snapshotDir,
+        improver,
+        mutexCheckOverrides: { list, nowMs: () => NOW },
+      }),
+    ).rejects.toBeInstanceOf(ImproveEntityMutexError);
+    expect(improverCalled).toBe(0);
+    // No snapshot — refused before the loop started.
+    expect(fs.existsSync(snapshotDir) ? fs.readdirSync(snapshotDir) : []).toEqual([]);
+  });
+
+  it("--force bypasses the mutex check (and forwards force to per-entity calls)", async () => {
+    const { suitePath, snapshotDir } = writeFixtureSuite(
+      { slug: "alpha", type: "policy" },
+      { slug: "beta", type: "policy" },
+    );
+    const NOW = Date.parse("2026-05-01T20:00:00.000Z");
+    // Fresh suite-level conflict that --force should bypass.
+    const fakeRunningRow = {
+      runId: "other-suite",
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      agentSessionId: 1,
+      status: "running",
+      startedAt: new Date(NOW).toISOString(),
+      heartbeatAt: new Date(NOW).toISOString(),
+    };
+    const list = vi
+      .fn()
+      .mockResolvedValue({ ok: true, data: { runs: [fakeRunningRow], count: 1 } });
+    const forceSeenByImprover: boolean[] = [];
+    const improver = async ({ force, slug }: { slug: string; force?: boolean }) => {
+      forceSeenByImprover.push(force === true);
+      return makeResult(slug);
+    };
+    const snap = await runSuiteForTest({
+      tag: "force",
+      totalBudgetUsd: 4.0,
+      maxIters: 1,
+      suitePath,
+      snapshotDir,
+      improver,
+      force: true,
+      mutexCheckOverrides: { list, nowMs: () => NOW },
+    });
+    // Both entities ran; suite-level check was short-circuited by --force.
+    expect(snap.entities.map((r) => r.status)).toEqual(["completed", "completed"]);
+    // Per-entity calls also received force=true so they don't re-check (and
+    // would have hit the same conflict if they did).
+    expect(forceSeenByImprover).toEqual([true, true]);
+    // The list mock should not have been called: --force short-circuits
+    // before the API request.
+    expect(list).not.toHaveBeenCalled();
   });
 });
 

--- a/crux/commands/research-improve-entity-suite.test.ts
+++ b/crux/commands/research-improve-entity-suite.test.ts
@@ -12,6 +12,22 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+// QUA-1032: the suite now wraps its body in `withPipelineRun` to register
+// itself as a `pipeline_runs` row. Mock the lifecycle helper at the module
+// level so tests don't hit the wiki-server. The real wrapper has
+// `allowOffline: true` so production survives outages, but in tests we get
+// faster, quieter runs by short-circuiting the wrapper entirely.
+vi.mock("../lib/pipeline-runs/lifecycle.ts", () => ({
+  withPipelineRun: vi.fn((_options: unknown, body: (ctx: unknown) => Promise<unknown>) =>
+    body({
+      runId: "test-run",
+      offline: true,
+      markStatus: vi.fn(),
+      markFollowup: vi.fn(),
+    }),
+  ),
+}));
+
 import {
   MIN_USEFUL_BUDGET_USD,
   aggregateResult,

--- a/crux/commands/research-improve-entity-suite.test.ts
+++ b/crux/commands/research-improve-entity-suite.test.ts
@@ -641,7 +641,7 @@ describe("runSuite", () => {
     expect(fs.existsSync(snapshotDir) ? fs.readdirSync(snapshotDir) : []).toEqual([]);
   });
 
-  it("--force bypasses the mutex check (and forwards force to per-entity calls)", async () => {
+  it("--force bypasses the suite-level mutex check", async () => {
     const { suitePath, snapshotDir } = writeFixtureSuite(
       { slug: "alpha", type: "policy" },
       { slug: "beta", type: "policy" },
@@ -659,11 +659,7 @@ describe("runSuite", () => {
     const list = vi
       .fn()
       .mockResolvedValue({ ok: true, data: { runs: [fakeRunningRow], count: 1 } });
-    const forceSeenByImprover: boolean[] = [];
-    const improver = async ({ force, slug }: { slug: string; force?: boolean }) => {
-      forceSeenByImprover.push(force === true);
-      return makeResult(slug);
-    };
+    const improver = async ({ slug }: { slug: string }) => makeResult(slug);
     const snap = await runSuiteForTest({
       tag: "force",
       totalBudgetUsd: 4.0,
@@ -676,12 +672,36 @@ describe("runSuite", () => {
     });
     // Both entities ran; suite-level check was short-circuited by --force.
     expect(snap.entities.map((r) => r.status)).toEqual(["completed", "completed"]);
-    // Per-entity calls also received force=true so they don't re-check (and
-    // would have hit the same conflict if they did).
-    expect(forceSeenByImprover).toEqual([true, true]);
     // The list mock should not have been called: --force short-circuits
     // before the API request.
     expect(list).not.toHaveBeenCalled();
+  });
+
+  it("forwards force=true to per-entity calls unconditionally (avoids self-conflict on suite's own running row)", async () => {
+    const { suitePath, snapshotDir } = writeFixtureSuite(
+      { slug: "alpha", type: "policy" },
+      { slug: "beta", type: "policy" },
+    );
+    const forceSeenByImprover: boolean[] = [];
+    const improver = async ({ force, slug }: { slug: string; force?: boolean }) => {
+      forceSeenByImprover.push(force === true);
+      return makeResult(slug);
+    };
+    // No --force at the suite level (the `runSuiteForTest` no-op mutex
+    // returns no conflicts so the suite proceeds).
+    await runSuiteForTest({
+      tag: "no-suite-force",
+      totalBudgetUsd: 4.0,
+      maxIters: 1,
+      suitePath,
+      snapshotDir,
+      improver,
+    });
+    // Even without --force at the suite level, per-entity calls still get
+    // force=true. The suite already owns the family-level lock; without
+    // this, the per-entity check would self-conflict on the suite's own
+    // `improve-entity-suite` running row.
+    expect(forceSeenByImprover).toEqual([true, true]);
   });
 });
 

--- a/crux/commands/research-improve-entity-suite.ts
+++ b/crux/commands/research-improve-entity-suite.ts
@@ -26,6 +26,7 @@ import {
 import {
   checkImproveEntityMutex,
   ImproveEntityMutexError,
+  IMPROVE_ENTITY_PIPELINE_NAME,
   IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
   type CheckMutexOptions,
 } from "../lib/improve-entity/mutex.ts";
@@ -272,19 +273,28 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
     );
   }
 
-  // QUA-1032 single-instance mutex (suite-level). Refuse to start if another
-  // suite run is already in flight (status=running, fresh heartbeat). The
-  // per-entity loop also relies on `improveSingleEntity`'s own mutex, but the
-  // suite-level check here gives the operator the more useful "another suite
-  // is running" message rather than reporting a per-entity conflict on the
-  // first row. --force skips both layers (forwarded to improver below).
+  // QUA-1032 single-instance mutex (suite-level). Refuse to start if any
+  // improve-entity family run (single or suite) is already in flight. We
+  // check BOTH pipeline names so a stand-alone improve-entity blocks the
+  // suite at this level — otherwise the suite would proceed past the
+  // suite-only check, then collide on the first per-entity invocation
+  // and abort mid-flight with a partial snapshot.
+  //
+  // --force skips this check. Per-entity invocations below always pass
+  // force=true (regardless of whether the operator passed --force) because
+  // the suite already owns the family-level lock — without that, the very
+  // first per-entity check would self-conflict on the suite's own
+  // `improve-entity-suite` running row.
   const conflict = await checkImproveEntityMutex({
-    pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+    pipelineNames: [
+      IMPROVE_ENTITY_PIPELINE_NAME,
+      IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+    ],
     force: opts.force,
     ...(opts.mutexCheckOverrides ?? {}),
   });
   if (conflict) {
-    throw new ImproveEntityMutexError(conflict, IMPROVE_ENTITY_SUITE_PIPELINE_NAME);
+    throw new ImproveEntityMutexError(conflict);
   }
 
   const startedAt = new Date().toISOString();
@@ -327,15 +337,12 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
         maxIters: opts.maxIters,
         dryRun: opts.dryRun,
         quiet: true,
-        // Forward --force from the suite level. The suite's mutex query is
-        // `pipelineName='improve-entity-suite'` and the per-entity query is
-        // `pipelineName='improve-entity'` — different filters, so the suite's
-        // own running row will NOT show up as a per-entity conflict. The
-        // sequential per-entity rows also don't conflict (each ends before
-        // the next starts). The only reason to force per-entity here is when
-        // the operator passed --force to the suite intending to override
-        // both layers.
-        force: opts.force,
+        // The per-entity mutex check looks for any running `improve-entity`
+        // OR `improve-entity-suite` row — including this suite's own row.
+        // Pass force=true unconditionally so the suite's per-entity calls
+        // don't self-conflict. The suite-level check above already
+        // enforced the family-wide lock; we don't need it twice.
+        force: true,
       });
       if (result.reason === BUDGET_EXHAUSTED_REASON) {
         console.warn(

--- a/crux/commands/research-improve-entity-suite.ts
+++ b/crux/commands/research-improve-entity-suite.ts
@@ -23,6 +23,12 @@ import {
   type ImproveResult,
   improveSingleEntity,
 } from "./research-improve-entity.ts";
+import {
+  checkImproveEntityMutex,
+  ImproveEntityMutexError,
+  IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+  type CheckMutexOptions,
+} from "../lib/improve-entity/mutex.ts";
 
 const ROOT = path.resolve(import.meta.dirname, "../..");
 const SUITE_YAML = path.join(ROOT, "crux/benchmarks/entity-suite.yaml");
@@ -196,6 +202,12 @@ export interface SuiteRunOptions {
    * Default is the real `improveSingleEntity` from research-improve-entity.ts.
    */
   improver?: (opts: ImproveOptions) => Promise<ImproveResult>;
+  /** When true, skip the QUA-1032 single-instance mutex check on the suite
+   *  and on each per-entity invocation. Default false. */
+  force?: boolean;
+  /** Test injection — passed through to {@link checkImproveEntityMutex} for
+   *  the suite-level mutex check. Production callers leave this undefined. */
+  mutexCheckOverrides?: Pick<CheckMutexOptions, "list" | "nowMs" | "freshnessMs">;
 }
 
 export interface SuiteSnapshot {
@@ -260,6 +272,21 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
     );
   }
 
+  // QUA-1032 single-instance mutex (suite-level). Refuse to start if another
+  // suite run is already in flight (status=running, fresh heartbeat). The
+  // per-entity loop also relies on `improveSingleEntity`'s own mutex, but the
+  // suite-level check here gives the operator the more useful "another suite
+  // is running" message rather than reporting a per-entity conflict on the
+  // first row. --force skips both layers (forwarded to improver below).
+  const conflict = await checkImproveEntityMutex({
+    pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+    force: opts.force,
+    ...(opts.mutexCheckOverrides ?? {}),
+  });
+  if (conflict) {
+    throw new ImproveEntityMutexError(conflict, IMPROVE_ENTITY_SUITE_PIPELINE_NAME);
+  }
+
   const startedAt = new Date().toISOString();
   const all = loadSuite(suitePath);
   const supported = filterToSupportedTypes(all);
@@ -300,6 +327,15 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
         maxIters: opts.maxIters,
         dryRun: opts.dryRun,
         quiet: true,
+        // Forward --force from the suite level. The suite's mutex query is
+        // `pipelineName='improve-entity-suite'` and the per-entity query is
+        // `pipelineName='improve-entity'` — different filters, so the suite's
+        // own running row will NOT show up as a per-entity conflict. The
+        // sequential per-entity rows also don't conflict (each ends before
+        // the next starts). The only reason to force per-entity here is when
+        // the operator passed --force to the suite intending to override
+        // both layers.
+        force: opts.force,
       });
       if (result.reason === BUDGET_EXHAUSTED_REASON) {
         console.warn(
@@ -377,7 +413,7 @@ export async function run(args: string[], options: Record<string, unknown>): Pro
   if (!tag) {
     return {
       output:
-        "Usage: crux tb improve-entity-suite --tag=<label> [--budget=10] [--max-iters=2] [--target=N] [--dry-run]",
+        "Usage: crux tb improve-entity-suite --tag=<label> [--budget=10] [--max-iters=2] [--target=N] [--dry-run] [--force]",
       exitCode: 1,
     };
   }
@@ -392,6 +428,7 @@ export async function run(args: string[], options: Record<string, unknown>): Pro
   const maxIters = options.maxIters != null ? parseInt(options.maxIters as string, 10) : 2;
   const target = options.target != null ? parseInt(options.target as string, 10) : undefined;
   const dryRun = !!options.dryRun;
+  const force = !!options.force;
 
   if (!Number.isFinite(totalBudgetUsd) || totalBudgetUsd <= 0) {
     return { output: `--budget must be a positive number; got ${options.budget}`, exitCode: 1 };
@@ -405,8 +442,13 @@ export async function run(args: string[], options: Record<string, unknown>): Pro
 
   let snapshot;
   try {
-    snapshot = await runSuite({ tag, totalBudgetUsd, maxIters, target, dryRun });
+    snapshot = await runSuite({ tag, totalBudgetUsd, maxIters, target, dryRun, force });
   } catch (err) {
+    // QUA-1032: mutex conflicts use exit code 2 to distinguish "another suite
+    // is running" from a generic suite failure (exit 1).
+    if (err instanceof ImproveEntityMutexError) {
+      return { output: err.message, exitCode: 2 };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return { output: `improve-entity-suite failed: ${msg}`, exitCode: 1 };
   }
@@ -455,6 +497,10 @@ Options:
   --max-iters=N     Max iterations per entity (default 2).
   --target=N        Per-entity (provisions+stakeholders) target (passed through).
   --dry-run         Don't write YAML changes back to data/entities/responses.yaml.
+  --force           Skip the QUA-1032 single-instance mutex check. By default,
+                    refuses to start (exit 2) if another improve-entity-suite
+                    or improve-entity run is already in flight. Use only for
+                    explicit takeover after a crashed run.
 
 Budget governance:
   Per-entity hard cap = 2 × (total_budget / N) where N = supported entities.

--- a/crux/commands/research-improve-entity-suite.ts
+++ b/crux/commands/research-improve-entity-suite.ts
@@ -22,14 +22,16 @@ import {
   type ImproveOptions,
   type ImproveResult,
   improveSingleEntity,
+  parseAgentSessionId,
 } from "./research-improve-entity.ts";
 import {
-  checkImproveEntityMutex,
+  assertNoImproveEntityMutexConflict,
   ImproveEntityMutexError,
-  IMPROVE_ENTITY_PIPELINE_NAME,
   IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
   type CheckMutexOptions,
 } from "../lib/improve-entity/mutex.ts";
+import { withPipelineRun } from "../lib/pipeline-runs/lifecycle.ts";
+import { getCachedAuditSessionId } from "../lib/wiki-server/audit-context.ts";
 
 const ROOT = path.resolve(import.meta.dirname, "../..");
 const SUITE_YAML = path.join(ROOT, "crux/benchmarks/entity-suite.yaml");
@@ -274,29 +276,44 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
   }
 
   // QUA-1032 single-instance mutex (suite-level). Refuse to start if any
-  // improve-entity family run (single or suite) is already in flight. We
-  // check BOTH pipeline names so a stand-alone improve-entity blocks the
-  // suite at this level — otherwise the suite would proceed past the
-  // suite-only check, then collide on the first per-entity invocation
-  // and abort mid-flight with a partial snapshot.
-  //
-  // --force skips this check. Per-entity invocations below always pass
-  // force=true (regardless of whether the operator passed --force) because
-  // the suite already owns the family-level lock — without that, the very
-  // first per-entity check would self-conflict on the suite's own
-  // `improve-entity-suite` running row.
-  const conflict = await checkImproveEntityMutex({
-    pipelineNames: [
-      IMPROVE_ENTITY_PIPELINE_NAME,
-      IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
-    ],
+  // family-member run (single or suite) is already in flight. The
+  // `withPipelineRun` wrapper below registers this suite under
+  // `improve-entity-suite` so a sibling suite started a moment later sees
+  // *this* run as a conflict via the same check.
+  await assertNoImproveEntityMutexConflict({
     force: opts.force,
-    ...(opts.mutexCheckOverrides ?? {}),
+    mutexCheckOverrides: opts.mutexCheckOverrides,
   });
-  if (conflict) {
-    throw new ImproveEntityMutexError(conflict);
-  }
 
+  // QUA-1032: register the suite as a `pipeline_runs` row so a second suite
+  // started seconds later (i.e. between this suite's per-entity invocations)
+  // sees the suite-family conflict via the mutex check. Without this wrapper
+  // there is no `improve-entity-suite` row anywhere, so suite-vs-suite
+  // blocking would only work coincidentally — when both happen to be inside
+  // a per-entity invocation at the same instant.
+  return withPipelineRun(
+    {
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      agentSessionId: parseAgentSessionId(getCachedAuditSessionId()),
+      // Same posture as the per-entity loop: dev sessions without server
+      // creds keep iterating; the helper logs a visible warning.
+      allowOffline: true,
+    },
+    async () => runSuiteBody(opts, suitePath, snapshotDir, improver),
+  );
+}
+
+/**
+ * Inner body of {@link runSuite} — separated so it runs inside the
+ * `pipeline_runs` lifecycle. The pre-flight checks (tag validation, mutex)
+ * stay outside the wrapper so a refused start doesn't write a row.
+ */
+async function runSuiteBody(
+  opts: SuiteRunOptions,
+  suitePath: string,
+  snapshotDir: string,
+  improver: NonNullable<SuiteRunOptions["improver"]>,
+): Promise<SuiteSnapshot> {
   const startedAt = new Date().toISOString();
   const all = loadSuite(suitePath);
   const supported = filterToSupportedTypes(all);
@@ -337,11 +354,9 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
         maxIters: opts.maxIters,
         dryRun: opts.dryRun,
         quiet: true,
-        // The per-entity mutex check looks for any running `improve-entity`
-        // OR `improve-entity-suite` row — including this suite's own row.
-        // Pass force=true unconditionally so the suite's per-entity calls
-        // don't self-conflict. The suite-level check above already
-        // enforced the family-wide lock; we don't need it twice.
+        // The per-entity check would otherwise self-conflict on the suite's
+        // own `improve-entity-suite` running row. We already cleared the
+        // family lock at the suite level, so skip the per-entity re-check.
         force: true,
       });
       if (result.reason === BUDGET_EXHAUSTED_REASON) {

--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -66,6 +66,7 @@ import {
   checkImproveEntityMutex,
   ImproveEntityMutexError,
   IMPROVE_ENTITY_PIPELINE_NAME,
+  IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
   type CheckMutexOptions,
 } from "../lib/improve-entity/mutex.ts";
 
@@ -1098,16 +1099,30 @@ export async function improveSingleEntity(opts: ImproveOptions): Promise<Improve
   }
 
   // QUA-1032 single-instance mutex: refuse to start if another improve-entity
-  // run is already in flight (status=running, fresh heartbeat). Skipped when
-  // --force is set. The check runs *before* `withPipelineRun` so the new run's
-  // own pipeline_runs row hasn't been inserted yet — no risk of self-detection.
+  // family run (single or suite) is already in flight (status=running, fresh
+  // heartbeat). Checks BOTH pipeline names because: (a) a running suite's
+  // per-entity invocation will collide with a stand-alone start anyway, so
+  // catching the suite at this level fails fast with a clear error; (b)
+  // symmetrically, a stand-alone in flight would block a suite that's about
+  // to start a per-entity invocation on the same family.
+  //
+  // Skipped when --force is set, OR when the caller is the suite (which
+  // already passed its own family-level check and forwards force=true to
+  // each per-entity invocation to avoid a self-detection conflict on the
+  // suite's own running row).
+  //
+  // Runs *before* `withPipelineRun` so this run's own pipeline_runs row
+  // hasn't been inserted yet — no risk of self-detection.
   const conflict = await checkImproveEntityMutex({
-    pipelineName: IMPROVE_ENTITY_PIPELINE_NAME,
+    pipelineNames: [
+      IMPROVE_ENTITY_PIPELINE_NAME,
+      IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+    ],
     force: opts.force,
     ...(opts.mutexCheckOverrides ?? {}),
   });
   if (conflict) {
-    throw new ImproveEntityMutexError(conflict, IMPROVE_ENTITY_PIPELINE_NAME);
+    throw new ImproveEntityMutexError(conflict);
   }
 
   // Pull the active agent_session_id (primed by crux.mjs at startup) so the

--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -62,6 +62,12 @@ import {
   type WithPipelineRunOptions,
 } from "../lib/pipeline-runs/lifecycle.ts";
 import { getCachedAuditSessionId } from "../lib/wiki-server/audit-context.ts";
+import {
+  checkImproveEntityMutex,
+  ImproveEntityMutexError,
+  IMPROVE_ENTITY_PIPELINE_NAME,
+  type CheckMutexOptions,
+} from "../lib/improve-entity/mutex.ts";
 
 const ROOT = path.resolve(import.meta.dirname, "../..");
 const ENTITIES_DIR = path.join(ROOT, "data/entities");
@@ -166,6 +172,12 @@ export interface ImproveOptions {
    *  fast-exit behavior). Recommended for CI gate suite runs (QUA-871) so
    *  per-run results aren't sensitive to worker-queue timing. */
   waitForSettle?: boolean;
+  /** When true, skip the QUA-1032 single-instance mutex check. Use only for
+   *  explicit takeover after a crashed run. Default false. */
+  force?: boolean;
+  /** Test injection — passed through to {@link checkImproveEntityMutex}.
+   *  Production callers leave this undefined. */
+  mutexCheckOverrides?: Pick<CheckMutexOptions, "list" | "nowMs" | "freshnessMs">;
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -1085,6 +1097,19 @@ export async function improveSingleEntity(opts: ImproveOptions): Promise<Improve
     );
   }
 
+  // QUA-1032 single-instance mutex: refuse to start if another improve-entity
+  // run is already in flight (status=running, fresh heartbeat). Skipped when
+  // --force is set. The check runs *before* `withPipelineRun` so the new run's
+  // own pipeline_runs row hasn't been inserted yet — no risk of self-detection.
+  const conflict = await checkImproveEntityMutex({
+    pipelineName: IMPROVE_ENTITY_PIPELINE_NAME,
+    force: opts.force,
+    ...(opts.mutexCheckOverrides ?? {}),
+  });
+  if (conflict) {
+    throw new ImproveEntityMutexError(conflict, IMPROVE_ENTITY_PIPELINE_NAME);
+  }
+
   // Pull the active agent_session_id (primed by crux.mjs at startup) so the
   // pipeline_runs row links back to the agent that triggered the run.
   // `getCachedAuditSessionId` returns a string; agent_sessions.id is bigint
@@ -1273,18 +1298,25 @@ async function doImproveSingleEntity(args: {
 export async function run(args: string[], options: Record<string, unknown>): Promise<CommandResult> {
   const slug = (args[0] || "").trim();
   if (!slug) {
-    return { output: "Usage: crux tb improve-entity <slug> [--target=N] [--budget=$] [--max-iters=N] [--wait-for-settle]", exitCode: 1 };
+    return { output: "Usage: crux tb improve-entity <slug> [--target=N] [--budget=N] [--max-iters=N] [--wait-for-settle] [--force]", exitCode: 1 };
   }
   const target = options.target != null ? parseInt(options.target as string, 10) : 12;
   const maxIters = options.maxIters != null ? parseInt(options.maxIters as string, 10) : 3;
   const budgetUsd = options.budget != null ? parseFloat(options.budget as string) : 2.0;
   const noWrite = !!options.dryRun;
   const waitForSettle = !!options.waitForSettle;
+  const force = !!options.force;
 
   let result: ImproveResult;
   try {
-    result = await improveSingleEntity({ slug, target, maxIters, budgetUsd, dryRun: noWrite, waitForSettle });
+    result = await improveSingleEntity({ slug, target, maxIters, budgetUsd, dryRun: noWrite, waitForSettle, force });
   } catch (err) {
+    // QUA-1032: mutex conflicts use exit code 2 to distinguish "another run
+    // is in flight" from a generic failure (exit 1). The message is already
+    // formatted by `formatMutexError` — surface it as-is.
+    if (err instanceof ImproveEntityMutexError) {
+      return { output: err.message, exitCode: 2 };
+    }
     return { output: err instanceof Error ? err.message : String(err), exitCode: 1 };
   }
   return { output: "", exitCode: result.hit_target ? 0 : 2 };
@@ -1292,7 +1324,7 @@ export async function run(args: string[], options: Record<string, unknown>): Pro
 
 export function help(): CommandResult {
   return {
-    output: `crux tb improve-entity <slug> [--target=N] [--budget=N] [--max-iters=N] [--wait-for-settle]
+    output: `crux tb improve-entity <slug> [--target=N] [--budget=N] [--max-iters=N] [--wait-for-settle] [--force]
 
 Closed-loop iterative entity improver. Discovers sources via runResearch,
 extracts gap-targeted claims with Haiku, pre-filters by token presence,
@@ -1316,6 +1348,10 @@ Options:
                        terminal status, applying any newly-verified verdicts
                        (capped at 30 min). Recommended for CI gate / suite runs
                        so per-run results aren't sensitive to worker timing.
+  --force              Skip the QUA-1032 single-instance mutex check. By
+                       default, refuses to start (exit 2) if another
+                       improve-entity run is already in flight. Use only for
+                       explicit takeover after a crashed run.
 `,
     exitCode: 0,
   };

--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -63,10 +63,9 @@ import {
 } from "../lib/pipeline-runs/lifecycle.ts";
 import { getCachedAuditSessionId } from "../lib/wiki-server/audit-context.ts";
 import {
-  checkImproveEntityMutex,
+  assertNoImproveEntityMutexConflict,
   ImproveEntityMutexError,
   IMPROVE_ENTITY_PIPELINE_NAME,
-  IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
   type CheckMutexOptions,
 } from "../lib/improve-entity/mutex.ts";
 
@@ -1098,32 +1097,15 @@ export async function improveSingleEntity(opts: ImproveOptions): Promise<Improve
     );
   }
 
-  // QUA-1032 single-instance mutex: refuse to start if another improve-entity
-  // family run (single or suite) is already in flight (status=running, fresh
-  // heartbeat). Checks BOTH pipeline names because: (a) a running suite's
-  // per-entity invocation will collide with a stand-alone start anyway, so
-  // catching the suite at this level fails fast with a clear error; (b)
-  // symmetrically, a stand-alone in flight would block a suite that's about
-  // to start a per-entity invocation on the same family.
-  //
-  // Skipped when --force is set, OR when the caller is the suite (which
-  // already passed its own family-level check and forwards force=true to
-  // each per-entity invocation to avoid a self-detection conflict on the
-  // suite's own running row).
-  //
-  // Runs *before* `withPipelineRun` so this run's own pipeline_runs row
-  // hasn't been inserted yet — no risk of self-detection.
-  const conflict = await checkImproveEntityMutex({
-    pipelineNames: [
-      IMPROVE_ENTITY_PIPELINE_NAME,
-      IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
-    ],
+  // QUA-1032 single-instance mutex: refuse to start if any family-member run
+  // (single or suite) is already in flight. Runs *before* `withPipelineRun`
+  // so this run's own `improve-entity` row hasn't been inserted yet, avoiding
+  // self-detection. Suite per-entity calls pass `force: true` because the
+  // suite's outer `withPipelineRun` already owns the family lock.
+  await assertNoImproveEntityMutexConflict({
     force: opts.force,
-    ...(opts.mutexCheckOverrides ?? {}),
+    mutexCheckOverrides: opts.mutexCheckOverrides,
   });
-  if (conflict) {
-    throw new ImproveEntityMutexError(conflict);
-  }
 
   // Pull the active agent_session_id (primed by crux.mjs at startup) so the
   // pipeline_runs row links back to the agent that triggered the run.
@@ -1172,7 +1154,7 @@ export function buildImproveEntityRunOptions(
   agentSessionId: number | null,
 ): WithPipelineRunOptions {
   return {
-    pipelineName: "improve-entity",
+    pipelineName: IMPROVE_ENTITY_PIPELINE_NAME,
     entityId: entity.stableId ?? entity.id,
     shape: entity.type,
     agentSessionId,

--- a/crux/lib/improve-entity/mutex.test.ts
+++ b/crux/lib/improve-entity/mutex.test.ts
@@ -69,14 +69,13 @@ describe('checkImproveEntityMutex', () => {
   it('returns null when no running rows match', async () => {
     const list = makeList([]);
     const result = await checkImproveEntityMutex({
-      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      pipelineNames: [IMPROVE_ENTITY_SUITE_PIPELINE_NAME, IMPROVE_ENTITY_PIPELINE_NAME],
       list,
       nowMs: NOW,
     });
     expect(result).toBeNull();
     expect(list).toHaveBeenCalledWith({
       status: 'running',
-      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
       limit: 50,
     });
   });
@@ -84,7 +83,7 @@ describe('checkImproveEntityMutex', () => {
   it('returns the conflict when one fresh running row exists', async () => {
     const row = makeRow({ runId: 'run-A', agentSessionId: 7 });
     const result = await checkImproveEntityMutex({
-      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      pipelineNames: [IMPROVE_ENTITY_SUITE_PIPELINE_NAME, IMPROVE_ENTITY_PIPELINE_NAME],
       list: makeList([row]),
       nowMs: NOW,
     });
@@ -101,7 +100,7 @@ describe('checkImproveEntityMutex', () => {
       heartbeatAt: new Date(T0 - 31 * 60_000).toISOString(),
     });
     const result = await checkImproveEntityMutex({
-      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      pipelineNames: [IMPROVE_ENTITY_SUITE_PIPELINE_NAME, IMPROVE_ENTITY_PIPELINE_NAME],
       list: makeList([stale]),
       nowMs: NOW,
     });
@@ -117,7 +116,7 @@ describe('checkImproveEntityMutex', () => {
       startedAt: new Date(T0 - 60_000).toISOString(),
     });
     const result = await checkImproveEntityMutex({
-      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      pipelineNames: [IMPROVE_ENTITY_SUITE_PIPELINE_NAME, IMPROVE_ENTITY_PIPELINE_NAME],
       list: makeList([row]),
       nowMs: NOW,
     });
@@ -139,7 +138,7 @@ describe('checkImproveEntityMutex', () => {
       heartbeatAt: new Date(T0 - 60_000).toISOString(),
     });
     const result = await checkImproveEntityMutex({
-      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      pipelineNames: [IMPROVE_ENTITY_SUITE_PIPELINE_NAME, IMPROVE_ENTITY_PIPELINE_NAME],
       list: makeList([older, newer, middle]),
       nowMs: NOW,
     });
@@ -151,7 +150,7 @@ describe('checkImproveEntityMutex', () => {
     const fresh = makeRow({ runId: 'should-be-bypassed' });
     const list = makeList([fresh]);
     const result = await checkImproveEntityMutex({
-      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      pipelineNames: [IMPROVE_ENTITY_SUITE_PIPELINE_NAME, IMPROVE_ENTITY_PIPELINE_NAME],
       force: true,
       list,
       nowMs: NOW,
@@ -169,7 +168,7 @@ describe('checkImproveEntityMutex', () => {
       heartbeatAt: new Date(T0 - 5 * 60_000).toISOString(),
     });
     const result = await checkImproveEntityMutex({
-      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      pipelineNames: [IMPROVE_ENTITY_SUITE_PIPELINE_NAME, IMPROVE_ENTITY_PIPELINE_NAME],
       freshnessMs: 60_000,
       list: makeList([row]),
       nowMs: NOW,
@@ -177,18 +176,54 @@ describe('checkImproveEntityMutex', () => {
     expect(result).toBeNull();
   });
 
-  it('forwards the pipelineName filter to the API', async () => {
-    const list = makeList([]);
-    await checkImproveEntityMutex({
+  it('filters returned rows to the requested pipeline names (drops unrelated families)', async () => {
+    const matching = makeRow({
+      runId: 'matching',
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      heartbeatAt: new Date(T0 - 30_000).toISOString(),
+    });
+    const otherFamily = makeRow({
+      runId: 'unrelated',
+      // Hypothetical other pipeline running concurrently — shouldn't conflict.
+      pipelineName: 'some-other-pipeline' as never,
+      heartbeatAt: new Date(T0 - 10_000).toISOString(),
+    });
+    const result = await checkImproveEntityMutex({
+      pipelineNames: [IMPROVE_ENTITY_SUITE_PIPELINE_NAME, IMPROVE_ENTITY_PIPELINE_NAME],
+      list: makeList([otherFamily, matching]),
+      nowMs: NOW,
+    });
+    expect(result?.runId).toBe('matching');
+  });
+
+  it('blocks when pipelineNames includes both — a stand-alone improve-entity row blocks a suite check', async () => {
+    // The cross-family case: the suite is about to start, but a stand-alone
+    // improve-entity is already in flight. Pre-MEDIUM-1-fix the suite would
+    // proceed and only collide on the first per-entity invocation.
+    const standalone = makeRow({
+      runId: 'standalone',
       pipelineName: IMPROVE_ENTITY_PIPELINE_NAME,
+      heartbeatAt: new Date(T0 - 10_000).toISOString(),
+    });
+    const result = await checkImproveEntityMutex({
+      pipelineNames: [IMPROVE_ENTITY_SUITE_PIPELINE_NAME, IMPROVE_ENTITY_PIPELINE_NAME],
+      list: makeList([standalone]),
+      nowMs: NOW,
+    });
+    expect(result?.runId).toBe('standalone');
+    expect(result?.pipelineName).toBe(IMPROVE_ENTITY_PIPELINE_NAME);
+  });
+
+  it('returns null when pipelineNames is empty', async () => {
+    const list = makeList([makeRow({ runId: 'fresh' })]);
+    const result = await checkImproveEntityMutex({
+      pipelineNames: [],
       list,
       nowMs: NOW,
     });
-    expect(list).toHaveBeenCalledWith({
-      status: 'running',
-      pipelineName: IMPROVE_ENTITY_PIPELINE_NAME,
-      limit: 50,
-    });
+    expect(result).toBeNull();
+    // Empty pipelineNames short-circuits before the API call.
+    expect(list).not.toHaveBeenCalled();
   });
 });
 
@@ -202,7 +237,7 @@ describe('checkImproveEntityMutex — fail-open', () => {
       message: 'wiki-server down',
     });
     const result = await checkImproveEntityMutex({
-      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      pipelineNames: [IMPROVE_ENTITY_SUITE_PIPELINE_NAME, IMPROVE_ENTITY_PIPELINE_NAME],
       list,
       nowMs: NOW,
     });
@@ -212,7 +247,7 @@ describe('checkImproveEntityMutex — fail-open', () => {
   it('returns null (allows run) when listPipelineRuns throws', async () => {
     const list = vi.fn().mockRejectedValue(new Error('network exploded'));
     const result = await checkImproveEntityMutex({
-      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      pipelineNames: [IMPROVE_ENTITY_SUITE_PIPELINE_NAME, IMPROVE_ENTITY_PIPELINE_NAME],
       list,
       nowMs: NOW,
     });
@@ -232,7 +267,7 @@ describe('formatMutexError', () => {
       heartbeatAt: new Date(T0 - 45_000),
       ageSeconds: 45,
     };
-    const msg = formatMutexError(conflict, IMPROVE_ENTITY_SUITE_PIPELINE_NAME);
+    const msg = formatMutexError(conflict);
     expect(msg).toContain('run_id=run-XYZ');
     expect(msg).toContain('agent_session_id=99');
     expect(msg).toContain('45s ago');
@@ -249,9 +284,27 @@ describe('formatMutexError', () => {
       heartbeatAt: new Date(T0),
       ageSeconds: 5,
     };
-    const msg = formatMutexError(conflict, IMPROVE_ENTITY_PIPELINE_NAME);
+    const msg = formatMutexError(conflict);
     expect(msg).not.toContain('agent_session_id');
     expect(msg).toContain('5s ago');
+    expect(msg).toContain('Another improve-entity run');
+  });
+
+  it('uses the conflict.pipelineName in the message (so suite-vs-standalone is visible)', () => {
+    // Cross-family case: a stand-alone run blocked a suite. The message
+    // should say "improve-entity" (the conflict's actual pipeline), not
+    // "improve-entity-suite" (the caller's pipeline).
+    const conflict = {
+      runId: 'standalone-1',
+      pipelineName: IMPROVE_ENTITY_PIPELINE_NAME,
+      agentSessionId: 7,
+      startedAt: new Date(T0),
+      heartbeatAt: new Date(T0),
+      ageSeconds: 30,
+    };
+    const msg = formatMutexError(conflict);
+    expect(msg).toContain('Another improve-entity run');
+    expect(msg).not.toContain('improve-entity-suite');
   });
 
   it('formats minute-scale ages as Xm', () => {
@@ -263,7 +316,7 @@ describe('formatMutexError', () => {
       heartbeatAt: new Date(T0),
       ageSeconds: 7 * 60 + 12, // 7m 12s — drops the seconds at minute scale
     };
-    expect(formatMutexError(conflict, IMPROVE_ENTITY_SUITE_PIPELINE_NAME)).toContain('7m ago');
+    expect(formatMutexError(conflict)).toContain('7m ago');
   });
 
   it('formats hour-scale ages as Xh Ym', () => {
@@ -275,12 +328,12 @@ describe('formatMutexError', () => {
       heartbeatAt: new Date(T0),
       ageSeconds: 3600 + 5 * 60,
     };
-    expect(formatMutexError(conflict, IMPROVE_ENTITY_SUITE_PIPELINE_NAME)).toContain('1h 5m ago');
+    expect(formatMutexError(conflict)).toContain('1h 5m ago');
   });
 });
 
 describe('ImproveEntityMutexError', () => {
-  it('exposes conflict + pipelineName and produces a useful message', () => {
+  it('exposes conflict and produces a useful message', () => {
     const conflict = {
       runId: 'run-1',
       pipelineName: IMPROVE_ENTITY_PIPELINE_NAME,
@@ -289,9 +342,9 @@ describe('ImproveEntityMutexError', () => {
       heartbeatAt: new Date(T0),
       ageSeconds: 12,
     };
-    const err = new ImproveEntityMutexError(conflict, IMPROVE_ENTITY_PIPELINE_NAME);
+    const err = new ImproveEntityMutexError(conflict);
     expect(err.conflict.runId).toBe('run-1');
-    expect(err.pipelineName).toBe(IMPROVE_ENTITY_PIPELINE_NAME);
+    expect(err.conflict.pipelineName).toBe(IMPROVE_ENTITY_PIPELINE_NAME);
     expect(err.message).toContain('run_id=run-1');
     expect(err.message).toContain('Another improve-entity run');
     expect(err.name).toBe('ImproveEntityMutexError');

--- a/crux/lib/improve-entity/mutex.test.ts
+++ b/crux/lib/improve-entity/mutex.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for `checkImproveEntityMutex` (QUA-1032).
+ *
+ * Pure-helper tests — `listPipelineRuns` is injected, no network. Each test
+ * pins the clock so freshness math is deterministic.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  checkImproveEntityMutex,
+  formatMutexError,
+  ImproveEntityMutexError,
+  IMPROVE_ENTITY_PIPELINE_NAME,
+  IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+  type CheckMutexOptions,
+} from './mutex.ts';
+import type { PipelineRunRow } from '../wiki-server/pipeline-runs.ts';
+import type { ApiResult } from '../wiki-server/client.ts';
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+const T0 = Date.parse('2026-05-01T20:00:00.000Z');
+const NOW = (): number => T0;
+
+function makeRow(overrides: Partial<PipelineRunRow> = {}): PipelineRunRow {
+  return {
+    runId: 'run-1',
+    pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+    agentSessionId: 42,
+    entityId: null,
+    shape: null,
+    status: 'running',
+    startedAt: new Date(T0 - 60_000).toISOString(),
+    heartbeatAt: new Date(T0 - 30_000).toISOString(),
+    endedAt: null,
+    failureReason: null,
+    errorCode: null,
+    errorPayload: null,
+    snapshotPath: null,
+    followupActions: [],
+    costUsd: null,
+    tokensInput: null,
+    tokensOutput: null,
+    tokensCacheRead: null,
+    tokensCacheWrite: null,
+    createdAt: new Date(T0 - 60_000).toISOString(),
+    updatedAt: new Date(T0 - 30_000).toISOString(),
+    ...overrides,
+  } as PipelineRunRow;
+}
+
+function makeList(
+  rows: PipelineRunRow[] | { ok: false; error: 'unavailable' | 'server_error'; message: string },
+): NonNullable<CheckMutexOptions['list']> {
+  return vi.fn().mockResolvedValue(
+    Array.isArray(rows)
+      ? ({ ok: true, data: { runs: rows, count: rows.length } } satisfies ApiResult<{
+          runs: PipelineRunRow[];
+          count: number;
+        }>)
+      : (rows satisfies ApiResult<{ runs: PipelineRunRow[]; count: number }>),
+  );
+}
+
+// ── core behavior ───────────────────────────────────────────────────────────
+
+describe('checkImproveEntityMutex', () => {
+  it('returns null when no running rows match', async () => {
+    const list = makeList([]);
+    const result = await checkImproveEntityMutex({
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      list,
+      nowMs: NOW,
+    });
+    expect(result).toBeNull();
+    expect(list).toHaveBeenCalledWith({
+      status: 'running',
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      limit: 50,
+    });
+  });
+
+  it('returns the conflict when one fresh running row exists', async () => {
+    const row = makeRow({ runId: 'run-A', agentSessionId: 7 });
+    const result = await checkImproveEntityMutex({
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      list: makeList([row]),
+      nowMs: NOW,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.runId).toBe('run-A');
+    expect(result!.agentSessionId).toBe(7);
+    expect(result!.ageSeconds).toBe(30);
+  });
+
+  it('skips rows whose heartbeat is older than the freshness window', async () => {
+    // 31 min stale heartbeat → above the 30-min default cutoff.
+    const stale = makeRow({
+      runId: 'stale',
+      heartbeatAt: new Date(T0 - 31 * 60_000).toISOString(),
+    });
+    const result = await checkImproveEntityMutex({
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      list: makeList([stale]),
+      nowMs: NOW,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('falls back to startedAt when heartbeatAt is null', async () => {
+    // No heartbeat yet (race between insert and first beat).
+    // startedAt is 1 min ago → within freshness.
+    const row = makeRow({
+      runId: 'fresh-no-beat',
+      heartbeatAt: null,
+      startedAt: new Date(T0 - 60_000).toISOString(),
+    });
+    const result = await checkImproveEntityMutex({
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      list: makeList([row]),
+      nowMs: NOW,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.runId).toBe('fresh-no-beat');
+  });
+
+  it('returns the most-recently-active conflict when multiple are fresh', async () => {
+    const older = makeRow({
+      runId: 'older',
+      heartbeatAt: new Date(T0 - 5 * 60_000).toISOString(),
+    });
+    const newer = makeRow({
+      runId: 'newer',
+      heartbeatAt: new Date(T0 - 15_000).toISOString(),
+    });
+    const middle = makeRow({
+      runId: 'middle',
+      heartbeatAt: new Date(T0 - 60_000).toISOString(),
+    });
+    const result = await checkImproveEntityMutex({
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      list: makeList([older, newer, middle]),
+      nowMs: NOW,
+    });
+    expect(result?.runId).toBe('newer');
+    expect(result?.ageSeconds).toBe(15);
+  });
+
+  it('returns null when force=true (regardless of running rows)', async () => {
+    const fresh = makeRow({ runId: 'should-be-bypassed' });
+    const list = makeList([fresh]);
+    const result = await checkImproveEntityMutex({
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      force: true,
+      list,
+      nowMs: NOW,
+    });
+    expect(result).toBeNull();
+    // force should short-circuit *before* the API call
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('respects a custom freshnessMs window', async () => {
+    // 5 min ago — would normally be fresh under the 30-min default,
+    // but rejected by a 1-min freshness window.
+    const row = makeRow({
+      runId: 'just-outside',
+      heartbeatAt: new Date(T0 - 5 * 60_000).toISOString(),
+    });
+    const result = await checkImproveEntityMutex({
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      freshnessMs: 60_000,
+      list: makeList([row]),
+      nowMs: NOW,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('forwards the pipelineName filter to the API', async () => {
+    const list = makeList([]);
+    await checkImproveEntityMutex({
+      pipelineName: IMPROVE_ENTITY_PIPELINE_NAME,
+      list,
+      nowMs: NOW,
+    });
+    expect(list).toHaveBeenCalledWith({
+      status: 'running',
+      pipelineName: IMPROVE_ENTITY_PIPELINE_NAME,
+      limit: 50,
+    });
+  });
+});
+
+// ── fail-open paths ─────────────────────────────────────────────────────────
+
+describe('checkImproveEntityMutex — fail-open', () => {
+  it('returns null (allows run) when listPipelineRuns returns ok:false', async () => {
+    const list = makeList({
+      ok: false,
+      error: 'unavailable',
+      message: 'wiki-server down',
+    });
+    const result = await checkImproveEntityMutex({
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      list,
+      nowMs: NOW,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null (allows run) when listPipelineRuns throws', async () => {
+    const list = vi.fn().mockRejectedValue(new Error('network exploded'));
+    const result = await checkImproveEntityMutex({
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      list,
+      nowMs: NOW,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ── error formatting ────────────────────────────────────────────────────────
+
+describe('formatMutexError', () => {
+  it('formats the conflict with run id, age, and session id', () => {
+    const conflict = {
+      runId: 'run-XYZ',
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      agentSessionId: 99,
+      startedAt: new Date(T0 - 60_000),
+      heartbeatAt: new Date(T0 - 45_000),
+      ageSeconds: 45,
+    };
+    const msg = formatMutexError(conflict, IMPROVE_ENTITY_SUITE_PIPELINE_NAME);
+    expect(msg).toContain('run_id=run-XYZ');
+    expect(msg).toContain('agent_session_id=99');
+    expect(msg).toContain('45s ago');
+    expect(msg).toContain('Wait for it to complete, or pass --force');
+    expect(msg).toMatch(/Another improve-entity-suite run is in progress/);
+  });
+
+  it('omits agent_session_id when null', () => {
+    const conflict = {
+      runId: 'run-1',
+      pipelineName: IMPROVE_ENTITY_PIPELINE_NAME,
+      agentSessionId: null,
+      startedAt: new Date(T0),
+      heartbeatAt: new Date(T0),
+      ageSeconds: 5,
+    };
+    const msg = formatMutexError(conflict, IMPROVE_ENTITY_PIPELINE_NAME);
+    expect(msg).not.toContain('agent_session_id');
+    expect(msg).toContain('5s ago');
+  });
+
+  it('formats minute-scale ages as Xm', () => {
+    const conflict = {
+      runId: 'run-1',
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      agentSessionId: null,
+      startedAt: new Date(T0),
+      heartbeatAt: new Date(T0),
+      ageSeconds: 7 * 60 + 12, // 7m 12s — drops the seconds at minute scale
+    };
+    expect(formatMutexError(conflict, IMPROVE_ENTITY_SUITE_PIPELINE_NAME)).toContain('7m ago');
+  });
+
+  it('formats hour-scale ages as Xh Ym', () => {
+    const conflict = {
+      runId: 'run-1',
+      pipelineName: IMPROVE_ENTITY_SUITE_PIPELINE_NAME,
+      agentSessionId: null,
+      startedAt: new Date(T0),
+      heartbeatAt: new Date(T0),
+      ageSeconds: 3600 + 5 * 60,
+    };
+    expect(formatMutexError(conflict, IMPROVE_ENTITY_SUITE_PIPELINE_NAME)).toContain('1h 5m ago');
+  });
+});
+
+describe('ImproveEntityMutexError', () => {
+  it('exposes conflict + pipelineName and produces a useful message', () => {
+    const conflict = {
+      runId: 'run-1',
+      pipelineName: IMPROVE_ENTITY_PIPELINE_NAME,
+      agentSessionId: 11,
+      startedAt: new Date(T0),
+      heartbeatAt: new Date(T0),
+      ageSeconds: 12,
+    };
+    const err = new ImproveEntityMutexError(conflict, IMPROVE_ENTITY_PIPELINE_NAME);
+    expect(err.conflict.runId).toBe('run-1');
+    expect(err.pipelineName).toBe(IMPROVE_ENTITY_PIPELINE_NAME);
+    expect(err.message).toContain('run_id=run-1');
+    expect(err.message).toContain('Another improve-entity run');
+    expect(err.name).toBe('ImproveEntityMutexError');
+  });
+});

--- a/crux/lib/improve-entity/mutex.ts
+++ b/crux/lib/improve-entity/mutex.ts
@@ -185,6 +185,31 @@ export class ImproveEntityMutexError extends Error {
   }
 }
 
+/**
+ * Family-wide mutex check used by both the single-entity and suite call sites.
+ * Always queries for both family members so a stand-alone `improve-entity`
+ * blocks the suite and vice versa.
+ *
+ * Throws {@link ImproveEntityMutexError} on conflict; resolves with no value
+ * when the family is clear or `force=true`.
+ */
+export async function assertNoImproveEntityMutexConflict(options: {
+  force?: boolean;
+  mutexCheckOverrides?: Pick<
+    CheckMutexOptions,
+    'list' | 'nowMs' | 'freshnessMs'
+  >;
+}): Promise<void> {
+  const conflict = await checkImproveEntityMutex({
+    pipelineNames: [IMPROVE_ENTITY_PIPELINE_NAME, IMPROVE_ENTITY_SUITE_PIPELINE_NAME],
+    force: options.force,
+    ...(options.mutexCheckOverrides ?? {}),
+  });
+  if (conflict) {
+    throw new ImproveEntityMutexError(conflict);
+  }
+}
+
 // ── Internal helpers ────────────────────────────────────────────────────────
 
 /** Convert a `Date | string | null | undefined` field into ms-since-epoch.

--- a/crux/lib/improve-entity/mutex.ts
+++ b/crux/lib/improve-entity/mutex.ts
@@ -1,0 +1,209 @@
+/**
+ * Single-instance mutex for `improve-entity` and `improve-entity-suite`
+ * (QUA-1032, parent QUA-1011).
+ *
+ * Two parallel suite runs is never what a user wants — they're either redundant
+ * or fighting for the same entity row. A coordinator session triggered
+ * improve-entity-suite twice on 2026-05-01 (output buffering hid the first run;
+ * second started in parallel) and both ran for ~10 minutes spending $5–10 each.
+ *
+ * This helper queries the existing `pipeline_runs` API for any matching
+ * `running` rows with a fresh heartbeat (≤30 min), and refuses to start if
+ * one is found unless `--force` is passed.
+ *
+ * ## Design choices
+ *
+ * - **Check happens *before* `withPipelineRun`.** That way the helper's own
+ *   pending row doesn't appear in the conflict list — if we checked from
+ *   inside the lifecycle, we'd self-detect.
+ * - **Freshness gate via `heartbeatAt`, not `startedAt`.** A run with
+ *   `status='running'` but `heartbeatAt` older than 30 min has crashed
+ *   (the lifecycle helper bumps every 30s). Without freshness filtering,
+ *   we'd block on stale rows forever — the pipeline-runs lifecycle has no
+ *   auto-sweep for crashed runs. The 30-min threshold matches the
+ *   `agent_sessions` stale-sweep cutoff for consistency.
+ * - **Fail-open on API error.** If the wiki-server is unreachable, the
+ *   mutex check can't run. Erring on "let the user proceed" rather than
+ *   "block all improve-entity runs because the server is down" matches
+ *   how `agent-checklist init --allow-offline` behaves.
+ * - **TOCTOU window.** Two concurrent agents could both pass the check
+ *   within ~50ms before either inserts its `pipeline_runs` row. The spec
+ *   accepts this — the wins from blocking the typical "ran the suite twice
+ *   in two terminals" case are the goal, not strict locking.
+ */
+
+import { listPipelineRuns } from '../wiki-server/pipeline-runs.ts';
+import type { PipelineRunRow } from '../wiki-server/pipeline-runs.ts';
+import type { ApiResult } from '../wiki-server/client.ts';
+
+export const IMPROVE_ENTITY_PIPELINE_NAME = 'improve-entity' as const;
+export const IMPROVE_ENTITY_SUITE_PIPELINE_NAME = 'improve-entity-suite' as const;
+
+export type ImproveEntityPipelineName =
+  | typeof IMPROVE_ENTITY_PIPELINE_NAME
+  | typeof IMPROVE_ENTITY_SUITE_PIPELINE_NAME;
+
+/** Default 30-min freshness window for "running" rows. Matches the
+ *  `agent_sessions` stale-sweep cutoff and the heartbeat cadence
+ *  (one heartbeat every 30s — a 30-min gap means ~60 missed beats). */
+export const DEFAULT_FRESHNESS_MS = 30 * 60 * 1000;
+
+export interface MutexConflict {
+  runId: string;
+  pipelineName: string;
+  agentSessionId: number | null;
+  startedAt: Date | string;
+  heartbeatAt: Date | string | null;
+  /** Seconds since the most-recent activity (heartbeatAt, falling back to
+   *  startedAt). Used for the human-readable error message. */
+  ageSeconds: number;
+}
+
+export interface CheckMutexOptions {
+  pipelineName: ImproveEntityPipelineName;
+  /** When true, skip the check entirely. Wired to the CLI `--force` flag. */
+  force?: boolean;
+  /** ms threshold for considering a running row "fresh". Default 30 min. */
+  freshnessMs?: number;
+  /** Test injection — defaults to the real `listPipelineRuns`. The shape
+   *  matches `listPipelineRuns` so a mocked function can stand in directly. */
+  list?: typeof listPipelineRuns;
+  /** Test injection — clock for "now". Defaults to `Date.now`. */
+  nowMs?: () => number;
+}
+
+/**
+ * Returns the most-recently-active conflict, or `null` if there's no
+ * running run that should block the caller. The "most-recently-active"
+ * conflict wins so the error message points at the run the operator is
+ * most likely to recognize.
+ */
+export async function checkImproveEntityMutex(
+  options: CheckMutexOptions,
+): Promise<MutexConflict | null> {
+  if (options.force) return null;
+
+  const list = options.list ?? listPipelineRuns;
+  const freshnessMs = options.freshnessMs ?? DEFAULT_FRESHNESS_MS;
+  const now = (options.nowMs ?? Date.now)();
+
+  let result: ApiResult<{ runs: PipelineRunRow[]; count: number }>;
+  try {
+    result = await list({
+      status: 'running',
+      pipelineName: options.pipelineName,
+      // 50 is well above any realistic concurrency. The list endpoint caps
+      // at 500; we don't need close to that.
+      limit: 50,
+    });
+  } catch (e) {
+    // Network/throw path — fail-open. Distinguishes from `ok: false` which
+    // is the API-returned-error path; both lead to the same fail-open
+    // behavior, but we log differently so debugging knows which branch hit.
+    console.warn(
+      `[mutex] list pipeline-runs threw; allowing run to proceed (fail-open). ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return null;
+  }
+
+  if (!result.ok) {
+    console.warn(
+      `[mutex] list pipeline-runs returned !ok; allowing run to proceed (fail-open). error=${result.error} message=${result.message}`,
+    );
+    return null;
+  }
+
+  // Filter to "fresh" running rows. heartbeatAt is the authoritative
+  // freshness signal; if it's null (route was hit before any heartbeat
+  // landed), fall back to startedAt — both are populated on insert.
+  const conflicts: MutexConflict[] = [];
+  for (const row of result.data.runs) {
+    const beat = row.heartbeatAt ?? row.startedAt;
+    const beatMs = parseToMs(beat);
+    if (beatMs == null) continue;
+    const age = now - beatMs;
+    if (age > freshnessMs) continue;
+    if (age < 0) {
+      // Row's heartbeat is in the future — clock skew between server and
+      // client. Don't block; treat as fresh and let the operator see it.
+      // (This is a fail-open within fail-open: skew shouldn't strand the
+      // user, but a future-heartbeat IS a live row so we still report it.)
+    }
+    conflicts.push({
+      runId: row.runId,
+      pipelineName: row.pipelineName,
+      agentSessionId: row.agentSessionId ?? null,
+      startedAt: row.startedAt,
+      heartbeatAt: row.heartbeatAt,
+      ageSeconds: Math.max(0, Math.round(age / 1000)),
+    });
+  }
+
+  if (conflicts.length === 0) return null;
+
+  // Most-recently-active wins. `ageSeconds` is small for active rows.
+  conflicts.sort((a, b) => a.ageSeconds - b.ageSeconds);
+  return conflicts[0];
+}
+
+/**
+ * Render the user-facing refusal message for a mutex conflict. Exported so
+ * tests can assert on the format, and so callers can choose between
+ * throwing and printing.
+ */
+export function formatMutexError(
+  conflict: MutexConflict,
+  pipelineName: ImproveEntityPipelineName,
+): string {
+  const ageStr = formatAge(conflict.ageSeconds);
+  const sessionStr =
+    conflict.agentSessionId != null
+      ? `, agent_session_id=${conflict.agentSessionId}`
+      : '';
+  return (
+    `✗ Another ${pipelineName} run is in progress ` +
+    `(run_id=${conflict.runId}, started ${ageStr} ago${sessionStr}).\n` +
+    `  Wait for it to complete, or pass --force to start anyway.`
+  );
+}
+
+/** Thrown by `improveSingleEntity` and `runSuite` when the mutex check
+ *  finds a conflicting run. Exit code 2 (matches the parent ticket spec).
+ *  The CLI catches this and prints `formatMutexError(conflict)`. */
+export class ImproveEntityMutexError extends Error {
+  readonly conflict: MutexConflict;
+  readonly pipelineName: ImproveEntityPipelineName;
+  constructor(conflict: MutexConflict, pipelineName: ImproveEntityPipelineName) {
+    super(formatMutexError(conflict, pipelineName));
+    this.name = 'ImproveEntityMutexError';
+    this.conflict = conflict;
+    this.pipelineName = pipelineName;
+  }
+}
+
+// ── Internal helpers ────────────────────────────────────────────────────────
+
+/** Convert a `Date | string | null | undefined` field into ms-since-epoch.
+ *  Returns null when the input is missing or unparseable. */
+function parseToMs(value: Date | string | null | undefined): number | null {
+  if (value == null) return null;
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isFinite(t) ? t : null;
+  }
+  const t = Date.parse(value);
+  return Number.isFinite(t) ? t : null;
+}
+
+/** Format an age in seconds as a compact human label.
+ *    7s, 45s, 3m, 12m, 1h 5m. */
+function formatAge(ageSeconds: number): string {
+  if (ageSeconds < 60) return `${ageSeconds}s`;
+  if (ageSeconds < 3600) {
+    const m = Math.floor(ageSeconds / 60);
+    return `${m}m`;
+  }
+  const h = Math.floor(ageSeconds / 3600);
+  const m = Math.floor((ageSeconds % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}

--- a/crux/lib/improve-entity/mutex.ts
+++ b/crux/lib/improve-entity/mutex.ts
@@ -60,8 +60,14 @@ export interface MutexConflict {
 }
 
 export interface CheckMutexOptions {
-  pipelineName: ImproveEntityPipelineName;
-  /** When true, skip the check entirely. Wired to the CLI `--force` flag. */
+  /** Pipeline names to consider as conflicts. Pass both family members
+   *  (`["improve-entity", "improve-entity-suite"]`) so an external suite
+   *  blocks a stand-alone run and vice versa. The list endpoint is queried
+   *  once without a server-side filter — names are filtered client-side. */
+  pipelineNames: ImproveEntityPipelineName[];
+  /** When true, skip the check entirely. Wired to the CLI `--force` flag,
+   *  and used by the suite to short-circuit per-entity re-checks (the suite
+   *  already owns the global lock). */
   force?: boolean;
   /** ms threshold for considering a running row "fresh". Default 30 min. */
   freshnessMs?: number;
@@ -82,18 +88,20 @@ export async function checkImproveEntityMutex(
   options: CheckMutexOptions,
 ): Promise<MutexConflict | null> {
   if (options.force) return null;
+  if (options.pipelineNames.length === 0) return null;
 
   const list = options.list ?? listPipelineRuns;
   const freshnessMs = options.freshnessMs ?? DEFAULT_FRESHNESS_MS;
   const now = (options.nowMs ?? Date.now)();
+  const wanted = new Set<string>(options.pipelineNames);
 
   let result: ApiResult<{ runs: PipelineRunRow[]; count: number }>;
   try {
+    // No `pipelineName` filter — we may want either name, and post-filtering
+    // client-side avoids a second API round-trip. 50 is well above any
+    // realistic concurrency; the list endpoint caps at 500.
     result = await list({
       status: 'running',
-      pipelineName: options.pipelineName,
-      // 50 is well above any realistic concurrency. The list endpoint caps
-      // at 500; we don't need close to that.
       limit: 50,
     });
   } catch (e) {
@@ -113,22 +121,19 @@ export async function checkImproveEntityMutex(
     return null;
   }
 
-  // Filter to "fresh" running rows. heartbeatAt is the authoritative
-  // freshness signal; if it's null (route was hit before any heartbeat
-  // landed), fall back to startedAt — both are populated on insert.
+  // Filter to "fresh" running rows in any of the requested pipelines.
+  // heartbeatAt is the authoritative freshness signal; if it's null (route
+  // was hit before any heartbeat landed), fall back to startedAt — both
+  // are populated on insert. `age < 0` (server clock ahead of ours) is
+  // floored at 0 in the conflict record so the message reads sensibly.
   const conflicts: MutexConflict[] = [];
   for (const row of result.data.runs) {
+    if (!wanted.has(row.pipelineName)) continue;
     const beat = row.heartbeatAt ?? row.startedAt;
     const beatMs = parseToMs(beat);
     if (beatMs == null) continue;
     const age = now - beatMs;
     if (age > freshnessMs) continue;
-    if (age < 0) {
-      // Row's heartbeat is in the future — clock skew between server and
-      // client. Don't block; treat as fresh and let the operator see it.
-      // (This is a fail-open within fail-open: skew shouldn't strand the
-      // user, but a future-heartbeat IS a live row so we still report it.)
-    }
     conflicts.push({
       runId: row.runId,
       pipelineName: row.pipelineName,
@@ -147,37 +152,36 @@ export async function checkImproveEntityMutex(
 }
 
 /**
- * Render the user-facing refusal message for a mutex conflict. Exported so
- * tests can assert on the format, and so callers can choose between
- * throwing and printing.
+ * Render the user-facing refusal message for a mutex conflict. The pipeline
+ * name in the message comes from the conflict itself — important when the
+ * suite blocks on a stand-alone improve-entity (or vice versa), so the
+ * operator knows which kind of run to wait for.
+ *
+ * Exported so tests can assert on the format and so callers can choose
+ * between throwing and printing.
  */
-export function formatMutexError(
-  conflict: MutexConflict,
-  pipelineName: ImproveEntityPipelineName,
-): string {
+export function formatMutexError(conflict: MutexConflict): string {
   const ageStr = formatAge(conflict.ageSeconds);
   const sessionStr =
     conflict.agentSessionId != null
       ? `, agent_session_id=${conflict.agentSessionId}`
       : '';
   return (
-    `✗ Another ${pipelineName} run is in progress ` +
+    `✗ Another ${conflict.pipelineName} run is in progress ` +
     `(run_id=${conflict.runId}, started ${ageStr} ago${sessionStr}).\n` +
     `  Wait for it to complete, or pass --force to start anyway.`
   );
 }
 
 /** Thrown by `improveSingleEntity` and `runSuite` when the mutex check
- *  finds a conflicting run. Exit code 2 (matches the parent ticket spec).
- *  The CLI catches this and prints `formatMutexError(conflict)`. */
+ *  finds a conflicting run. The CLI catches this and exits with code 2
+ *  (matches the parent ticket spec). */
 export class ImproveEntityMutexError extends Error {
   readonly conflict: MutexConflict;
-  readonly pipelineName: ImproveEntityPipelineName;
-  constructor(conflict: MutexConflict, pipelineName: ImproveEntityPipelineName) {
-    super(formatMutexError(conflict, pipelineName));
+  constructor(conflict: MutexConflict) {
+    super(formatMutexError(conflict));
     this.name = 'ImproveEntityMutexError';
     this.conflict = conflict;
-    this.pipelineName = pipelineName;
   }
 }
 


### PR DESCRIPTION
## Summary

After 2026-05-01's $89 API bill (parent QUA-1011), add a pre-flight mutex check so a coordinator can't accidentally run `improve-entity` or `improve-entity-suite` twice in parallel. The first commit in this branch wires the basic mutex; the second commit fixes a real correctness bug caught by self-review (cross-family blocking).

## What changed

1. **`crux/lib/improve-entity/mutex.ts`** — pure helper. Queries `/api/pipeline-runs?status=running` once, filters client-side to running rows in either family member (`improve-entity` or `improve-entity-suite`) with a fresh heartbeat (≤30 min default), returns the most-recently-active conflict or `null`.

2. **Wired into both commands**:
   - `crux tb improve-entity <slug>`: refuses (exit 2) when any family-member run is in flight
   - `crux tb improve-entity-suite`: refuses (exit 2) at the suite level
   - Suite's per-entity calls always pass `force: true` (the suite already owns the family-level lock; without forcing, the first per-entity check would self-conflict on the suite's own `improve-entity-suite` running row)

3. **`--force` flag** on both commands skips the check entirely. Used for explicit takeover after a crashed run.

## Design choices documented in `mutex.ts`

- **Check before `withPipelineRun`**: avoids self-detection of the about-to-be-inserted row.
- **Freshness via `heartbeatAt`**: a `running` row whose heartbeat is >30 min stale is a crashed run; treat as not-blocking.
- **Fail-open**: if the wiki-server is unreachable, allow the run. Mirrors the `--allow-offline` posture of agent-checklist.
- **TOCTOU acknowledged**: two concurrent agents could both pass the check within ~50ms before either inserts. The spec accepts this — the goal is preventing the typical "ran the suite twice in two terminals" case, not strict locking.

## Bug caught in self-review

The first commit only filtered the suite check on `pipelineName=improve-entity-suite`. A running stand-alone `crux tb improve-entity` would NOT have blocked the suite at the start — the suite would proceed past the suite-only check and then crash on the first per-entity invocation. The second commit refactors to a `pipelineNames: string[]` API and has both call sites check both family members.

## Test plan

- [x] 18 unit tests on the mutex helper (blocking/passthrough, --force short-circuit, freshness window, multi-row priority, fail-open paths, age formatting, cross-family blocking, empty pipelineNames)
- [x] 2 integration tests on the suite wiring (refusal raises `ImproveEntityMutexError`, --force bypasses; per-entity force=true is unconditional)
- [x] 2 integration tests on the per-entity wiring via mocked `withPipelineRun` (refusal short-circuits before `withPipelineRun`; --force lets the wrapper run anyway)
- [x] Existing tests refactored to inject a no-op mutex `list` so they don't make real network calls
- [x] 88 vitest tests pass total
- [x] Pre-push gate green (67 checks, 2 advisory)
- [x] Self-review pass via subagent — caught the cross-family bug above and the misleading layering comment; both fixed in the second commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-1032


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--force` flag to improve-entity and improve-entity-suite commands, allowing users to bypass built-in concurrency protections when necessary
  * Implemented automatic single-instance mutual exclusion to prevent multiple concurrent command executions

* **Behavior Changes**
  * Mutex conflict errors now return exit code 2, distinguishing them from other failure modes which return exit code 1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->