### PR TITLE
fix(agent-workspace): per-slot TMPDIR to isolate tsx compile cache (immediate-relief patch from QUA-1053)

### DIFF
--- a/crux/commands/agent-workspace.ts
+++ b/crux/commands/agent-workspace.ts
@@ -65,6 +65,7 @@ import {
   type DispatchOptions,
   type PermissionMode,
 } from '../lib/agent-workspace/dispatch.ts';
+import { ensureSlotTmpDir } from '../lib/agent-workspace/tsx-cache-isolation.ts';
 import { realDoctorEnv } from '../lib/agent-workspace/doctor/env.ts';
 import { SLOTS_CHECKS } from '../lib/agent-workspace/doctor/slots.ts';
 import { RELEASES_CHECKS } from '../lib/agent-workspace/doctor/releases.ts';
@@ -546,12 +547,15 @@ async function open(args: string[], _options: CommandOptions): Promise<CommandRe
   const branch = git(slotDir, 'branch', '--show-current') || 'detached';
   const fullWindowName = sanitizeForTmux(`A${slot}:${branch}`);
 
+  // Isolate tsx compile cache per-slot. tmux's `-e KEY=VALUE` sets the env var
+  // on the new window; the shell + any `pnpm crux ...` invocations inside it
+  // inherit it. See tsx-cache-isolation.ts.
+  const slotTmpDir = ensureSlotTmpDir(slot);
+  const tmuxArgs = ['new-window', '-n', fullWindowName, '-c', slotDir, '-e', `TMPDIR=${slotTmpDir}`];
+  if (withClaude) tmuxArgs.push('claude');
+
   try {
-    if (withClaude) {
-      execFileSync('tmux', ['new-window', '-n', fullWindowName, '-c', slotDir, 'claude'], { stdio: 'inherit' });
-    } else {
-      execFileSync('tmux', ['new-window', '-n', fullWindowName, '-c', slotDir], { stdio: 'inherit' });
-    }
+    execFileSync('tmux', tmuxArgs, { stdio: 'inherit' });
     return { exitCode: 0, output: `Opened tmux window ${fullWindowName} at ${slotDir}${withClaude ? ' (with claude)' : ''}` };
   } catch (e) {
     return { exitCode: 1, output: `Error opening tmux window: ${e instanceof Error ? e.message : String(e)}` };
@@ -956,6 +960,9 @@ async function dispatchCmd(args: string[], options: DispatchCliOptions): Promise
     appendSystemPrompt: options.appendSystemPrompt,
     permissionMode,
     force: !!options.force,
+    // Isolate tsx compile cache per-slot to eliminate cross-slot fs contention
+    // that has caused 25+ minute hangs under heavy concurrent load.
+    tmpDir: ensureSlotTmpDir(slot),
   };
 
   let result;

--- a/crux/lib/agent-workspace/__tests__/dispatch.test.ts
+++ b/crux/lib/agent-workspace/__tests__/dispatch.test.ts
@@ -35,6 +35,7 @@ interface SpawnCall {
   stdoutFd: number;
   stderrFd: number;
   assignedPid: number;
+  env?: NodeJS.ProcessEnv;
 }
 
 class FakeEnv implements DispatchEnv {
@@ -84,9 +85,21 @@ class FakeEnv implements DispatchEnv {
     }
     return false;
   }
-  spawnDetached(cmd: string, args: string[], opts: { cwd: string; stdoutFd: number; stderrFd: number }) {
+  spawnDetached(
+    cmd: string,
+    args: string[],
+    opts: { cwd: string; stdoutFd: number; stderrFd: number; env?: NodeJS.ProcessEnv },
+  ) {
     const assignedPid = this.nextPid++;
-    this.spawnCalls.push({ cmd, args, cwd: opts.cwd, stdoutFd: opts.stdoutFd, stderrFd: opts.stderrFd, assignedPid });
+    this.spawnCalls.push({
+      cmd,
+      args,
+      cwd: opts.cwd,
+      stdoutFd: opts.stdoutFd,
+      stderrFd: opts.stderrFd,
+      assignedPid,
+      env: opts.env,
+    });
     this.alivePids.add(assignedPid);
     return assignedPid;
   }
@@ -526,6 +539,30 @@ describe('spawnDispatch', () => {
     expect(call.args[i('--max-budget-usd') + 1]).toBe('12');
     expect(call.args[i('--allowedTools') + 1]).toBe('Read');
     expect(call.args[i('--permission-mode') + 1]).toBe('acceptEdits');
+  });
+
+  it('does not override TMPDIR when no tmpDir is provided', () => {
+    const env = new FakeEnv();
+    const paths = dispatchPaths('/lw/a3');
+    spawnDispatch(env, paths, { slot: 3, cwd: '/lw/a3', prompt: 'x' });
+    // Without tmpDir, env should be undefined (child inherits parent's TMPDIR).
+    expect(env.spawnCalls[0].env).toBeUndefined();
+  });
+
+  it('passes tmpDir as TMPDIR on child env when provided', () => {
+    const env = new FakeEnv();
+    const paths = dispatchPaths('/lw/a3');
+    spawnDispatch(env, paths, {
+      slot: 3,
+      cwd: '/lw/a3',
+      prompt: 'x',
+      tmpDir: '/tmp/tsx-slot-a3',
+    });
+    const childEnv = env.spawnCalls[0].env;
+    expect(childEnv).toBeDefined();
+    expect(childEnv?.TMPDIR).toBe('/tmp/tsx-slot-a3');
+    // The rest of process.env should still be present (we extend, not replace).
+    expect(childEnv?.PATH).toBe(process.env.PATH);
   });
 });
 

--- a/crux/lib/agent-workspace/__tests__/tsx-cache-isolation.test.ts
+++ b/crux/lib/agent-workspace/__tests__/tsx-cache-isolation.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { existsSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getSlotTmpDir, ensureSlotTmpDir } from '../tsx-cache-isolation.ts';
+
+describe('getSlotTmpDir', () => {
+  it('returns deterministic per-slot paths under os.tmpdir()', () => {
+    const a2 = getSlotTmpDir(2);
+    const a15 = getSlotTmpDir(15);
+    expect(a2).toBe(join(tmpdir(), 'tsx-slot-a2'));
+    expect(a15).toBe(join(tmpdir(), 'tsx-slot-a15'));
+    expect(a2).not.toBe(a15);
+  });
+
+  it('is stable across calls (same slot → same path)', () => {
+    expect(getSlotTmpDir(7)).toBe(getSlotTmpDir(7));
+  });
+
+  it('rejects non-positive or non-integer slots', () => {
+    expect(() => getSlotTmpDir(0)).toThrow(/positive integer/);
+    expect(() => getSlotTmpDir(-1)).toThrow(/positive integer/);
+    expect(() => getSlotTmpDir(1.5)).toThrow(/positive integer/);
+    expect(() => getSlotTmpDir(NaN)).toThrow(/positive integer/);
+  });
+});
+
+describe('ensureSlotTmpDir', () => {
+  // Use slot numbers far from any real slot to avoid colliding with live
+  // workspace state. Cleanup runs in afterEach regardless of test outcome.
+  const TEST_SLOTS = [9001, 9002, 9003];
+
+  afterEach(() => {
+    for (const slot of TEST_SLOTS) {
+      rmSync(getSlotTmpDir(slot), { recursive: true, force: true });
+    }
+  });
+
+  it('creates the slot directory and returns its path', () => {
+    const dir = ensureSlotTmpDir(9001);
+    expect(dir).toBe(getSlotTmpDir(9001));
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  it('is idempotent — repeated calls do not throw', () => {
+    expect(() => ensureSlotTmpDir(9002)).not.toThrow();
+    expect(() => ensureSlotTmpDir(9002)).not.toThrow();
+    expect(() => ensureSlotTmpDir(9002)).not.toThrow();
+    expect(existsSync(getSlotTmpDir(9002))).toBe(true);
+  });
+
+  it('rejects invalid slots before creating anything', () => {
+    expect(() => ensureSlotTmpDir(0)).toThrow(/positive integer/);
+    expect(() => ensureSlotTmpDir(-5)).toThrow(/positive integer/);
+  });
+});

--- a/crux/lib/agent-workspace/dispatch.ts
+++ b/crux/lib/agent-workspace/dispatch.ts
@@ -78,6 +78,13 @@ export interface DispatchOptions {
   permissionMode?: PermissionMode;
   /** When true, ignore an existing live dispatch in the target slot. */
   force?: boolean;
+  /**
+   * Per-slot TMPDIR set on the child process to isolate tsx's compile cache
+   * from other slots. Caller must ensure the directory exists. Omit to inherit
+   * the parent's TMPDIR (test harnesses do this; the production caller passes
+   * `ensureSlotTmpDir(slot)`). See `tsx-cache-isolation.ts`.
+   */
+  tmpDir?: string;
 }
 
 /** True if `s` is a valid claude CLI permission mode. */
@@ -165,8 +172,12 @@ export interface DispatchEnv {
   /**
    * Spawn `claude` detached with stdout/stderr wired to the provided fds.
    * Returns the child pid. Does not wait.
+   *
+   * `env`, when provided, fully replaces the child's environment (mirrors
+   * Node's `child_process.spawn` semantics). Pass `{ ...process.env, ... }` to
+   * extend rather than replace.
    */
-  spawnDetached(cmd: string, args: string[], opts: { cwd: string; stdoutFd: number; stderrFd: number }): number;
+  spawnDetached(cmd: string, args: string[], opts: { cwd: string; stdoutFd: number; stderrFd: number; env?: NodeJS.ProcessEnv }): number;
   /** Generate a UUID v4 (pre-assigned session id). */
   uuid(): string;
 }
@@ -216,11 +227,12 @@ export function realDispatchEnv(): DispatchEnv {
         return false;
       }
     },
-    spawnDetached: (cmd, args, { cwd, stdoutFd, stderrFd }) => {
+    spawnDetached: (cmd, args, { cwd, stdoutFd, stderrFd, env: spawnEnv }) => {
       const spawnOpts: SpawnOptions = {
         cwd,
         detached: true,
         stdio: ['ignore', stdoutFd, stderrFd],
+        ...(spawnEnv ? { env: spawnEnv } : {}),
       };
       const child: ChildProcess = cpSpawn(cmd, args, spawnOpts);
       if (typeof child.pid !== 'number') {
@@ -568,12 +580,21 @@ export function spawnDispatch(env: DispatchEnv, paths: DispatchPaths, opts: Disp
     throw e;
   }
 
+  // Per-slot tsx cache (see tsx-cache-isolation.ts for context). Caller is
+  // responsible for ensuring the directory exists before invoking spawnDispatch
+  // (the real CLI path does so via ensureSlotTmpDir; tests can pass any dir or
+  // omit the override entirely).
+  const childEnv: NodeJS.ProcessEnv | undefined = opts.tmpDir
+    ? { ...process.env, TMPDIR: opts.tmpDir }
+    : undefined;
+
   let pid: number;
   try {
     pid = env.spawnDetached('claude', argv, {
       cwd: opts.cwd,
       stdoutFd,
       stderrFd,
+      ...(childEnv ? { env: childEnv } : {}),
     });
   } finally {
     // Parent closes its handles; child inherited duplicates.

--- a/crux/lib/agent-workspace/tsx-cache-isolation.ts
+++ b/crux/lib/agent-workspace/tsx-cache-isolation.ts
@@ -1,0 +1,43 @@
+/**
+ * Per-slot tsx cache isolation.
+ *
+ * Every `pnpm crux ...` invocation runs through `node --import tsx/esm` which
+ * compiles TypeScript modules on demand using a worker thread. The compiled
+ * output is cached in `$TMPDIR/tsx-<uid>/`. When 20+ agent slots share that
+ * cache, macOS filesystem locking degrades catastrophically — the main thread
+ * blocks in `Atomics.wait()` waiting for the worker to finish compiling and
+ * writing cache files. We have observed crux commands hung 25+ minutes under
+ * heavy concurrent load while a direct `curl` to the same backend completed
+ * in under a second.
+ *
+ * Setting a slot-specific TMPDIR before launching `claude` (interactive or
+ * dispatched) gives each slot its own tsx cache. Each slot pays a one-time
+ * compile cost (~1-2s) on first invocation, but cross-slot contention
+ * disappears entirely. A/B test: shared cache hung 7+ min, isolated TMPDIR
+ * completed in 2.25s under the same concurrent load.
+ *
+ * The directory is rooted at `os.tmpdir()` which on macOS is already per-user
+ * (`/private/var/folders/<hash>/T/`), so no uid suffix is needed.
+ */
+
+import { mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/**
+ * Path to the per-slot TMPDIR. Each slot's tsx cache lives at
+ * `<this>/tsx-<uid>/`, written by tsx itself.
+ */
+export function getSlotTmpDir(slot: number): string {
+  if (!Number.isInteger(slot) || slot < 1) {
+    throw new Error(`getSlotTmpDir: slot must be a positive integer, got ${slot}`);
+  }
+  return join(tmpdir(), `tsx-slot-a${slot}`);
+}
+
+/** Idempotently create the slot's TMPDIR if missing. Returns the path. */
+export function ensureSlotTmpDir(slot: number): string {
+  const dir = getSlotTmpDir(slot);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}


### PR DESCRIPTION
## Summary

- Per-slot `TMPDIR=$TMPDIR/tsx-slot-aN` set on `claude` workers spawned by both `crux sys agent-workspace open --claude` (interactive) and `dispatch` (headless), eliminating cross-slot tsx cache contention that caused crux commands to hang 25+ min under load.
- New helper `crux/lib/agent-workspace/tsx-cache-isolation.ts` with `getSlotTmpDir(slot)` + `ensureSlotTmpDir(slot)`.
- `DispatchOptions.tmpDir` + `spawnDetached(env)` thread the value through. Caller does the `mkdirSync`; `spawnDispatch` stays pure for testability.
- 6 new unit tests + 2 added to dispatch suite.

## Why

Investigated 2026-05-01 after `pnpm crux linear create` hung 25+ min. Found:

| Signal | Value |
|---|---|
| Concurrent node-tsx processes (whole machine) | **357** |
| Direct curl to Linear API | 0.18s |
| `pnpm crux linear search` (shared cache, under load) | hung 7+ min |
| `pnpm crux linear search` (isolated TMPDIR + no-cache) | **2.25s** |
| Hung process main-thread stack | `AtomicsWait → DoWait → FutexEmulation::WaitSync → pthread_cond_wait` |

That stack is exclusively used by tsx 4.x's worker-sync — main thread blocks waiting for a worker to finish compile + cache write. With 300+ concurrent processes hitting the same `$TMPDIR/tsx-<uid>/`, macOS filesystem locking degrades catastrophically. No network sockets on the hung process — it never reached application code.

Per-slot TMPDIR fragments the cache: each slot pays a one-time compile cost (~1-2s) on first invocation, but cross-slot contention disappears entirely.

Live-tested during this PR's own push: pre-push gate hung indefinitely with the shared cache; with `TMPDIR=/tmp/tsx-isolated-501` set on the parent shell it ran 66 gate checks in 45.2s.

## Why not just `TSX_DISABLE_CACHE=1`?

Disabling the cache eliminates contention but adds 1-2s recompile to every invocation. Per-slot keeps the cache benefit within a slot while killing cross-slot contention. Strict improvement.

## Relationship to QUA-1053

This is the **immediate-relief patch**. The full fix — pre-build crux to `dist/` once, run as plain node, eliminate tsx from the runtime hot path entirely — is tracked in [QUA-1053](https://linear.app/quantifieduncertainty/issue/QUA-1053). This patch lands first because it's a focused wrapper change with no build-system implications; QUA-1053 is a deeper refactor.

## Coverage gap (will file follow-up)

Outside the scope of this PR but worth flagging from the hostile-review pass: 6 other `spawn('claude', ...)` callsites exist beyond `dispatch.ts`:

- `crux/authoring/creator/{synthesis,validation,deployment}.ts`
- `crux/authoring/page-improver/api.ts`
- `crux/pr-patrol/execution.ts`
- `apps/groundskeeper/src/claude.ts`

Most inherit the parent slot's TMPDIR via the env-passthrough that this PR already wires up (so a slot opened via `./ws open --claude` propagates the per-slot TMPDIR to all subsequent crux invocations within it). The remaining gaps — `pr-patrol/execution.ts` running from worktrees, `groundskeeper` running in k8s — have different context models and need their own fix shapes. Filing a follow-up Linear ticket for the per-context isolation work; not blocking this PR.

## Hostile-review findings (3 MEDIUM, 6 LOW, 0 CRITICAL/HIGH)

All MEDIUMs reviewed and dismissed with rationale; LOWs accepted as documentation/cosmetic items.

- **MEDIUM (80% conf): `mkdirSync` failure not caught** — Dismissed. The realistic failure modes (ENOSPC, EACCES, path collision) all warrant loud failure rather than silent fallback to inheriting parent TMPDIR (the contention bug returns). Letting the error propagate is the correct behavior.
- **MEDIUM (75% conf): empty-string `tmpDir` silently ignored** — Dismissed. The only callsite passes `ensureSlotTmpDir(slot)` which is guaranteed to return a non-empty string. Tightening the guard would be defensive cosmetics for an unreachable code path.
- **MEDIUM (70% conf): `ensureSlotTmpDir` runs even when `--claude` is false in `open()`** — Intentional. The comment in the code already states the TMPDIR applies to "the shell + any `pnpm crux ...` invocations inside it" — broadening scope to the whole pane is the right move because anything tsx-using in that pane benefits from isolation.
- **6 LOWs**: JSDoc wording, multi-user `/tmp` collision risk on Linux (single-user fleet so n/a today), conditional spread redundancy (cosmetic), eager mkdir on tmux failure (idempotent so harmless), test cleanup pattern, real-spawn env branch not unit-tested (covered by this PR's own push using the same env-extension path live).

## Test plan

- [x] `npx vitest run crux/lib/agent-workspace` — 217 tests pass across 7 files (6 new tsx-cache-isolation, 2 added dispatch)
- [x] `tsc --noEmit -p crux/tsconfig.json` — no new errors (4 pre-existing in unrelated files: aiid/fetch.ts, backfill-sources, pipeline-runs, propose-client)
- [x] `tsc --noEmit -p apps/web/tsconfig.json` and `apps/wiki-server/tsconfig.json` — no new errors
- [x] Pre-push gate: 66 checks passed (45.2s) with isolated TMPDIR — empirical confirmation the fix works
- [x] Adversarial inputs to `getSlotTmpDir`: 13 cases (valid integers, MAX_SAFE_INTEGER, 0, negative, infinite, decimal, NaN, string, null, undefined, object) — valid produce paths, all 10 invalid throw with clear messages
- [x] CLI smoke: `crux sys agent-workspace dispatch --help` exits clean
- [ ] CI passes
- [ ] Manual smoke after merge: `./ws open <slot> --claude` shows `TMPDIR=/private/.../tsx-slot-aN` in the new window's `env`
- [ ] Manual smoke after merge: `./ws dispatch <slot> "<prompt>"` produces a worker whose `env` contains the slot-specific TMPDIR (verifiable via `ps -E` on the worker pid)

Fixes QUA-1053
