### PR TITLE
QUA-1048: coordinator-session health-monitor daemon (MVP)

### DIFF
--- a/crux/commands/health-monitor.ts
+++ b/crux/commands/health-monitor.ts
@@ -1,0 +1,165 @@
+/**
+ * Health Monitor Command Handlers
+ *
+ * Coordinator-session degradation alarms (QUA-1048). Polls /health and
+ * GitHub main-branch CI for two MVP signals:
+ *   - ci-stale: last green main CI > threshold (default 2h)
+ *   - jobs-stuck: pendingJobs queue not draining (default 15min trend)
+ *
+ * Usage:
+ *   crux sys health-monitor run        Run the daemon (continuous)
+ *   crux sys health-monitor once       Single check cycle
+ *   crux sys health-monitor status     Show daemon state + active alerts
+ *   crux sys health-monitor explain    Long-form explanation
+ */
+
+import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
+import { getColors } from '../lib/output.ts';
+import {
+  buildConfig,
+  getDaemonStatus,
+  runDaemon,
+} from '../health-monitor/daemon.ts';
+import type { DaemonConfig } from '../health-monitor/types.ts';
+
+function parseSeconds(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value;
+  if (typeof value === 'string') {
+    const n = parseInt(value, 10);
+    if (!Number.isNaN(n) && n > 0) return n;
+  }
+  return fallback;
+}
+
+function configFromOptions(options: CommandOptions, once = false): DaemonConfig {
+  return buildConfig({
+    pollIntervalSeconds: parseSeconds(options.interval, 60),
+    ciCheckEveryNCycles: parseSeconds(options['ci-every'], 5),
+    ciStaleThresholdSeconds: parseSeconds(options['ci-stale-seconds'], 2 * 60 * 60),
+    jobsTrendWindowSeconds: parseSeconds(options['jobs-window-seconds'], 15 * 60),
+    jobsTrendMinGrowthSeconds: parseSeconds(options['jobs-min-growth-seconds'], 12 * 60),
+    once,
+  });
+}
+
+async function run(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  await runDaemon(configFromOptions(options));
+  return { output: '', exitCode: 0 };
+}
+
+async function once(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  await runDaemon(configFromOptions(options, true));
+  return { output: '', exitCode: 0 };
+}
+
+async function status(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const c = getColors(Boolean(options.ci));
+  const s = getDaemonStatus();
+
+  if (options.json) {
+    return { output: JSON.stringify(s, null, 2) + '\n', exitCode: 0 };
+  }
+
+  const lines: string[] = [];
+  if (s.running && s.pid) {
+    lines.push(`${c.green}✓${c.reset} health-monitor running (pid ${s.pid})`);
+  } else {
+    lines.push(`${c.red}✗${c.reset} health-monitor not running`);
+  }
+  lines.push(`  cache:           ${s.cacheDir}`);
+  lines.push(`  recent samples:  ${s.recentSampleCount} (last 30 min)`);
+  if (s.alerts.length === 0) {
+    lines.push(`  alerts:          ${c.green}none${c.reset}`);
+  } else {
+    lines.push(`  alerts:          ${c.red}${s.alerts.length} active${c.reset}`);
+    for (const a of s.alerts) {
+      lines.push(`    ${c.red}⚠${c.reset} ${a.signal} — first seen ${formatSince(a.since)}`);
+      for (const [k, v] of Object.entries(a.context)) {
+        lines.push(`        ${k}: ${formatValue(v)}`);
+      }
+    }
+  }
+  return { output: lines.join('\n') + '\n', exitCode: 0 };
+}
+
+async function explain(_args: string[], _options: CommandOptions): Promise<CommandResult> {
+  const out = `\
+Health Monitor — Coordinator-session degradation alarms (QUA-1048)
+
+Polls the wiki-server /health endpoint every minute and the GitHub
+main-branch CI every five minutes. Two MVP signals:
+
+  ci-stale     Last green CI on main > 2h ago.
+               Threshold: --ci-stale-seconds (default 7200)
+
+  jobs-stuck   pendingJobs > 0 with oldestPendingJobAgeSeconds growing
+               for the trend window — likely DB / worker-loop issue.
+               Window:  --jobs-window-seconds      (default 900)
+               Growth:  --jobs-min-growth-seconds  (default 720)
+
+When a signal is breached, the daemon writes
+  ~/.cache/health-monitor/state/alert-<signal>
+which scripts/inject-health-status.sh reads on every coord turn and
+surfaces as a <system-reminder>. The alert file is removed when the
+signal recovers.
+
+Lifecycle is owned by launchd via com.qu.health-monitor.plist —
+install with scripts/launchd/health-monitor.sh (sibling of the
+pr-patrol installer).
+`;
+  return { output: out, exitCode: 0 };
+}
+
+function formatSince(iso: string): string {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return iso;
+  const ageS = Math.floor((Date.now() - ts) / 1000);
+  if (ageS < 60) return `${ageS}s ago`;
+  if (ageS < 3600) return `${Math.floor(ageS / 60)}m ago`;
+  return `${(ageS / 3600).toFixed(1)}h ago`;
+}
+
+function formatValue(v: unknown): string {
+  if (v === null || v === undefined) return String(v);
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+    return String(v);
+  }
+  return JSON.stringify(v);
+}
+
+export const commands = {
+  run,
+  once,
+  status,
+  explain,
+  default: status,
+};
+
+export function getHelp(): string {
+  return `\
+Health Monitor — Coordinator-session degradation daemon (QUA-1048)
+
+Commands:
+  run                              Run the daemon continuously
+  once                             Single check cycle then exit
+  status (default)                 Show daemon state + active alerts
+  explain                          Long-form explanation
+
+Options for run/once:
+  --interval=N                     Seconds between /health polls (default 60)
+  --ci-every=N                     Check CI every N cycles (default 5)
+  --ci-stale-seconds=N             ci-stale threshold (default 7200)
+  --jobs-window-seconds=N          jobs-stuck trend window (default 900)
+  --jobs-min-growth-seconds=N      jobs-stuck minimum age growth (default 720)
+
+Status options:
+  --json                           Machine-readable output
+
+Examples:
+  crux sys health-monitor run                     Continuous daemon
+  crux sys health-monitor once                    One cycle then exit
+  crux sys health-monitor status                  Current state
+  crux sys health-monitor status --json           Machine-readable
+  crux sys health-monitor explain                 How it works
+`;
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -78,6 +78,7 @@ import * as agentSessionEventsCommands from './commands/agent-session-events.ts'
 import * as auditsCommands from './commands/audits.ts';
 import * as releaseCommands from './commands/release.ts';
 import * as prPatrolCommands from './commands/pr-patrol.ts';
+import * as healthMonitorCommands from './commands/health-monitor.ts';
 import * as factbaseCommands from './commands/factbase.ts';
 import * as factbaseImport990Commands from './commands/factbase-import-990.ts';
 import * as footnotesCommands from './commands/footnotes.ts';
@@ -186,6 +187,7 @@ const domains = {
   audits: auditsCommands,
   release: releaseCommands,
   'pr-patrol': prPatrolCommands,
+  'health-monitor': healthMonitorCommands,
   factbase: factbaseCommands,
   kb: factbaseCommands, // deprecated alias
   'import-990': factbaseImport990Commands,

--- a/crux/health-monitor/daemon.ts
+++ b/crux/health-monitor/daemon.ts
@@ -51,7 +51,17 @@ export const DEFAULT_CONFIG: DaemonConfig = {
 };
 
 export function buildConfig(overrides: Partial<DaemonConfig> = {}): DaemonConfig {
-  return { ...DEFAULT_CONFIG, ...overrides };
+  const merged = { ...DEFAULT_CONFIG, ...overrides };
+  // Clamp pacing to safe minimums. The CLI parser refuses 0/negative, but a
+  // programmatic caller (or a future config-file path) could pass them.
+  // Without this clamp, ciCheckEveryNCycles=0 makes `cycleNum % 0` = NaN
+  // (always false after cycle 0), silently disabling CI checks forever.
+  if (merged.pollIntervalSeconds < 1) merged.pollIntervalSeconds = 1;
+  if (merged.ciCheckEveryNCycles < 1) merged.ciCheckEveryNCycles = 1;
+  if (merged.jobsTrendWindowSeconds < 60) merged.jobsTrendWindowSeconds = 60;
+  if (merged.jobsTrendMinGrowthSeconds < 0) merged.jobsTrendMinGrowthSeconds = 0;
+  if (merged.ciStaleThresholdSeconds < 60) merged.ciStaleThresholdSeconds = 60;
+  return merged;
 }
 
 interface HealthEndpointResponse {
@@ -104,12 +114,23 @@ export async function fetchHealthSnapshot(nowMs = Date.now()): Promise<HealthSna
       };
     }
     const data = (await res.json()) as HealthEndpointResponse;
+    // `serverHealthy` means "we received parseable queue-state data" — NOT
+    // strictly "the server reports status:healthy". A server returning
+    // `{status:"degraded"}` with a numeric pendingJobs still gives us valid
+    // queue information; we want jobs-stuck evaluation to consider those
+    // samples. The reviewer caught this in the QUA-1048 review pass: the
+    // earlier strict `status === 'healthy'` check let a degraded-but-
+    // responsive server silently discard its own queue data.
+    const hasQueueData =
+      typeof data.pendingJobs === 'number' &&
+      (data.oldestPendingJobAgeSeconds === null ||
+        typeof data.oldestPendingJobAgeSeconds === 'number');
     return {
       ts,
       pendingJobs: data.pendingJobs ?? null,
       oldestPendingJobAgeSeconds: data.oldestPendingJobAgeSeconds ?? null,
       uptime: data.uptime ?? null,
-      serverHealthy: data.status === 'healthy',
+      serverHealthy: hasQueueData,
     };
   } catch (err) {
     return {
@@ -132,19 +153,33 @@ export async function fetchCiSnapshot(nowMs = Date.now()): Promise<CiSnapshot> {
     );
     const runs = resp.workflow_runs ?? [];
     if (runs.length === 0) {
-      return { ts, lastGreenAt: null, lastConclusion: null };
+      return {
+        ts,
+        lastGreenAt: null,
+        lastConclusion: null,
+        completedRunsSampled: 0,
+        oldestSampledAt: null,
+      };
     }
     const lastGreen = runs.find((r) => r.conclusion === 'success');
+    // GitHub returns workflow_runs newest-first. The oldest sampled run is
+    // the last in the list — we use it as a lower-bound for the ci-stale
+    // synthetic age when no green is found in the page.
+    const oldest = runs[runs.length - 1];
     return {
       ts,
       lastGreenAt: lastGreen?.created_at ?? null,
       lastConclusion: runs[0].conclusion,
+      completedRunsSampled: runs.length,
+      oldestSampledAt: oldest.created_at ?? null,
     };
   } catch (err) {
     return {
       ts,
       lastGreenAt: null,
       lastConclusion: null,
+      completedRunsSampled: 0,
+      oldestSampledAt: null,
       fetchError: err instanceof Error ? err.message : String(err),
     };
   }

--- a/crux/health-monitor/daemon.ts
+++ b/crux/health-monitor/daemon.ts
@@ -1,0 +1,305 @@
+/**
+ * Health Monitor — Daemon main loop.
+ *
+ * Polls the wiki-server /health endpoint every `pollIntervalSeconds`,
+ * polls GitHub workflow_runs every `ciCheckEveryNCycles` cycles, and
+ * evaluates the two MVP signals from QUA-1048:
+ *   - ci-stale: last green main CI > threshold
+ *   - jobs-stuck: pendingJobs queue not draining for trend window
+ *
+ * State is written to ~/.cache/health-monitor/. The companion
+ * scripts/inject-health-status.sh hook reads alert-* files and
+ * surfaces them as <system-reminder> blocks on coord turns.
+ */
+
+import { existsSync } from 'fs';
+import { githubApi, REPO } from '../lib/github.ts';
+import { getApiKey, getServerUrl } from '../lib/wiki-server/client.ts';
+import {
+  appendHistory,
+  clearAlert,
+  clearPidFile,
+  defaultCacheDir,
+  ensureDirs,
+  pidIsRunning,
+  readAlert,
+  readPidFile,
+  readRecentHistory,
+  trimHistory,
+  writeAlert,
+  writePidFile,
+} from './state.ts';
+import { evaluateCiStale, evaluateJobsStuck } from './signals.ts';
+import type {
+  Alert,
+  CiSnapshot,
+  DaemonConfig,
+  HealthSnapshot,
+  SignalId,
+} from './types.ts';
+
+const FETCH_TIMEOUT_MS = 15_000;
+const CI_WORKFLOW = 'ci.yml';
+
+export const DEFAULT_CONFIG: DaemonConfig = {
+  pollIntervalSeconds: 60,
+  ciCheckEveryNCycles: 5,
+  ciStaleThresholdSeconds: 2 * 60 * 60,
+  jobsTrendWindowSeconds: 15 * 60,
+  jobsTrendMinGrowthSeconds: 12 * 60,
+  cacheDir: defaultCacheDir(),
+};
+
+export function buildConfig(overrides: Partial<DaemonConfig> = {}): DaemonConfig {
+  return { ...DEFAULT_CONFIG, ...overrides };
+}
+
+interface HealthEndpointResponse {
+  status?: string;
+  pendingJobs?: number | null;
+  oldestPendingJobAgeSeconds?: number | null;
+  uptime?: number | null;
+}
+
+interface WorkflowRun {
+  conclusion: string | null;
+  created_at: string;
+}
+
+interface WorkflowRunsResponse {
+  workflow_runs?: WorkflowRun[];
+}
+
+/** Always returns a snapshot — wraps fetch errors into the snapshot itself. */
+export async function fetchHealthSnapshot(nowMs = Date.now()): Promise<HealthSnapshot> {
+  const ts = new Date(nowMs).toISOString();
+  const url = getServerUrl();
+  if (!url) {
+    return {
+      ts,
+      pendingJobs: null,
+      oldestPendingJobAgeSeconds: null,
+      uptime: null,
+      serverHealthy: false,
+      fetchError: 'wiki-server URL not set',
+    };
+  }
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const apiKey = getApiKey();
+  if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+
+  try {
+    const res = await fetch(`${url}/health`, {
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      return {
+        ts,
+        pendingJobs: null,
+        oldestPendingJobAgeSeconds: null,
+        uptime: null,
+        serverHealthy: false,
+        fetchError: `HTTP ${res.status}`,
+      };
+    }
+    const data = (await res.json()) as HealthEndpointResponse;
+    return {
+      ts,
+      pendingJobs: data.pendingJobs ?? null,
+      oldestPendingJobAgeSeconds: data.oldestPendingJobAgeSeconds ?? null,
+      uptime: data.uptime ?? null,
+      serverHealthy: data.status === 'healthy',
+    };
+  } catch (err) {
+    return {
+      ts,
+      pendingJobs: null,
+      oldestPendingJobAgeSeconds: null,
+      uptime: null,
+      serverHealthy: false,
+      fetchError: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/** Always returns a snapshot — wraps fetch errors into the snapshot. */
+export async function fetchCiSnapshot(nowMs = Date.now()): Promise<CiSnapshot> {
+  const ts = new Date(nowMs).toISOString();
+  try {
+    const resp = await githubApi<WorkflowRunsResponse>(
+      `/repos/${REPO}/actions/workflows/${CI_WORKFLOW}/runs?branch=main&status=completed&per_page=10`,
+    );
+    const runs = resp.workflow_runs ?? [];
+    if (runs.length === 0) {
+      return { ts, lastGreenAt: null, lastConclusion: null };
+    }
+    const lastGreen = runs.find((r) => r.conclusion === 'success');
+    return {
+      ts,
+      lastGreenAt: lastGreen?.created_at ?? null,
+      lastConclusion: runs[0].conclusion,
+    };
+  } catch (err) {
+    return {
+      ts,
+      lastGreenAt: null,
+      lastConclusion: null,
+      fetchError: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export interface CycleEvaluation {
+  signal: SignalId;
+  reason: string;
+  alerting: boolean;
+}
+
+export interface CycleResult {
+  health: HealthSnapshot;
+  ci: CiSnapshot | null;
+  evaluations: CycleEvaluation[];
+}
+
+/**
+ * Run a single check cycle: fetch /health, optionally fetch CI, evaluate
+ * signals, and update alert files. Returns a summary for logging.
+ *
+ * `cycleNum` controls CI rate-limiting — CI is only fetched on cycle 0
+ * and every Nth cycle thereafter.
+ */
+export async function runCycle(
+  config: DaemonConfig,
+  cycleNum: number,
+  nowMs = Date.now(),
+): Promise<CycleResult> {
+  ensureDirs(config.cacheDir);
+
+  const health = await fetchHealthSnapshot(nowMs);
+  appendHistory(config.cacheDir, health);
+
+  const shouldFetchCi = cycleNum === 0 || cycleNum % config.ciCheckEveryNCycles === 0;
+  const ci = shouldFetchCi ? await fetchCiSnapshot(nowMs) : null;
+
+  const evaluations: CycleEvaluation[] = [];
+
+  if (ci) {
+    const ev = evaluateCiStale(ci, config, nowMs);
+    evaluations.push({ signal: ev.signal, reason: ev.reason, alerting: !!ev.alert });
+    if (ev.alert) {
+      const merged = mergePreservingSince(config.cacheDir, ev.alert);
+      writeAlert(config.cacheDir, merged);
+    } else if (!ci.fetchError) {
+      // Only clear when the fetch actually succeeded — a transient API
+      // outage shouldn't drop an active alert.
+      clearAlert(config.cacheDir, ev.signal);
+    }
+  }
+
+  // jobs-stuck always evaluates against the most recent history slice
+  const recent = readRecentHistory(config.cacheDir, config.jobsTrendWindowSeconds, nowMs);
+  const jobsEv = evaluateJobsStuck(recent, config);
+  evaluations.push({ signal: jobsEv.signal, reason: jobsEv.reason, alerting: !!jobsEv.alert });
+  if (jobsEv.alert) {
+    const merged = mergePreservingSince(config.cacheDir, jobsEv.alert);
+    writeAlert(config.cacheDir, merged);
+  } else if (health.serverHealthy) {
+    // Same logic as ci-stale: only clear when we actually saw the server.
+    clearAlert(config.cacheDir, jobsEv.signal);
+  }
+
+  // Bound disk usage — keep ~2x trend window of history
+  trimHistory(config.cacheDir, config.jobsTrendWindowSeconds * 2, nowMs);
+
+  return { health, ci, evaluations };
+}
+
+function mergePreservingSince(cacheDir: string, fresh: Alert): Alert {
+  const existing = readAlert(cacheDir, fresh.signal);
+  if (!existing) return fresh;
+  return { ...fresh, since: existing.since };
+}
+
+/** Run the daemon loop. Sets a singleton lock and respects SIGTERM/SIGINT. */
+export async function runDaemon(config: DaemonConfig = DEFAULT_CONFIG): Promise<void> {
+  ensureDirs(config.cacheDir);
+
+  const existing = readPidFile(config.cacheDir);
+  if (existing && existing !== process.pid && pidIsRunning(existing)) {
+    console.error(`[health-monitor] another daemon is running (pid ${existing}); exiting`);
+    return;
+  }
+  writePidFile(config.cacheDir, process.pid);
+
+  const cleanup = () => {
+    const cur = readPidFile(config.cacheDir);
+    if (cur === process.pid) clearPidFile(config.cacheDir);
+  };
+  const onSig = () => {
+    cleanup();
+    process.exit(0);
+  };
+  process.on('SIGTERM', onSig);
+  process.on('SIGINT', onSig);
+  process.on('exit', cleanup);
+
+  console.error(
+    `[health-monitor] starting (pid ${process.pid}, cache ${config.cacheDir})`,
+  );
+  console.error(
+    `[health-monitor] poll=${config.pollIntervalSeconds}s ci-every=${config.ciCheckEveryNCycles} ci-stale=${config.ciStaleThresholdSeconds}s jobs-window=${config.jobsTrendWindowSeconds}s`,
+  );
+
+  let cycleNum = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      const result = await runCycle(config, cycleNum);
+      const tag = `cycle=${cycleNum}`;
+      const evs = result.evaluations
+        .map((e) => `${e.signal}=${e.alerting ? 'ALERT' : 'ok'}`)
+        .join(' ');
+      console.error(`[health-monitor] ${tag} ${evs}`);
+      for (const e of result.evaluations) {
+        console.error(`[health-monitor]   ${e.signal}: ${e.reason}`);
+      }
+    } catch (err) {
+      console.error(
+        `[health-monitor] cycle error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (config.once) break;
+    cycleNum++;
+    await sleep(config.pollIntervalSeconds * 1000);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export interface DaemonStatus {
+  pid: number | null;
+  running: boolean;
+  alerts: Alert[];
+  recentSampleCount: number;
+  cacheDir: string;
+}
+
+export function getDaemonStatus(
+  cacheDir: string = defaultCacheDir(),
+  nowMs = Date.now(),
+): DaemonStatus {
+  const pid = readPidFile(cacheDir);
+  const running = pid !== null && pidIsRunning(pid);
+  const alerts: Alert[] = [];
+  for (const sig of ['ci-stale', 'jobs-stuck'] as SignalId[]) {
+    const a = readAlert(cacheDir, sig);
+    if (a) alerts.push(a);
+  }
+  const recentSampleCount = existsSync(cacheDir)
+    ? readRecentHistory(cacheDir, 30 * 60, nowMs).length
+    : 0;
+  return { pid, running, alerts, recentSampleCount, cacheDir };
+}

--- a/crux/health-monitor/index.ts
+++ b/crux/health-monitor/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Health Monitor — re-exports for the command handler & tests.
+ */
+
+export {
+  buildConfig,
+  fetchCiSnapshot,
+  fetchHealthSnapshot,
+  getDaemonStatus,
+  runCycle,
+  runDaemon,
+  DEFAULT_CONFIG,
+} from './daemon.ts';
+export { evaluateCiStale, evaluateJobsStuck } from './signals.ts';
+export type {
+  Alert,
+  CiSnapshot,
+  DaemonConfig,
+  HealthSnapshot,
+  SignalId,
+} from './types.ts';

--- a/crux/health-monitor/signals.test.ts
+++ b/crux/health-monitor/signals.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Health Monitor — Signal evaluation tests.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { evaluateCiStale, evaluateJobsStuck } from './signals.ts';
+import type { CiSnapshot, HealthSnapshot } from './types.ts';
+
+const CI_THRESHOLD = 2 * 60 * 60; // 2h
+const TREND_WINDOW = 15 * 60;     // 15min
+const MIN_GROWTH = 12 * 60;       // 12min
+
+const ciConfig = { ciStaleThresholdSeconds: CI_THRESHOLD };
+const jobsConfig = {
+  jobsTrendWindowSeconds: TREND_WINDOW,
+  jobsTrendMinGrowthSeconds: MIN_GROWTH,
+};
+
+const NOW = new Date('2026-05-02T12:00:00Z').getTime();
+
+function isoMinutesAgo(min: number): string {
+  return new Date(NOW - min * 60_000).toISOString();
+}
+
+function snap(opts: {
+  minutesAgo: number;
+  pendingJobs: number | null;
+  ageSeconds: number | null;
+  serverHealthy?: boolean;
+  fetchError?: string;
+}): HealthSnapshot {
+  return {
+    ts: isoMinutesAgo(opts.minutesAgo),
+    pendingJobs: opts.pendingJobs,
+    oldestPendingJobAgeSeconds: opts.ageSeconds,
+    uptime: 1000,
+    serverHealthy: opts.serverHealthy ?? true,
+    fetchError: opts.fetchError,
+  };
+}
+
+describe('evaluateCiStale', () => {
+  it('clears the alert when last green is recent', () => {
+    const ci: CiSnapshot = {
+      ts: new Date(NOW).toISOString(),
+      lastGreenAt: isoMinutesAgo(30),     // 30 min ago
+      lastConclusion: 'success',
+    };
+    const res = evaluateCiStale(ci, ciConfig, NOW);
+    expect(res.alert).toBeNull();
+    expect(res.reason).toMatch(/under/);
+  });
+
+  it('alerts when last green is older than threshold', () => {
+    const ci: CiSnapshot = {
+      ts: new Date(NOW).toISOString(),
+      lastGreenAt: isoMinutesAgo(180),    // 3h ago, threshold is 2h
+      lastConclusion: 'failure',
+    };
+    const res = evaluateCiStale(ci, ciConfig, NOW);
+    expect(res.alert).not.toBeNull();
+    expect(res.alert!.signal).toBe('ci-stale');
+    expect(res.alert!.context).toMatchObject({
+      lastConclusion: 'failure',
+      thresholdSeconds: CI_THRESHOLD,
+    });
+    expect(res.alert!.context.ageSeconds).toBe(180 * 60);
+  });
+
+  it('exact threshold counts as stale (>= threshold)', () => {
+    const ci: CiSnapshot = {
+      ts: new Date(NOW).toISOString(),
+      lastGreenAt: isoMinutesAgo(120),    // exactly 2h
+      lastConclusion: 'success',
+    };
+    const res = evaluateCiStale(ci, ciConfig, NOW);
+    expect(res.alert).not.toBeNull();
+  });
+
+  it('does not alert when no green is found (insufficient data)', () => {
+    const ci: CiSnapshot = {
+      ts: new Date(NOW).toISOString(),
+      lastGreenAt: null,
+      lastConclusion: 'failure',
+    };
+    const res = evaluateCiStale(ci, ciConfig, NOW);
+    expect(res.alert).toBeNull();
+    expect(res.reason).toMatch(/no green/);
+  });
+
+  it('does not alert when fetch failed (transient API outage)', () => {
+    const ci: CiSnapshot = {
+      ts: new Date(NOW).toISOString(),
+      lastGreenAt: null,
+      lastConclusion: null,
+      fetchError: 'rate limit',
+    };
+    const res = evaluateCiStale(ci, ciConfig, NOW);
+    expect(res.alert).toBeNull();
+    expect(res.reason).toMatch(/ci-fetch-error/);
+  });
+
+  it('does not crash on unparseable timestamps', () => {
+    const ci: CiSnapshot = {
+      ts: new Date(NOW).toISOString(),
+      lastGreenAt: 'not-a-date',
+      lastConclusion: 'success',
+    };
+    const res = evaluateCiStale(ci, ciConfig, NOW);
+    expect(res.alert).toBeNull();
+    expect(res.reason).toMatch(/unparseable/);
+  });
+});
+
+describe('evaluateJobsStuck', () => {
+  it('returns null when history is empty', () => {
+    const res = evaluateJobsStuck([], jobsConfig);
+    expect(res.alert).toBeNull();
+  });
+
+  it('returns null when sample span is shorter than 90% of window', () => {
+    // 10 minutes of samples, but window is 15
+    const history = [
+      snap({ minutesAgo: 10, pendingJobs: 5, ageSeconds: 700 }),
+      snap({ minutesAgo: 0, pendingJobs: 5, ageSeconds: 1300 }),
+    ];
+    const res = evaluateJobsStuck(history, jobsConfig);
+    expect(res.alert).toBeNull();
+    expect(res.reason).toMatch(/only/);
+  });
+
+  it('alerts when pendingJobs > 0 throughout window and age grew enough', () => {
+    // 16 min span, age went from 100s to 1100s (grew by ~17min) — clear stuck
+    const history = [
+      snap({ minutesAgo: 16, pendingJobs: 12, ageSeconds: 100 }),
+      snap({ minutesAgo: 12, pendingJobs: 12, ageSeconds: 340 }),
+      snap({ minutesAgo: 8, pendingJobs: 12, ageSeconds: 580 }),
+      snap({ minutesAgo: 4, pendingJobs: 12, ageSeconds: 820 }),
+      snap({ minutesAgo: 0, pendingJobs: 12, ageSeconds: 1100 }),
+    ];
+    const res = evaluateJobsStuck(history, jobsConfig);
+    expect(res.alert).not.toBeNull();
+    expect(res.alert!.signal).toBe('jobs-stuck');
+    expect(res.alert!.context).toMatchObject({
+      windowStartAge: 100,
+      windowEndAge: 1100,
+      growthSeconds: 1000,
+      pendingJobsLatest: 12,
+      sampleCount: 5,
+    });
+  });
+
+  it('does not alert when queue drained mid-window', () => {
+    const history = [
+      snap({ minutesAgo: 16, pendingJobs: 12, ageSeconds: 100 }),
+      snap({ minutesAgo: 8, pendingJobs: 0, ageSeconds: 0 }),  // drained!
+      snap({ minutesAgo: 0, pendingJobs: 12, ageSeconds: 800 }),
+    ];
+    const res = evaluateJobsStuck(history, jobsConfig);
+    expect(res.alert).toBeNull();
+    expect(res.reason).toMatch(/drained/);
+  });
+
+  it('does not alert when growth is below minimum', () => {
+    // Age grew only 100s over the window — well under 720s threshold
+    const history = [
+      snap({ minutesAgo: 16, pendingJobs: 5, ageSeconds: 1000 }),
+      snap({ minutesAgo: 0, pendingJobs: 5, ageSeconds: 1100 }),
+    ];
+    const res = evaluateJobsStuck(history, jobsConfig);
+    expect(res.alert).toBeNull();
+    expect(res.reason).toMatch(/grew only/);
+  });
+
+  it('does not alert when oldest age is shorter than the window (fresh slow job)', () => {
+    // Age grew from 0 to 800s over 16 minutes — looks like a fresh job
+    // that's been running 800s, not a queue stuck for 15+ minutes
+    const history = [
+      snap({ minutesAgo: 16, pendingJobs: 5, ageSeconds: 0 }),
+      snap({ minutesAgo: 0, pendingJobs: 5, ageSeconds: 800 }),
+    ];
+    const res = evaluateJobsStuck(history, jobsConfig);
+    expect(res.alert).toBeNull();
+    expect(res.reason).toMatch(/shorter than window/);
+  });
+
+  it('ignores samples with fetchError or unhealthy server', () => {
+    const history = [
+      snap({ minutesAgo: 20, pendingJobs: null, ageSeconds: null, serverHealthy: false, fetchError: 'down' }),
+      snap({ minutesAgo: 16, pendingJobs: 12, ageSeconds: 100 }),
+      snap({ minutesAgo: 8, pendingJobs: null, ageSeconds: null, serverHealthy: false, fetchError: 'timeout' }),
+      snap({ minutesAgo: 0, pendingJobs: 12, ageSeconds: 1100 }),
+    ];
+    // Two usable samples spanning 16min — should still alert
+    const res = evaluateJobsStuck(history, jobsConfig);
+    expect(res.alert).not.toBeNull();
+    expect(res.alert!.context.sampleCount).toBe(2);
+  });
+
+  it('uses the OLDEST snapshot timestamp as `since` (preserves first-detected time)', () => {
+    const history = [
+      snap({ minutesAgo: 20, pendingJobs: 10, ageSeconds: 500 }),
+      snap({ minutesAgo: 0, pendingJobs: 10, ageSeconds: 1700 }),
+    ];
+    const res = evaluateJobsStuck(history, jobsConfig);
+    expect(res.alert).not.toBeNull();
+    expect(res.alert!.since).toBe(history[0].ts);
+    expect(res.alert!.detectedAt).toBe(history[1].ts);
+  });
+
+  it('handles unsorted history correctly', () => {
+    const history = [
+      snap({ minutesAgo: 0, pendingJobs: 12, ageSeconds: 1100 }),
+      snap({ minutesAgo: 16, pendingJobs: 12, ageSeconds: 100 }),
+      snap({ minutesAgo: 8, pendingJobs: 12, ageSeconds: 580 }),
+    ];
+    const res = evaluateJobsStuck(history, jobsConfig);
+    expect(res.alert).not.toBeNull();
+    expect(res.alert!.context.windowStartAge).toBe(100);
+    expect(res.alert!.context.windowEndAge).toBe(1100);
+  });
+});

--- a/crux/health-monitor/signals.test.ts
+++ b/crux/health-monitor/signals.test.ts
@@ -39,24 +39,35 @@ function snap(opts: {
   };
 }
 
+function ciSnap(opts: Partial<CiSnapshot> & { ts?: string } = {}): CiSnapshot {
+  return {
+    ts: opts.ts ?? new Date(NOW).toISOString(),
+    lastGreenAt: opts.lastGreenAt ?? null,
+    lastConclusion: opts.lastConclusion ?? null,
+    completedRunsSampled: opts.completedRunsSampled ?? 0,
+    oldestSampledAt: opts.oldestSampledAt ?? null,
+    fetchError: opts.fetchError,
+  };
+}
+
 describe('evaluateCiStale', () => {
   it('clears the alert when last green is recent', () => {
-    const ci: CiSnapshot = {
-      ts: new Date(NOW).toISOString(),
-      lastGreenAt: isoMinutesAgo(30),     // 30 min ago
+    const ci = ciSnap({
+      lastGreenAt: isoMinutesAgo(30),
       lastConclusion: 'success',
-    };
+      completedRunsSampled: 5,
+    });
     const res = evaluateCiStale(ci, ciConfig, NOW);
     expect(res.alert).toBeNull();
     expect(res.reason).toMatch(/under/);
   });
 
   it('alerts when last green is older than threshold', () => {
-    const ci: CiSnapshot = {
-      ts: new Date(NOW).toISOString(),
-      lastGreenAt: isoMinutesAgo(180),    // 3h ago, threshold is 2h
+    const ci = ciSnap({
+      lastGreenAt: isoMinutesAgo(180),
       lastConclusion: 'failure',
-    };
+      completedRunsSampled: 5,
+    });
     const res = evaluateCiStale(ci, ciConfig, NOW);
     expect(res.alert).not.toBeNull();
     expect(res.alert!.signal).toBe('ci-stale');
@@ -68,44 +79,71 @@ describe('evaluateCiStale', () => {
   });
 
   it('exact threshold counts as stale (>= threshold)', () => {
-    const ci: CiSnapshot = {
-      ts: new Date(NOW).toISOString(),
-      lastGreenAt: isoMinutesAgo(120),    // exactly 2h
+    const ci = ciSnap({
+      lastGreenAt: isoMinutesAgo(120),
       lastConclusion: 'success',
-    };
+      completedRunsSampled: 5,
+    });
     const res = evaluateCiStale(ci, ciConfig, NOW);
     expect(res.alert).not.toBeNull();
   });
 
-  it('does not alert when no green is found (insufficient data)', () => {
-    const ci: CiSnapshot = {
-      ts: new Date(NOW).toISOString(),
+  it('alerts when sampled window has runs but none are green (QUA-1048 review fix)', () => {
+    const ci = ciSnap({
       lastGreenAt: null,
       lastConclusion: 'failure',
-    };
+      completedRunsSampled: 10,
+      oldestSampledAt: isoMinutesAgo(300),  // 5h old → ≥ threshold
+    });
+    const res = evaluateCiStale(ci, ciConfig, NOW);
+    expect(res.alert).not.toBeNull();
+    expect(res.alert!.context).toMatchObject({
+      lastGreenAt: null,
+      completedRunsSampled: 10,
+      syntheticAge: true,
+    });
+    expect(res.alert!.context.ageSeconds).toBe(300 * 60);
+    expect(res.reason).toMatch(/no green in last 10/);
+  });
+
+  it('uses the threshold as a lower bound when oldest sampled run is fresher than threshold', () => {
+    const ci = ciSnap({
+      lastGreenAt: null,
+      lastConclusion: 'failure',
+      completedRunsSampled: 10,
+      oldestSampledAt: isoMinutesAgo(30),   // only 30 min old
+    });
+    const res = evaluateCiStale(ci, ciConfig, NOW);
+    expect(res.alert).not.toBeNull();
+    expect(res.alert!.context.ageSeconds).toBe(CI_THRESHOLD);
+  });
+
+  it('does NOT alert when zero completed runs sampled (quiet repo)', () => {
+    const ci = ciSnap({
+      lastGreenAt: null,
+      lastConclusion: null,
+      completedRunsSampled: 0,
+    });
     const res = evaluateCiStale(ci, ciConfig, NOW);
     expect(res.alert).toBeNull();
-    expect(res.reason).toMatch(/no green/);
+    expect(res.reason).toMatch(/no completed runs/);
   });
 
   it('does not alert when fetch failed (transient API outage)', () => {
-    const ci: CiSnapshot = {
-      ts: new Date(NOW).toISOString(),
-      lastGreenAt: null,
-      lastConclusion: null,
+    const ci = ciSnap({
       fetchError: 'rate limit',
-    };
+    });
     const res = evaluateCiStale(ci, ciConfig, NOW);
     expect(res.alert).toBeNull();
     expect(res.reason).toMatch(/ci-fetch-error/);
   });
 
   it('does not crash on unparseable timestamps', () => {
-    const ci: CiSnapshot = {
-      ts: new Date(NOW).toISOString(),
+    const ci = ciSnap({
       lastGreenAt: 'not-a-date',
       lastConclusion: 'success',
-    };
+      completedRunsSampled: 5,
+    });
     const res = evaluateCiStale(ci, ciConfig, NOW);
     expect(res.alert).toBeNull();
     expect(res.reason).toMatch(/unparseable/);

--- a/crux/health-monitor/signals.ts
+++ b/crux/health-monitor/signals.ts
@@ -24,12 +24,54 @@ export function evaluateCiStale(
   nowMs = Date.now(),
 ): SignalEvaluation {
   const signal: SignalId = 'ci-stale';
+  const tsIso = new Date(nowMs).toISOString();
 
   if (ci.fetchError) {
     return { signal, alert: null, reason: `ci-fetch-error: ${ci.fetchError}` };
   }
+
+  // No green found in the sampled window. There are two sub-cases:
+  //   (a) The repo is quiet — no completed runs at all on main. Don't alert.
+  //   (b) Every sampled run is a non-success conclusion (failure, cancelled,
+  //       timed out). The last green is older than the entire sample, so
+  //       it's at least as stale as the oldest sample timestamp — that's
+  //       exactly when ci-stale should fire loudest. Use the oldest sampled
+  //       run's age as a *lower bound* for the synthetic age.
+  // The earlier MVP missed (b): an all-failures sampled window returned
+  // alert: null, suppressing the alert exactly when CI was most broken.
+  // Caught in QUA-1048 review pass.
   if (!ci.lastGreenAt) {
-    return { signal, alert: null, reason: 'no green CI run found in recent history' };
+    if (ci.completedRunsSampled === 0) {
+      return { signal, alert: null, reason: 'no completed runs sampled' };
+    }
+    let syntheticAgeSeconds = config.ciStaleThresholdSeconds;
+    let oldestForReason: string | null = null;
+    if (ci.oldestSampledAt) {
+      const oldestMs = new Date(ci.oldestSampledAt).getTime();
+      if (!Number.isNaN(oldestMs)) {
+        const ageFromOldest = Math.floor((nowMs - oldestMs) / 1000);
+        if (ageFromOldest > syntheticAgeSeconds) syntheticAgeSeconds = ageFromOldest;
+        oldestForReason = ci.oldestSampledAt;
+      }
+    }
+    return {
+      signal,
+      alert: {
+        signal,
+        since: tsIso,
+        detectedAt: tsIso,
+        context: {
+          lastGreenAt: null,
+          lastConclusion: ci.lastConclusion,
+          ageSeconds: syntheticAgeSeconds,
+          thresholdSeconds: config.ciStaleThresholdSeconds,
+          completedRunsSampled: ci.completedRunsSampled,
+          oldestSampledAt: oldestForReason,
+          syntheticAge: true,
+        },
+      },
+      reason: `no green in last ${ci.completedRunsSampled} completed runs (≥ ${formatSeconds(syntheticAgeSeconds)} stale)`,
+    };
   }
 
   const lastGreenMs = new Date(ci.lastGreenAt).getTime();
@@ -46,7 +88,6 @@ export function evaluateCiStale(
     };
   }
 
-  const tsIso = new Date(nowMs).toISOString();
   return {
     signal,
     alert: {

--- a/crux/health-monitor/signals.ts
+++ b/crux/health-monitor/signals.ts
@@ -1,0 +1,167 @@
+/**
+ * Health Monitor — Pure signal evaluation.
+ *
+ * No I/O — both functions take already-fetched snapshots and return a
+ * decision. The daemon wraps these with cache + alert-file management.
+ *
+ * Signals:
+ *   ci-stale    Last green main CI is older than threshold.
+ *   jobs-stuck  pendingJobs > 0 with oldestPendingJobAgeSeconds growing
+ *               for the trend window.
+ */
+
+import type { Alert, CiSnapshot, DaemonConfig, HealthSnapshot, SignalId } from './types.ts';
+
+export interface SignalEvaluation {
+  signal: SignalId;
+  alert: Alert | null;       // non-null when the signal is currently breached
+  reason: string;            // one-line human-readable explanation
+}
+
+export function evaluateCiStale(
+  ci: CiSnapshot,
+  config: Pick<DaemonConfig, 'ciStaleThresholdSeconds'>,
+  nowMs = Date.now(),
+): SignalEvaluation {
+  const signal: SignalId = 'ci-stale';
+
+  if (ci.fetchError) {
+    return { signal, alert: null, reason: `ci-fetch-error: ${ci.fetchError}` };
+  }
+  if (!ci.lastGreenAt) {
+    return { signal, alert: null, reason: 'no green CI run found in recent history' };
+  }
+
+  const lastGreenMs = new Date(ci.lastGreenAt).getTime();
+  if (Number.isNaN(lastGreenMs)) {
+    return { signal, alert: null, reason: `unparseable lastGreenAt: ${ci.lastGreenAt}` };
+  }
+
+  const ageSeconds = Math.floor((nowMs - lastGreenMs) / 1000);
+  if (ageSeconds < config.ciStaleThresholdSeconds) {
+    return {
+      signal,
+      alert: null,
+      reason: `last green ${formatSeconds(ageSeconds)} ago (under ${formatSeconds(config.ciStaleThresholdSeconds)})`,
+    };
+  }
+
+  const tsIso = new Date(nowMs).toISOString();
+  return {
+    signal,
+    alert: {
+      signal,
+      since: tsIso,
+      detectedAt: tsIso,
+      context: {
+        lastGreenAt: ci.lastGreenAt,
+        lastConclusion: ci.lastConclusion,
+        ageSeconds,
+        thresholdSeconds: config.ciStaleThresholdSeconds,
+      },
+    },
+    reason: `last green ${formatSeconds(ageSeconds)} ago (over ${formatSeconds(config.ciStaleThresholdSeconds)})`,
+  };
+}
+
+/**
+ * Evaluate "queue is stuck" against a recent slice of HealthSnapshot history.
+ *
+ * The queue is "stuck" when:
+ *   - We have ≥ 90% of the trend window worth of samples
+ *   - Every sample in the window has pendingJobs > 0
+ *   - oldestPendingJobAgeSeconds grew end-to-end by ≥ minGrowthSeconds
+ *   - The newest oldestPendingJobAgeSeconds itself exceeds the trend window
+ *     (else we're observing a fresh slow job, not an actually-stuck queue)
+ *
+ * If `pendingJobs` ever drops to 0 the queue drained normally and we don't
+ * alert. If `oldestPendingJobAgeSeconds` declines, a worker picked something
+ * up — also no alert. Strict monotonicity is NOT required: small dips can
+ * happen when one job completes briefly between samples.
+ */
+export function evaluateJobsStuck(
+  history: HealthSnapshot[],
+  config: Pick<DaemonConfig, 'jobsTrendWindowSeconds' | 'jobsTrendMinGrowthSeconds'>,
+): SignalEvaluation {
+  const signal: SignalId = 'jobs-stuck';
+
+  const usable = history.filter(
+    (s) =>
+      s.serverHealthy &&
+      s.pendingJobs !== null &&
+      s.oldestPendingJobAgeSeconds !== null,
+  );
+
+  if (usable.length < 2) {
+    return {
+      signal,
+      alert: null,
+      reason: `insufficient samples (${usable.length}) for trend analysis`,
+    };
+  }
+
+  const sorted = [...usable].sort(
+    (a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime(),
+  );
+  const oldest = sorted[0];
+  const newest = sorted[sorted.length - 1];
+  const oldestMs = new Date(oldest.ts).getTime();
+  const newestMs = new Date(newest.ts).getTime();
+  const spanSeconds = (newestMs - oldestMs) / 1000;
+  const requiredSpan = config.jobsTrendWindowSeconds * 0.9;
+
+  if (spanSeconds < requiredSpan) {
+    return {
+      signal,
+      alert: null,
+      reason: `only ${formatSeconds(Math.floor(spanSeconds))} of samples (need ${formatSeconds(config.jobsTrendWindowSeconds)})`,
+    };
+  }
+
+  if (sorted.some((s) => (s.pendingJobs ?? 0) <= 0)) {
+    return { signal, alert: null, reason: 'queue drained at some point in window' };
+  }
+
+  const ageStart = oldest.oldestPendingJobAgeSeconds ?? 0;
+  const ageEnd = newest.oldestPendingJobAgeSeconds ?? 0;
+  const growthSeconds = ageEnd - ageStart;
+
+  if (growthSeconds < config.jobsTrendMinGrowthSeconds) {
+    return {
+      signal,
+      alert: null,
+      reason: `oldest age grew only ${growthSeconds}s in window (need ${config.jobsTrendMinGrowthSeconds}s)`,
+    };
+  }
+
+  if (ageEnd < config.jobsTrendWindowSeconds) {
+    return {
+      signal,
+      alert: null,
+      reason: `oldest job age (${ageEnd}s) shorter than window — possibly a fresh slow job`,
+    };
+  }
+
+  return {
+    signal,
+    alert: {
+      signal,
+      since: oldest.ts,
+      detectedAt: newest.ts,
+      context: {
+        windowStartAge: ageStart,
+        windowEndAge: ageEnd,
+        growthSeconds,
+        pendingJobsLatest: newest.pendingJobs,
+        sampleCount: sorted.length,
+      },
+    },
+    reason: `oldest age grew ${growthSeconds}s over ${formatSeconds(Math.floor(spanSeconds))}; ${newest.pendingJobs} jobs pending`,
+  };
+}
+
+function formatSeconds(s: number): string {
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  return `${(s / 3600).toFixed(1)}h`;
+}

--- a/crux/health-monitor/state.test.ts
+++ b/crux/health-monitor/state.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Health Monitor — State persistence tests.
+ *
+ * Uses a temp directory per test to avoid touching ~/.cache.
+ */
+
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  alertFilePath,
+  appendHistory,
+  clearAlert,
+  ensureDirs,
+  historyFilePath,
+  pidFilePath,
+  readAlert,
+  readPidFile,
+  readRecentHistory,
+  trimHistory,
+  writeAlert,
+  writePidFile,
+} from './state.ts';
+import type { Alert, HealthSnapshot } from './types.ts';
+
+let CACHE_DIR: string;
+
+beforeEach(() => {
+  CACHE_DIR = mkdtempSync(join(tmpdir(), 'health-monitor-test-'));
+});
+
+afterEach(() => {
+  rmSync(CACHE_DIR, { recursive: true, force: true });
+});
+
+const NOW = new Date('2026-05-02T12:00:00Z').getTime();
+
+function snap(opts: {
+  minutesAgo: number;
+  pendingJobs: number | null;
+  ageSeconds: number | null;
+  serverHealthy?: boolean;
+}): HealthSnapshot {
+  return {
+    ts: new Date(NOW - opts.minutesAgo * 60_000).toISOString(),
+    pendingJobs: opts.pendingJobs,
+    oldestPendingJobAgeSeconds: opts.ageSeconds,
+    uptime: 1000,
+    serverHealthy: opts.serverHealthy ?? true,
+  };
+}
+
+describe('alert files', () => {
+  it('writes and reads back an alert', () => {
+    const alert: Alert = {
+      signal: 'ci-stale',
+      since: '2026-05-02T10:00:00Z',
+      detectedAt: '2026-05-02T11:00:00Z',
+      context: { ageSeconds: 9000, lastConclusion: 'failure' },
+    };
+    writeAlert(CACHE_DIR, alert);
+    const read = readAlert(CACHE_DIR, 'ci-stale');
+    expect(read).toEqual(alert);
+  });
+
+  it('returns null for a non-existent alert', () => {
+    expect(readAlert(CACHE_DIR, 'jobs-stuck')).toBeNull();
+  });
+
+  it('clearAlert removes the file', () => {
+    writeAlert(CACHE_DIR, {
+      signal: 'jobs-stuck',
+      since: '2026-05-02T10:00:00Z',
+      detectedAt: '2026-05-02T11:00:00Z',
+      context: {},
+    });
+    expect(readAlert(CACHE_DIR, 'jobs-stuck')).not.toBeNull();
+    clearAlert(CACHE_DIR, 'jobs-stuck');
+    expect(readAlert(CACHE_DIR, 'jobs-stuck')).toBeNull();
+  });
+
+  it('clearAlert is a no-op when the file is absent', () => {
+    expect(() => clearAlert(CACHE_DIR, 'ci-stale')).not.toThrow();
+  });
+
+  it('returns null on corrupt JSON', () => {
+    ensureDirs(CACHE_DIR);
+    writeFileSync(alertFilePath(CACHE_DIR, 'ci-stale'), 'not-valid-json{');
+    expect(readAlert(CACHE_DIR, 'ci-stale')).toBeNull();
+  });
+});
+
+describe('history persistence', () => {
+  it('appends and reads back snapshots within window', () => {
+    const a = snap({ minutesAgo: 10, pendingJobs: 5, ageSeconds: 600 });
+    const b = snap({ minutesAgo: 5, pendingJobs: 5, ageSeconds: 900 });
+    appendHistory(CACHE_DIR, a);
+    appendHistory(CACHE_DIR, b);
+
+    const all = readRecentHistory(CACHE_DIR, 30 * 60, NOW);
+    expect(all).toHaveLength(2);
+    expect(all[0].oldestPendingJobAgeSeconds).toBe(600);
+    expect(all[1].oldestPendingJobAgeSeconds).toBe(900);
+  });
+
+  it('filters out snapshots older than window', () => {
+    appendHistory(CACHE_DIR, snap({ minutesAgo: 60, pendingJobs: 5, ageSeconds: 100 }));
+    appendHistory(CACHE_DIR, snap({ minutesAgo: 5, pendingJobs: 5, ageSeconds: 900 }));
+
+    const out = readRecentHistory(CACHE_DIR, 15 * 60, NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].oldestPendingJobAgeSeconds).toBe(900);
+  });
+
+  it('returns empty array when history file is absent', () => {
+    expect(readRecentHistory(CACHE_DIR, 60, NOW)).toEqual([]);
+  });
+
+  it('skips corrupt JSON lines', () => {
+    ensureDirs(CACHE_DIR);
+    const f = historyFilePath(CACHE_DIR);
+    const validRow = JSON.stringify(snap({ minutesAgo: 1, pendingJobs: 5, ageSeconds: 100 }));
+    writeFileSync(f, `corrupt-line\n${validRow}\n{also-bad`);
+    const out = readRecentHistory(CACHE_DIR, 30 * 60, NOW);
+    expect(out).toHaveLength(1);
+  });
+
+  it('trimHistory removes rows older than keep window', () => {
+    appendHistory(CACHE_DIR, snap({ minutesAgo: 60, pendingJobs: 5, ageSeconds: 100 }));
+    appendHistory(CACHE_DIR, snap({ minutesAgo: 30, pendingJobs: 5, ageSeconds: 200 }));
+    appendHistory(CACHE_DIR, snap({ minutesAgo: 5, pendingJobs: 5, ageSeconds: 900 }));
+
+    trimHistory(CACHE_DIR, 15 * 60, NOW);
+    const remaining = readFileSync(historyFilePath(CACHE_DIR), 'utf-8').trim().split('\n');
+    expect(remaining).toHaveLength(1);
+    expect(JSON.parse(remaining[0]).oldestPendingJobAgeSeconds).toBe(900);
+  });
+
+  it('trimHistory writes empty content when no rows are kept', () => {
+    appendHistory(CACHE_DIR, snap({ minutesAgo: 60, pendingJobs: 5, ageSeconds: 100 }));
+    trimHistory(CACHE_DIR, 60, NOW);     // keep last 60s — nothing should remain
+    const remaining = readFileSync(historyFilePath(CACHE_DIR), 'utf-8');
+    expect(remaining).toBe('');
+  });
+});
+
+describe('pid file', () => {
+  it('writes and reads pid', () => {
+    writePidFile(CACHE_DIR, 12345);
+    expect(readPidFile(CACHE_DIR)).toBe(12345);
+  });
+
+  it('returns null when pid file is absent', () => {
+    expect(readPidFile(CACHE_DIR)).toBeNull();
+  });
+
+  it('returns null when pid file is malformed', () => {
+    ensureDirs(CACHE_DIR);
+    writeFileSync(pidFilePath(CACHE_DIR), 'not-a-number');
+    expect(readPidFile(CACHE_DIR)).toBeNull();
+  });
+});

--- a/crux/health-monitor/state.test.ts
+++ b/crux/health-monitor/state.test.ts
@@ -145,6 +145,24 @@ describe('history persistence', () => {
   });
 });
 
+describe('clearAlert ENOENT-safety', () => {
+  it('is a no-op when called twice in a row', () => {
+    writeAlert(CACHE_DIR, {
+      signal: 'ci-stale',
+      since: '2026-05-02T10:00:00Z',
+      detectedAt: '2026-05-02T10:00:00Z',
+      context: {},
+    });
+    expect(() => {
+      // First call deletes; second call must not throw ENOENT.
+      // (Real-world: another process unlinks between our existsSync and unlink.)
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      clearAlert(CACHE_DIR, 'ci-stale');
+      clearAlert(CACHE_DIR, 'ci-stale');
+    }).not.toThrow();
+  });
+});
+
 describe('pid file', () => {
   it('writes and reads pid', () => {
     writePidFile(CACHE_DIR, 12345);

--- a/crux/health-monitor/state.ts
+++ b/crux/health-monitor/state.ts
@@ -1,0 +1,134 @@
+/**
+ * Health Monitor — File-based state management.
+ *
+ * Layout under cacheDir (default ~/.cache/health-monitor/):
+ *   daemon.pid               singleton lock — pid of the live daemon
+ *   run.log                  written by the supervisor (not by this module)
+ *   history.jsonl            append-only stream of HealthSnapshot rows
+ *   state/alert-<signal>     present iff the signal is currently alerting
+ *
+ * The injector hook (scripts/inject-health-status.sh) reads
+ * state/alert-* files and surfaces them as <system-reminder> blocks.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import type { Alert, HealthSnapshot, SignalId } from './types.ts';
+
+const HOME = process.env.HOME ?? '/tmp';
+
+export function defaultCacheDir(): string {
+  return join(HOME, '.cache', 'health-monitor');
+}
+
+export function ensureDirs(cacheDir: string): void {
+  mkdirSync(cacheDir, { recursive: true });
+  mkdirSync(join(cacheDir, 'state'), { recursive: true });
+}
+
+export function pidFilePath(cacheDir: string): string {
+  return join(cacheDir, 'daemon.pid');
+}
+
+export function historyFilePath(cacheDir: string): string {
+  return join(cacheDir, 'history.jsonl');
+}
+
+export function alertFilePath(cacheDir: string, signal: SignalId): string {
+  return join(cacheDir, 'state', `alert-${signal}`);
+}
+
+export function writeAlert(cacheDir: string, alert: Alert): void {
+  ensureDirs(cacheDir);
+  writeFileSync(alertFilePath(cacheDir, alert.signal), JSON.stringify(alert, null, 2));
+}
+
+export function clearAlert(cacheDir: string, signal: SignalId): void {
+  const f = alertFilePath(cacheDir, signal);
+  if (existsSync(f)) unlinkSync(f);
+}
+
+export function readAlert(cacheDir: string, signal: SignalId): Alert | null {
+  const f = alertFilePath(cacheDir, signal);
+  if (!existsSync(f)) return null;
+  try {
+    return JSON.parse(readFileSync(f, 'utf-8')) as Alert;
+  } catch {
+    return null;
+  }
+}
+
+export function appendHistory(cacheDir: string, snapshot: HealthSnapshot): void {
+  ensureDirs(cacheDir);
+  appendFileSync(historyFilePath(cacheDir), JSON.stringify(snapshot) + '\n');
+}
+
+/** Read history rows whose `ts` is within the given window of `nowMs`. */
+export function readRecentHistory(
+  cacheDir: string,
+  windowSeconds: number,
+  nowMs = Date.now(),
+): HealthSnapshot[] {
+  const f = historyFilePath(cacheDir);
+  if (!existsSync(f)) return [];
+  const cutoffMs = nowMs - windowSeconds * 1000;
+  const out: HealthSnapshot[] = [];
+  for (const line of readFileSync(f, 'utf-8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const snap = JSON.parse(line) as HealthSnapshot;
+      if (new Date(snap.ts).getTime() >= cutoffMs) out.push(snap);
+    } catch {
+      // Skip corrupt lines silently — the trim pass will remove them eventually.
+    }
+  }
+  return out;
+}
+
+/** Trim history older than `keepSeconds` to bound disk usage. */
+export function trimHistory(
+  cacheDir: string,
+  keepSeconds: number,
+  nowMs = Date.now(),
+): void {
+  const f = historyFilePath(cacheDir);
+  if (!existsSync(f)) return;
+  const cutoffMs = nowMs - keepSeconds * 1000;
+  const kept: string[] = [];
+  for (const line of readFileSync(f, 'utf-8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const snap = JSON.parse(line) as HealthSnapshot;
+      if (new Date(snap.ts).getTime() >= cutoffMs) kept.push(line);
+    } catch {
+      // drop corrupt
+    }
+  }
+  writeFileSync(f, kept.join('\n') + (kept.length > 0 ? '\n' : ''));
+}
+
+export function writePidFile(cacheDir: string, pid: number): void {
+  ensureDirs(cacheDir);
+  writeFileSync(pidFilePath(cacheDir), String(pid));
+}
+
+export function readPidFile(cacheDir: string): number | null {
+  const f = pidFilePath(cacheDir);
+  if (!existsSync(f)) return null;
+  const pid = parseInt(readFileSync(f, 'utf-8').trim(), 10);
+  return Number.isNaN(pid) ? null : pid;
+}
+
+export function clearPidFile(cacheDir: string): void {
+  const f = pidFilePath(cacheDir);
+  if (existsSync(f)) unlinkSync(f);
+}
+
+export function pidIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/crux/health-monitor/state.ts
+++ b/crux/health-monitor/state.ts
@@ -11,7 +11,7 @@
  * state/alert-* files and surfaces them as <system-reminder> blocks.
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import type { Alert, HealthSnapshot, SignalId } from './types.ts';
 
@@ -44,8 +44,15 @@ export function writeAlert(cacheDir: string, alert: Alert): void {
 }
 
 export function clearAlert(cacheDir: string, signal: SignalId): void {
+  // ENOENT-safe: a concurrent process may have just unlinked it. The
+  // existsSync→unlinkSync sequence is non-atomic; rely on the unlink itself
+  // and swallow ENOENT. Other errors (EPERM, EISDIR) propagate.
   const f = alertFilePath(cacheDir, signal);
-  if (existsSync(f)) unlinkSync(f);
+  try {
+    unlinkSync(f);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
 }
 
 export function readAlert(cacheDir: string, signal: SignalId): Alert | null {
@@ -85,7 +92,19 @@ export function readRecentHistory(
   return out;
 }
 
-/** Trim history older than `keepSeconds` to bound disk usage. */
+/**
+ * Trim history older than `keepSeconds` to bound disk usage.
+ *
+ * Crash-safe: writes to `<file>.tmp` then atomically renames over the
+ * original. A SIGKILL during the rewrite leaves either the original intact
+ * or the new file fully written — never a zero-byte file. (Caught in
+ * QUA-1048 review pass.)
+ *
+ * Concurrency caveat: if another process appends to the original file
+ * between our read and the rename, that append is lost. The `runDaemon`
+ * singleton makes the daemon→daemon case impossible; the daemon→`once`
+ * race is documented in the command help.
+ */
 export function trimHistory(
   cacheDir: string,
   keepSeconds: number,
@@ -104,7 +123,9 @@ export function trimHistory(
       // drop corrupt
     }
   }
-  writeFileSync(f, kept.join('\n') + (kept.length > 0 ? '\n' : ''));
+  const tmp = f + '.tmp';
+  writeFileSync(tmp, kept.join('\n') + (kept.length > 0 ? '\n' : ''));
+  renameSync(tmp, f);
 }
 
 export function writePidFile(cacheDir: string, pid: number): void {

--- a/crux/health-monitor/types.ts
+++ b/crux/health-monitor/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Health Monitor — Type definitions shared across the daemon.
+ *
+ * MVP scope per QUA-1048: two signals, no Linear posting yet.
+ */
+
+export interface HealthSnapshot {
+  ts: string;                          // ISO timestamp of the sample
+  pendingJobs: number | null;          // wiki-server /health.pendingJobs
+  oldestPendingJobAgeSeconds: number | null;
+  uptime: number | null;               // seconds since wiki-server start
+  serverHealthy: boolean;              // /health returned 200 with status:"healthy"
+  fetchError?: string;                 // populated when fetch failed
+}
+
+export interface CiSnapshot {
+  ts: string;                          // when the GitHub poll happened
+  lastGreenAt: string | null;          // ISO of most recent green main run, or null
+  lastConclusion: string | null;       // conclusion of the most recent completed run
+  fetchError?: string;
+}
+
+export type SignalId = 'ci-stale' | 'jobs-stuck';
+
+export interface Alert {
+  signal: SignalId;
+  since: string;                       // first detection (preserved across cycles)
+  detectedAt: string;                  // most recent confirmation
+  context: Record<string, unknown>;    // signal-specific debug context
+}
+
+export interface DaemonConfig {
+  pollIntervalSeconds: number;         // default 60
+  ciCheckEveryNCycles: number;         // default 5 (≈5 min at 60s cadence)
+  ciStaleThresholdSeconds: number;     // default 7200 (2h)
+  jobsTrendWindowSeconds: number;      // default 900 (15 min)
+  jobsTrendMinGrowthSeconds: number;   // default 720 (12 min — slack vs perfect 1:1)
+  cacheDir: string;                    // default ~/.cache/health-monitor
+  once?: boolean;                      // single cycle then exit
+}

--- a/crux/health-monitor/types.ts
+++ b/crux/health-monitor/types.ts
@@ -17,6 +17,15 @@ export interface CiSnapshot {
   ts: string;                          // when the GitHub poll happened
   lastGreenAt: string | null;          // ISO of most recent green main run, or null
   lastConclusion: string | null;       // conclusion of the most recent completed run
+  /** Total completed runs in the sampled page — needed to disambiguate
+   *  "no green found because no runs at all" from "no green found because
+   *  the entire sampled window is non-green failures" (the second is a
+   *  ci-stale alert; the first is just a quiet repo). */
+  completedRunsSampled: number;
+  /** ISO timestamp of the oldest completed run in the sampled page, or null
+   *  if no runs were sampled. Used to attribute a synthetic age when no
+   *  green run was found. */
+  oldestSampledAt: string | null;
   fetchError?: string;
 }
 

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -136,6 +136,7 @@ export const GROUPS: Record<string, GroupDef> = {
       'sessions',
       'edit-log',
       'health',
+      'health-monitor',
       'audits',
       'maintain',
       'wiki-server',

--- a/scripts/health-monitor-supervisor.sh
+++ b/scripts/health-monitor-supervisor.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# health-monitor-supervisor.sh
+#
+# Daemon loop launched by the com.qu.health-monitor launchd agent.
+# Runs `pnpm crux sys health-monitor run` continuously, restarting it
+# 30s after each exit so a crash, network blip, or `crux ... once`
+# is followed by automatic recovery.
+#
+# Why an inner loop *and* launchd KeepAlive: launchd respawns the
+# supervisor itself on crash, but a clean exit of `health-monitor run`
+# (e.g. EEXIST on daemon.pid because another monitor still holds the
+# lock) shouldn't cycle launchd — the inner sleep keeps diagnostic
+# output contiguous in run.log instead of fragmenting into launchd.err.
+#
+# Watch the live log:
+#   tail -f ~/.cache/health-monitor/run.log
+#
+# Install/uninstall: ./launchd/health-monitor.sh {install|uninstall|status}
+#
+# Mirrors the structure of pr-patrol-supervisor.sh — see QUA-987 for
+# the original launchd-supervisor design and QUA-1048 for this monitor.
+
+set -uo pipefail
+
+# ── User identity ────────────────────────────────────────────────────────────
+# launchd LaunchAgents do NOT inherit USER/LOGNAME. Without these the macOS
+# keychain lookup that `claude` uses for OAuth returns "Not logged in".
+# Health-monitor doesn't currently spawn `claude`, but match pr-patrol's
+# pattern so the supervisor template stays consistent.
+export USER="${USER:-$(id -un)}"
+export LOGNAME="${LOGNAME:-$USER}"
+
+# ── PATH setup ────────────────────────────────────────────────────────────────
+# launchd starts agents with a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin).
+# Source nvm so `pnpm`, `node`, and `tsx` resolve, then prepend homebrew/system
+# so `gh`, `git`, etc. are findable too.
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck disable=SC1091
+  . "$NVM_DIR/nvm.sh" --no-use 2>/dev/null || true
+  nvm use --silent default >/dev/null 2>&1 || true
+fi
+if ! command -v pnpm >/dev/null 2>&1 && [ -d "$NVM_DIR/versions/node" ]; then
+  fallback_bin=$(/bin/ls -d "$NVM_DIR/versions/node/"v*/bin 2>/dev/null | sort -V | tail -1)
+  [ -n "$fallback_bin" ] && export PATH="$fallback_bin:${PATH:-}"
+fi
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+
+WIKI_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CACHE_DIR="$HOME/.cache/health-monitor"
+LOG="$CACHE_DIR/run.log"
+LOG_MAX_BYTES=$((20 * 1024 * 1024))   # 20 MB before rotation
+mkdir -p "$CACHE_DIR"
+
+# Bash builtin %(...)T avoids forking a date subshell per log line.
+ts() { printf '%(%Y-%m-%d %H:%M:%S)T' -1; }
+
+maybe_rotate_log() {
+  [ -f "$LOG" ] || return 0
+  local size
+  size=$(/usr/bin/stat -f %z "$LOG" 2>/dev/null) || return 0
+  if [ "$size" -gt "$LOG_MAX_BYTES" ]; then
+    /bin/mv "$LOG" "$LOG.1" 2>/dev/null || true
+  fi
+}
+
+cd "$WIKI_ROOT" || {
+  printf '%s ERROR: cannot cd to %s — exiting (launchd will throttle and retry)\n' \
+    "$(ts)" "$WIKI_ROOT" >> "$LOG"
+  exit 1
+}
+
+# ── Wiki-server target ───────────────────────────────────────────────────────
+# The monitor's job is to watch *production* — main/ is not inside an a<N>
+# slot, so the auto-detect in client.ts won't pick PROD. Force prod here so
+# /health requests don't go to a non-existent local server.
+export WIKI_SERVER_ENV="${WIKI_SERVER_ENV:-prod}"
+
+# ── Signal handling ──────────────────────────────────────────────────────────
+# When launchd sends SIGTERM (`launchctl unload` or shutdown), kill the
+# child process group and exit cleanly. `set -m` puts each `&`-spawned
+# child in its own pgid; signalling -PGID reaches the node grandchild too.
+set -m
+
+monitor_pid=""
+shutdown() {
+  if [ -n "$monitor_pid" ] && kill -0 "$monitor_pid" 2>/dev/null; then
+    printf '%s ── supervisor received signal — terminating child pgid=%d ──\n' \
+      "$(ts)" "$monitor_pid" >> "$LOG"
+    kill -TERM -- "-$monitor_pid" 2>/dev/null || kill -TERM "$monitor_pid" 2>/dev/null || true
+    wait "$monitor_pid" 2>/dev/null || true
+  fi
+  exit 0
+}
+trap shutdown TERM INT
+
+printf '%s ── supervisor starting (pid=%d, wiki=%s) ──\n' \
+  "$(ts)" "$$" "$WIKI_ROOT" >> "$LOG"
+
+# Backgrounded sleep + wait so SIGTERM fires promptly during the inter-cycle
+# pause (bare `sleep N` defers traps until the external sleep returns).
+sleep_interruptible() {
+  sleep "$1" &
+  monitor_pid=$!
+  wait "$monitor_pid" 2>/dev/null || true
+  monitor_pid=""
+}
+
+while true; do
+  maybe_rotate_log
+
+  printf '%s ── health-monitor starting ──\n' "$(ts)" >> "$LOG"
+  pnpm crux sys health-monitor run >> "$LOG" 2>&1 &
+  monitor_pid=$!
+  wait "$monitor_pid"
+  ec=$?
+  monitor_pid=""
+  printf '%s ── health-monitor exited code=%d, sleeping 30s ──\n' "$(ts)" "$ec" >> "$LOG"
+  sleep_interruptible 30
+done

--- a/scripts/inject-health-status.sh
+++ b/scripts/inject-health-status.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# UserPromptSubmit hook — surfaces health-monitor alerts and a dead daemon
+# to the coordinator on every turn. Silent no-op when the daemon is alive
+# and no alerts are active. Mirrors inject-patrol-status.sh.
+#
+# Wire into a coord session's `.claude/settings.local.json`:
+#
+#   "hooks": {
+#     "UserPromptSubmit": [
+#       { "command": "/abs/path/to/scripts/inject-health-status.sh" }
+#     ]
+#   }
+#
+# The "alert" files (~/.cache/health-monitor/state/alert-*) are written by
+# `crux sys health-monitor` when a signal threshold is breached and removed
+# automatically when the signal recovers. See QUA-1048.
+
+set -uo pipefail
+
+CACHE_DIR="$HOME/.cache/health-monitor"
+STATE_DIR="$CACHE_DIR/state"
+
+# ─── Daemon liveness ──────────────────────────────────────────────────────────
+# Match either the daemon process itself (`crux sys health-monitor run` /
+# pnpm parent) or the launchd supervisor in its 30s sleep window. Without
+# the supervisor case we'd false-alarm every 30s during the launchd-managed
+# restart cadence. Single pgrep with alternation = one process-table walk
+# per user prompt. Pattern kept in sync with health-monitor.sh.
+monitor_pid=$(pgrep -f 'sys health-monitor run|health-monitor-supervisor\.sh' 2>/dev/null | head -1)
+
+# ─── Active alert collection ─────────────────────────────────────────────────
+# Glob with nullglob — fewer forks than `ls | grep | sed | tr` and no
+# ls-output parsing. Each filename is `alert-<signal-id>`.
+active_alerts=""
+shopt -s nullglob
+for f in "$STATE_DIR"/alert-*; do
+  name="${f##*/alert-}"
+  active_alerts="$active_alerts $name"
+done
+shopt -u nullglob
+active_alerts="${active_alerts# }"
+
+# Fast exit: nothing to report
+if [ -z "$active_alerts" ] && [ -n "$monitor_pid" ]; then
+  exit 0
+fi
+
+# ─── Resolve the installer path from this script's location ──────────────────
+# When deployed from a wiki clone, this script is at
+# <wiki>/scripts/inject-health-status.sh and the installer is at
+# <wiki>/scripts/launchd/health-monitor.sh — siblings under scripts/.
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="$HOOK_DIR/launchd/health-monitor.sh"
+
+echo "<system-reminder>"
+
+if [ -z "$monitor_pid" ]; then
+  echo "⚠ Coordinator health-monitor is NOT running."
+  if launchctl list 2>/dev/null | grep -q com.qu.health-monitor; then
+    echo "  launchd lists com.qu.health-monitor but no daemon/supervisor process found —"
+    echo "  check ~/.cache/health-monitor/launchd.err and ~/.cache/health-monitor/run.log."
+    echo "  Status: $INSTALLER status"
+  else
+    echo "  No launchd agent installed. Install:"
+    echo "    $INSTALLER install"
+  fi
+  echo ""
+fi
+
+if [ -n "$active_alerts" ]; then
+  for sig in $active_alerts; do
+    case "$sig" in
+      ci-stale)
+        echo "⚠ ci-stale: main-branch CI hasn't been green for over the configured threshold."
+        echo "  Likely cause: stuck main, broken deploy gate, or a regression nobody noticed."
+        ;;
+      jobs-stuck)
+        echo "⚠ jobs-stuck: wiki-server pendingJobs queue is not draining."
+        echo "  Likely cause: stuck DB, dead worker loop, or a slow job blocking the queue."
+        ;;
+      *)
+        echo "⚠ $sig: health-monitor reports an active alert."
+        ;;
+    esac
+    body=""
+    [ -f "$STATE_DIR/alert-$sig" ] && body=$(cat "$STATE_DIR/alert-$sig" 2>/dev/null || echo "")
+    if [ -n "$body" ]; then
+      # Indent for readability
+      printf '%s\n' "$body" | sed 's/^/    /'
+    fi
+    echo ""
+  done
+  echo "Surfaced by health-monitor (QUA-1048). To clear an alert manually:"
+  echo "  rm $STATE_DIR/alert-<signal>"
+fi
+
+echo "</system-reminder>"

--- a/scripts/launchd/README.md
+++ b/scripts/launchd/README.md
@@ -10,10 +10,12 @@ window after login" pattern.
 | Label | Plist | Purpose | Linear |
 |---|---|---|---|
 | `com.qu.pr-patrol` | `com.qu.pr-patrol.plist` | Keeps `crux gh pr-patrol run` alive — auto-restarts on crash, on logout/login cycle, and after reboot | QUA-987 |
+| `com.qu.health-monitor` | `com.qu.health-monitor.plist` | Coordinator-session degradation alarms — polls `/health` and main-branch CI; raises alerts via `<system-reminder>` injection | QUA-1048 |
 
 The supervisor scripts the agents launch are siblings of this directory:
 
 - `../pr-patrol-supervisor.sh` — runs `pnpm crux gh pr-patrol run` in a 30-second restart loop, with shutdown on `SIGTERM`/`SIGINT` so `launchctl unload` is a graceful stop.
+- `../health-monitor-supervisor.sh` — same loop, runs `pnpm crux sys health-monitor run`. Forces `WIKI_SERVER_ENV=prod` so /health requests target production.
 
 ## Install / status / uninstall
 
@@ -24,6 +26,13 @@ The supervisor scripts the agents launch are siblings of this directory:
 ./scripts/launchd/pr-patrol.sh tail        # tail the run log
 ./scripts/launchd/pr-patrol.sh tcc-check   # probe macOS Full Disk Access (see below)
 ./scripts/launchd/pr-patrol.sh uninstall   # unload + remove
+
+# health-monitor follows the same shape:
+./scripts/launchd/health-monitor.sh install   # install + render + load + TCC probe
+./scripts/launchd/health-monitor.sh status    # launchctl state + monitor process + active alerts
+./scripts/launchd/health-monitor.sh tail
+./scripts/launchd/health-monitor.sh tcc-check
+./scripts/launchd/health-monitor.sh uninstall
 ```
 
 The install script is **idempotent** — re-running is safe. It also reports if
@@ -38,6 +47,13 @@ every 30s until the existing patrol exits.
 ~/.cache/pr-patrol/run.log                             # supervisor's log (tail this)
 ~/.cache/pr-patrol/launchd.{out,err}                   # launchd's own captured output
 ~/.cache/pr-patrol/daemon.pid                          # patrol's singleton lock
+
+~/Library/LaunchAgents/com.qu.health-monitor.plist     # health-monitor (QUA-1048)
+~/.cache/health-monitor/run.log                        # supervisor's log
+~/.cache/health-monitor/launchd.{out,err}              # launchd captured output
+~/.cache/health-monitor/daemon.pid                     # singleton lock
+~/.cache/health-monitor/history.jsonl                  # rolling /health snapshot history
+~/.cache/health-monitor/state/alert-<signal>           # per-signal alert files
 ```
 
 ## One-time macOS Full Disk Access grant

--- a/scripts/launchd/com.qu.health-monitor.plist
+++ b/scripts/launchd/com.qu.health-monitor.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Template for ~/Library/LaunchAgents/com.qu.health-monitor.plist (QUA-1048).
+
+  Install via scripts/launchd/health-monitor.sh — the install script fills
+  in the absolute supervisor and home-dir paths before copying.
+
+  Why these keys (mirrored from com.qu.pr-patrol.plist for consistency):
+    KeepAlive       respawn the supervisor on crash. Combined with the
+                    inner while-loop in health-monitor-supervisor.sh, this
+                    gives two layers of recovery.
+    RunAtLoad       start at login + on launchctl load, no manual nudge.
+    ThrottleInterval=30  prevent tight crash loops if something is fundamentally
+                    broken (missing supervisor, missing pnpm, etc.). Matches
+                    the inner sleep so the cadence is consistent.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.qu.health-monitor</string>
+
+    <!--
+      Invoke /bin/bash explicitly rather than relying on the supervisor's
+      shebang. macOS attributes shell-script execution to the kernel-resolved
+      interpreter chain (`/usr/bin/env bash …`), and a Full Disk Access grant
+      on `/bin/bash` does NOT propagate through that chain — the supervisor
+      exits 126 ("Operation not permitted") on every cycle. Spelling bash
+      explicitly here makes /bin/bash the responsible exec, so the FDA grant
+      the install script tells users to add actually applies. See QUA-1004.
+    -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__SUPERVISOR__</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/.cache/health-monitor/launchd.out</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.cache/health-monitor/launchd.err</string>
+</dict>
+</plist>

--- a/scripts/launchd/health-monitor.sh
+++ b/scripts/launchd/health-monitor.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+#
+# health-monitor.sh — install / uninstall / status for the
+# com.qu.health-monitor launchd agent.
+#
+# Usage:
+#   ./health-monitor.sh             # install (idempotent — re-running is safe)
+#   ./health-monitor.sh install     # same as no-arg
+#   ./health-monitor.sh uninstall   # unload + remove from ~/Library/LaunchAgents
+#   ./health-monitor.sh status      # show launchd state + actual monitor process
+#   ./health-monitor.sh tail        # tail the run log (Ctrl-C to exit)
+#   ./health-monitor.sh tcc-check   # probe macOS Full Disk Access
+#
+# Mirrors pr-patrol.sh's structure (QUA-987). The TCC self-test logic is
+# duplicated for now — when a third launchd agent appears we should extract
+# it into scripts/lib/launchd-tcc.sh. Tracked in code review notes for QUA-1048.
+#
+# See QUA-1048.
+
+set -euo pipefail
+
+WIKI_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST_SRC="$WIKI_ROOT/scripts/launchd/com.qu.health-monitor.plist"
+PLIST_DST="$HOME/Library/LaunchAgents/com.qu.health-monitor.plist"
+LABEL="com.qu.health-monitor"
+SUPERVISOR="$WIKI_ROOT/scripts/health-monitor-supervisor.sh"
+CACHE_DIR="$HOME/.cache/health-monitor"
+LOG="$CACHE_DIR/run.log"
+# Loose pattern: matches the daemon process (`node ... sys health-monitor run`)
+# and the supervisor in its 30s sleep window. Kept in sync with
+# inject-health-status.sh so liveness checks agree across files.
+MONITOR_PROCESS_PATTERN='sys health-monitor run|health-monitor-supervisor\.sh'
+
+cmd="${1:-install}"
+
+# Escape sed replacement-string metachars (\, &, |) so paths with shell-special
+# characters survive substitution. macOS allows `&`, `'`, `(`, `)`, etc. in
+# usernames; HOME/SUPERVISOR could contain any of them.
+sed_replacement_escape() {
+  printf '%s\n' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+# Render the embedded XML template, substituting placeholders via sed.
+# Placeholders are sorted longest-first so a future short name can never
+# clobber bytes inside a longer one (e.g. `__HOME__` inside `__HOME_DIR__`).
+render_template() {
+  local input="$1" output="$2"
+  shift 2
+  local pairs=("$@")
+  local sorted
+  sorted=$(printf '%s\n' "${pairs[@]}" | awk '{ print length($0)"\t"$0 }' | sort -rn | cut -f2-)
+  local sed_args=()
+  local pair name val esc
+  while IFS= read -r pair; do
+    name="${pair%%=*}"
+    val="${pair#*=}"
+    esc=$(sed_replacement_escape "$val")
+    sed_args+=(-e "s|$name|$esc|g")
+  done <<<"$sorted"
+  sed "${sed_args[@]}" "$input" > "$output"
+}
+
+# ── TCC self-test ─────────────────────────────────────────────────────────────
+# Modern macOS blocks launchd-spawned processes from reading anything under
+# ~/Documents/ unless the user grants Full Disk Access. Probe via a one-shot
+# test plist that tries to cat $WIKI_ROOT/.git/HEAD: success means launchd
+# can reach our wiki clone, failure means FDA is needed.
+tcc_self_test() {
+  local probe_label="com.qu.health-monitor-tccprobe"
+  local probe_plist="$HOME/Library/LaunchAgents/$probe_label.plist"
+  local probe_out="/tmp/$probe_label.out"
+  local probe_err="/tmp/$probe_label.err"
+  local probe_target="$WIKI_ROOT/.git/HEAD"
+  local probe_template="/tmp/$probe_label.template"
+
+  cleanup_probe() {
+    launchctl unload "$probe_plist" 2>/dev/null || true
+    /bin/rm -f "$probe_plist" "$probe_out" "$probe_err" "$probe_template"
+  }
+  trap cleanup_probe EXIT INT TERM
+
+  /bin/rm -f "$probe_out" "$probe_err" "$probe_template"
+
+  cat > "$probe_template" <<'PROBE_PLIST_TEMPLATE'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>__PROBE_LABEL__</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>cat "__PROBE_TARGET__" > "__PROBE_OUT__" 2> "__PROBE_ERR__"</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+PROBE_PLIST_TEMPLATE
+
+  render_template "$probe_template" "$probe_plist" \
+    "__PROBE_LABEL__=$probe_label" \
+    "__PROBE_TARGET__=$probe_target" \
+    "__PROBE_OUT__=$probe_out" \
+    "__PROBE_ERR__=$probe_err"
+
+  launchctl unload "$probe_plist" 2>/dev/null || true
+  if ! launchctl load "$probe_plist" 2>/dev/null; then
+    trap - EXIT INT TERM
+    cleanup_probe
+    return 1
+  fi
+
+  for _ in 1 2 3 4 5 6; do
+    [ -s "$probe_out" ] && break
+    [ -s "$probe_err" ] && break
+    sleep 0.5
+  done
+
+  local result=1
+  [ -s "$probe_out" ] && result=0
+
+  trap - EXIT INT TERM
+  cleanup_probe
+  return $result
+}
+
+print_tcc_help() {
+  cat <<EOM
+
+⚠ launchd cannot read files under ~/Documents/ — Full Disk Access is required.
+
+  This is a macOS TCC restriction: agents loaded into launchd's Aqua context
+  do not inherit the TCC profile of Terminal/iTerm.
+
+  To grant access (one-time per machine):
+    1. Open  System Settings → Privacy & Security → Full Disk Access
+    2. Click  ＋ , press  Cmd-Shift-G , type  /bin , and select  bash .
+       (Adding the supervisor script directly does NOT work: macOS attributes
+       shell-script execution to the interpreter, not the script — see
+       QUA-1004.)
+    3. Toggle the new entry ON.
+    4. Re-run:  ./health-monitor.sh install
+
+  The same grant covers the pr-patrol launchd agent if you have it installed.
+EOM
+}
+
+case "$cmd" in
+  install)
+    [ -f "$PLIST_SRC" ] || { echo "✗ Missing template: $PLIST_SRC" >&2; exit 1; }
+    [ -f "$SUPERVISOR" ] || { echo "✗ Missing supervisor: $SUPERVISOR" >&2; exit 1; }
+
+    chmod +x "$SUPERVISOR"
+    mkdir -p "$HOME/Library/LaunchAgents" "$CACHE_DIR"
+
+    render_template "$PLIST_SRC" "$PLIST_DST" \
+      "__SUPERVISOR__=$SUPERVISOR" \
+      "__HOME__=$HOME"
+
+    launchctl unload "$PLIST_DST" 2>/dev/null || true
+    launchctl load "$PLIST_DST"
+
+    echo "✓ Installed $PLIST_DST"
+    echo "  Supervisor: $SUPERVISOR"
+    echo "  Watch:      tail -f $LOG"
+    echo "  Status:     $0 status"
+
+    echo ""
+    echo "Checking macOS Full Disk Access for launchd…"
+    if tcc_self_test; then
+      echo "✓ launchd can reach ~/Documents — agent should be running."
+    else
+      echo "✗ launchd is blocked from reading ~/Documents."
+      print_tcc_help
+    fi
+
+    if pgrep -f "$MONITOR_PROCESS_PATTERN" >/dev/null 2>&1; then
+      echo ""
+      echo "ℹ Existing health-monitor process detected — it owns daemon.pid until it exits."
+      echo "  The launchd supervisor will retry every 30s and take over once free."
+    fi
+    ;;
+
+  tcc-check)
+    echo "Probing launchd → ~/Documents access…"
+    if tcc_self_test; then
+      echo "✓ launchd can reach ~/Documents — Full Disk Access is granted."
+    else
+      echo "✗ launchd is blocked from reading ~/Documents."
+      print_tcc_help
+      exit 1
+    fi
+    ;;
+
+  uninstall)
+    if [ -f "$PLIST_DST" ]; then
+      launchctl unload "$PLIST_DST" 2>/dev/null || true
+      rm -f "$PLIST_DST"
+      echo "✓ Uninstalled $PLIST_DST"
+    else
+      echo "Already absent: $PLIST_DST"
+    fi
+    if launchctl list 2>/dev/null | grep -q "$LABEL"; then
+      echo "⚠ launchd still lists $LABEL — try \`launchctl remove $LABEL\` if it persists."
+    fi
+    ;;
+
+  status)
+    launchd_row=$(launchctl list 2>/dev/null | awk -v L="$LABEL" '$3 == L { print; exit }' || true)
+    last_exit=""
+    if [ -n "$launchd_row" ]; then
+      echo "✓ launchd: loaded"
+      lpid=$(awk '{print $1}' <<<"$launchd_row")
+      last_exit=$(awk '{print $2}' <<<"$launchd_row")
+      echo "  pid=$lpid  last_exit=$last_exit  label=$LABEL"
+      if [ "$last_exit" != "0" ] && [ "$last_exit" != "-" ] && [ -n "$last_exit" ]; then
+        echo "  ⚠ supervisor exited non-zero last cycle (code=$last_exit) — see ~/.cache/health-monitor/launchd.err"
+        if [ "$last_exit" = "126" ]; then
+          echo "    code 126 = Operation not permitted; run \`$0 tcc-check\` to verify FDA."
+        fi
+      fi
+    else
+      echo "✗ launchd: not loaded   (run: $0 install)"
+    fi
+    # `|| true` on the pgrep so set -e doesn't bail when no monitor is running
+    # (pgrep exits 1 on no-match, which would otherwise propagate through the
+    # `pid=$(…)` assignment and abort the status case).
+    pid=$( (pgrep -f "$MONITOR_PROCESS_PATTERN" 2>/dev/null || true) | head -1)
+    if [ -n "$pid" ]; then
+      echo "✓ monitor process: pid=$pid"
+    else
+      echo "✗ monitor process: not running"
+    fi
+    pidfile="$CACHE_DIR/daemon.pid"
+    if [ -f "$pidfile" ]; then
+      pidcontents=$(cat "$pidfile" 2>/dev/null || echo "<unreadable>")
+      echo "  daemon.pid: $pidcontents ($pidfile)"
+    fi
+    if [ -f "$LOG" ]; then
+      mtime=$(stat -f %Sm -t '%Y-%m-%d %H:%M:%S' "$LOG" 2>/dev/null || echo unknown)
+      echo "  run.log:    last write $mtime"
+    fi
+    # Surface active alerts
+    state_dir="$CACHE_DIR/state"
+    if [ -d "$state_dir" ]; then
+      shopt -s nullglob
+      alerts=("$state_dir"/alert-*)
+      shopt -u nullglob
+      if [ "${#alerts[@]}" -gt 0 ]; then
+        echo "  active alerts: ${#alerts[@]}"
+        for a in "${alerts[@]}"; do
+          echo "    ⚠ ${a##*/alert-}"
+        done
+      else
+        echo "  active alerts: none"
+      fi
+    fi
+    ;;
+
+  tail)
+    [ -f "$LOG" ] || { echo "Log not found: $LOG" >&2; exit 1; }
+    exec tail -F "$LOG"
+    ;;
+
+  *)
+    echo "Usage: $0 {install|uninstall|status|tail|tcc-check}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

MVP for [QUA-1048](https://linear.app/quantifieduncertainty/issue/QUA-1048) per the user's "minimal-win first iteration" comment: daemon + state files + injector hook, two signals only, no Linear posting yet, wired only to `/setup-slot-orchestration`.

Closes QUA-1048.

## What it does

A long-running daemon (managed by launchd) that polls the wiki-server `/health` endpoint and main-branch CI, then surfaces degradation as `<system-reminder>` blocks on coordinator turns.

Two signals (configurable via flags):

| Signal | When it fires |
|---|---|
| `ci-stale` | Last green main CI > 2h ago — OR no green found among the last N completed runs |
| `jobs-stuck` | `pendingJobs > 0` with `oldestPendingJobAgeSeconds` growing for >15 min |

Same observability gap pattern as QUA-1000 / QUA-411 / QUA-820 — site stays up serving stale data while CI / jobs are silently broken.

## Components

- `crux sys health-monitor {run,once,status,explain}` — TS daemon
- `crux/health-monitor/` — types, state, **pure** signal evaluation, daemon loop
- `scripts/health-monitor-supervisor.sh` — bash supervisor (mirrors `pr-patrol-supervisor.sh`)
- `scripts/launchd/com.qu.health-monitor.plist` + `health-monitor.sh` — launchd lifecycle, FDA-aware
- `scripts/inject-health-status.sh` — `UserPromptSubmit` hook (silent no-op when daemon alive + no alerts)

## State layout

```
~/.cache/health-monitor/
  daemon.pid                   # singleton lock
  history.jsonl                # rolling /health snapshots, atomic-rename trim
  run.log                      # supervisor log
  state/alert-<signal>         # present iff signal currently breached
                               # `since` preserved across cycles
```

## Tests

32 unit tests across `signals.test.ts` (17) and `state.test.ts` (15). End-to-end smoke tests done locally.

## Review pass findings (already fixed in this PR)

A hostile-reviewer pass on the first commit caught 8 issues. 5 fixed in `92561ae22`:

| Severity | Issue | Fix |
|---|---|---|
| HIGH | `evaluateJobsStuck` filtered samples when wiki-server returned `status != "healthy"` even with valid queue data | `serverHealthy` now means "got parseable queue-state data" (HTTP 200 + numeric `pendingJobs`) |
| HIGH | `evaluateCiStale` returned no alert when last 10 completed runs were all failures | Added synthetic `ageSeconds` from `oldestSampledAt` (or threshold lower bound) when `lastGreenAt` is null but completed runs were sampled |
| MEDIUM | `ciCheckEveryNCycles=0` → `cycleNum % 0 = NaN` → CI never checked | Clamp pacing in `buildConfig` to safe minimums |
| MEDIUM | `clearAlert` ENOENT race with concurrent process | Swallow ENOENT only |
| MEDIUM | `trimHistory`'s `writeFileSync` opens with O_TRUNC; SIGKILL between leaves zero-byte file | Write `.tmp` then `renameSync` |

## Out of scope (intentional)

- Linear auto-commenting on signal breach
- `/setup-releases` wiring
- Workspace docs (`lw/.claude/commands/setup-slot-orchestration.md`, `lw/README.md`) — those live in `lw/` workspace repo (separate)
- Refactor of duplicated TCC self-test between `pr-patrol.sh` and `health-monitor.sh`

## Follow-up filed

- **QUA-1054** — `pr-patrol.sh status` exits early under `set -euo pipefail` when no patrol is running. Same one-line `(pgrep ... || true) | head -1` fix.

## Test plan

- [x] **32 unit tests pass** (`npx vitest run crux/health-monitor`) — covers every signal branch incl. all-failures synthetic-age, queue-drain debounce, fresh-slow-job confound, ENOENT-safe `clearAlert`, atomic-rename `trimHistory`, malformed JSON / corrupt history lines.
- [x] **Smoke `crux sys health-monitor once`** — fetched live `/health` + GitHub CI in one cycle. ci-stale fired correctly: "last green 2.2h ago (over 2.0h)" — picked up a real prod signal at the time. Daemon exited cleanly, `daemon.pid` cleaned up.
- [x] **Smoke `crux sys health-monitor run --interval=2 --jobs-window-seconds=60`** — daemon accumulated 9 history samples in 8s. `crux sys health-monitor status` reported `pid=...running`, `recent samples: 9`. SIGTERM cleanly exited and removed `daemon.pid`.
- [x] **Inject hook tested in 3 modes**: silent when daemon alive + no alerts; emits "monitor NOT running" when no daemon; emits per-signal banner with full alert JSON body when alert files exist (tested by manually writing a fake alert file).
- [x] **Pre-push gate**: full gate (`pnpm crux w validate gate --skip-slow`) — 67 checks passed (3 advisory warnings, all pre-existing baseline).
- [ ] CI green (assess after push)
- [ ] **Manual install on coord/ machine** — required follow-up for the operator: `./scripts/launchd/health-monitor.sh install`, then wire into `coord/.claude/settings.local.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
