### PR TITLE
fix(factbase): cap GenericCollectionTable at 200 SSR rows (QUA-1052)

### DIFF
--- a/apps/web/src/components/factbase/__tests__/entity-collection-table.test.tsx
+++ b/apps/web/src/components/factbase/__tests__/entity-collection-table.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+/**
+ * Regression test for QUA-1052: GenericCollectionTable must not render the
+ * full row set when the collection is huge. Rendering thousands of rows
+ * inside a path-mode tab tree (org/[slug] page) made the SSR HTML for
+ * mega-funders (coefficient-giving with 2,626 grants, cea with 1,649)
+ * blow past 5MB and intermittently crashed React hydration with #418.
+ */
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { FactBaseRecordEntry } from "@/data/factbase";
+
+// `entity-collection-table` reads from the global database/factbase module
+// to look up record schemas + verdicts. Mock both so the test stays a pure
+// render check that doesn't depend on built artifacts.
+vi.mock("@/data/factbase", () => ({
+  getKBRecordSchema: () => undefined,
+}));
+vi.mock("@/data/tablebase", () => ({
+  getRecordVerdict: () => undefined,
+}));
+vi.mock("@/app/sourcing/sourcing-shared", () => ({
+  getSourcingHref: () => undefined,
+}));
+vi.mock("@/components/sourcing/SourcingDot", () => ({
+  SourcingDot: () => <span data-testid="dot" />,
+}));
+vi.mock("@/components/sourcing/sourcing-status", () => ({
+  recordVerdictToStatus: () => "not_run",
+}));
+vi.mock("@/components/wiki/factbase/FBCellValue", () => ({
+  FBCellValue: ({ value }: { value: unknown }) => <>{String(value ?? "")}</>,
+}));
+vi.mock("@/components/wiki/factbase/format", () => ({
+  titleCase: (s: string) => s.charAt(0).toUpperCase() + s.slice(1),
+}));
+
+import { GenericCollectionTable } from "@/components/factbase/entity-collection-table";
+
+function makeItems(n: number): FactBaseRecordEntry[] {
+  return Array.from({ length: n }, (_, i) => ({
+    key: `key-${i}`,
+    schema: "test-schema",
+    ownerEntityId: "owner",
+    fields: { name: `Row ${i}` },
+  }));
+}
+
+function countDataRows(container: HTMLElement): number {
+  // Match every <tr> in <tbody>; the header tr lives in <thead>.
+  return container.querySelectorAll("tbody tr").length;
+}
+
+describe("GenericCollectionTable — SSR row cap (QUA-1052)", () => {
+  it("renders all rows when count is at or below the 200-row cap", () => {
+    const { container } = render(
+      <GenericCollectionTable collectionName="grants" items={makeItems(50)} />,
+    );
+    expect(countDataRows(container)).toBe(50);
+    // Truncation notice should not appear.
+    expect(container.textContent).not.toContain("Showing first");
+  });
+
+  it("renders all rows when count is exactly at the cap", () => {
+    const { container } = render(
+      <GenericCollectionTable collectionName="grants" items={makeItems(200)} />,
+    );
+    expect(countDataRows(container)).toBe(200);
+    expect(container.textContent).not.toContain("Showing first");
+  });
+
+  it("caps rendered rows and shows truncation notice when count exceeds cap", () => {
+    const { container } = render(
+      <GenericCollectionTable collectionName="grants" items={makeItems(2626)} />,
+    );
+    // Only the first 200 rows make it into SSR — this is what guards
+    // hydration on coefficient-giving's 2,626-grant collection.
+    expect(countDataRows(container)).toBe(200);
+    expect(screen.getByText(/Showing first 200 of 2,626 rows/)).toBeTruthy();
+  });
+
+  it("preserves the full count badge in the section header even when truncated", () => {
+    const { container } = render(
+      <GenericCollectionTable collectionName="grants" items={makeItems(2626)} />,
+    );
+    // The SectionHeader renders the *true* total (2626), not the rendered
+    // subset, so users see the full size of the underlying collection.
+    expect(container.textContent).toContain("2626");
+  });
+});

--- a/apps/web/src/components/factbase/__tests__/entity-collection-table.test.tsx
+++ b/apps/web/src/components/factbase/__tests__/entity-collection-table.test.tsx
@@ -12,9 +12,13 @@ import { render, screen } from "@testing-library/react";
 
 import type { FactBaseRecordEntry } from "@/data/factbase";
 
-// `entity-collection-table` reads from the global database/factbase module
-// to look up record schemas + verdicts. Mock both so the test stays a pure
-// render check that doesn't depend on built artifacts.
+// `entity-collection-table` reaches into several modules that themselves
+// load the built database.json / factbase-data.json at module load. The
+// mocks below cover exactly the imports the component uses today — if a
+// future edit pulls in another symbol from one of these modules, vitest
+// will surface the gap as a "X is not a function" failure (long after the
+// code change but still before merging, via the test suite). Keep the
+// surface minimal and explicit.
 vi.mock("@/data/factbase", () => ({
   getKBRecordSchema: () => undefined,
 }));
@@ -37,7 +41,10 @@ vi.mock("@/components/wiki/factbase/format", () => ({
   titleCase: (s: string) => s.charAt(0).toUpperCase() + s.slice(1),
 }));
 
-import { GenericCollectionTable } from "@/components/factbase/entity-collection-table";
+import {
+  GenericCollectionTable,
+  MAX_SSR_ROWS,
+} from "@/components/factbase/entity-collection-table";
 
 function makeItems(n: number): FactBaseRecordEntry[] {
   return Array.from({ length: n }, (_, i) => ({
@@ -54,7 +61,7 @@ function countDataRows(container: HTMLElement): number {
 }
 
 describe("GenericCollectionTable — SSR row cap (QUA-1052)", () => {
-  it("renders all rows when count is at or below the 200-row cap", () => {
+  it("renders all rows when count is well below the cap", () => {
     const { container } = render(
       <GenericCollectionTable collectionName="grants" items={makeItems(50)} />,
     );
@@ -63,30 +70,104 @@ describe("GenericCollectionTable — SSR row cap (QUA-1052)", () => {
     expect(container.textContent).not.toContain("Showing first");
   });
 
-  it("renders all rows when count is exactly at the cap", () => {
+  it("renders all rows when count is exactly at the cap (boundary)", () => {
     const { container } = render(
-      <GenericCollectionTable collectionName="grants" items={makeItems(200)} />,
+      <GenericCollectionTable
+        collectionName="grants"
+        items={makeItems(MAX_SSR_ROWS)}
+      />,
     );
-    expect(countDataRows(container)).toBe(200);
+    expect(countDataRows(container)).toBe(MAX_SSR_ROWS);
     expect(container.textContent).not.toContain("Showing first");
   });
 
-  it("caps rendered rows and shows truncation notice when count exceeds cap", () => {
+  it("caps rendered rows when count is one above the cap (off-by-one boundary)", () => {
+    // Catches a >= vs > regression on the truncation predicate. With
+    // items.length = MAX_SSR_ROWS + 1, the >= variant would render all
+    // rows, while > correctly truncates to MAX_SSR_ROWS.
+    const oneAbove = MAX_SSR_ROWS + 1;
     const { container } = render(
-      <GenericCollectionTable collectionName="grants" items={makeItems(2626)} />,
+      <GenericCollectionTable
+        collectionName="grants"
+        items={makeItems(oneAbove)}
+      />,
     );
-    // Only the first 200 rows make it into SSR — this is what guards
-    // hydration on coefficient-giving's 2,626-grant collection.
-    expect(countDataRows(container)).toBe(200);
-    expect(screen.getByText(/Showing first 200 of 2,626 rows/)).toBeTruthy();
+    expect(countDataRows(container)).toBe(MAX_SSR_ROWS);
+    expect(container.textContent).toContain(
+      `Showing first ${MAX_SSR_ROWS} of ${oneAbove} rows.`,
+    );
   });
 
-  it("preserves the full count badge in the section header even when truncated", () => {
+  it("caps rendered rows and shows truncation notice on a mega-funder-sized collection", () => {
+    const total = 2626; // coefficient-giving's actual grant count
     const { container } = render(
-      <GenericCollectionTable collectionName="grants" items={makeItems(2626)} />,
+      <GenericCollectionTable
+        collectionName="grants"
+        items={makeItems(total)}
+      />,
     );
-    // The SectionHeader renders the *true* total (2626), not the rendered
-    // subset, so users see the full size of the underlying collection.
-    expect(container.textContent).toContain("2626");
+    // Only the first MAX_SSR_ROWS rows make it into SSR — this is what guards
+    // hydration on coefficient-giving's 2,626-grant collection.
+    expect(countDataRows(container)).toBe(MAX_SSR_ROWS);
+    expect(
+      screen.getByText(
+        new RegExp(`Showing first ${MAX_SSR_ROWS} of 2,626 rows`),
+      ),
+    ).toBeTruthy();
+  });
+
+  it("renders a Link to the dedicated directory when one exists", () => {
+    // For collections with a top-level directory page (grants, publications,
+    // investments, funding-rounds, funding-programs, divisions), the
+    // truncation notice surfaces a navigation affordance so users can
+    // browse the remaining rows.
+    render(
+      <GenericCollectionTable
+        collectionName="grants"
+        items={makeItems(MAX_SSR_ROWS + 100)}
+      />,
+    );
+    const link = screen.getByRole("link", {
+      name: /Browse all grants in the Grants directory/,
+    });
+    expect(link.getAttribute("href")).toBe("/grants");
+  });
+
+  it("omits the directory link for collections without a dedicated directory", () => {
+    // `safety-milestones` has no top-level directory, so the truncation
+    // notice should still render but without a navigation link — better
+    // than a stale or 404-ing href.
+    render(
+      <GenericCollectionTable
+        collectionName="safety-milestones"
+        items={makeItems(MAX_SSR_ROWS + 50)}
+      />,
+    );
+    expect(
+      screen.queryByRole("link", { name: /Browse all/ }),
+    ).toBeNull();
+    expect(
+      screen.getByText(/Showing first 200 of 250 rows/),
+    ).toBeTruthy();
+  });
+
+  it("keeps the true total in the section header — not the rendered subset", () => {
+    // The SectionHeader is anchored at `#col-{collectionName}`. We scope the
+    // count assertion to that node so a regression that moves the count out
+    // of the header (or replaces it with the rendered subset) actually fails
+    // — a substring check on the whole document would pass on any "2626"
+    // anywhere in the markup.
+    const total = 2626;
+    const { container } = render(
+      <GenericCollectionTable
+        collectionName="grants"
+        items={makeItems(total)}
+      />,
+    );
+    const header = container.querySelector("#col-grants");
+    expect(header).not.toBeNull();
+    expect(header!.textContent).toContain(String(total));
+    // And the rendered subset count (MAX_SSR_ROWS) should NOT be the badge.
+    expect(header!.textContent).not.toContain(`(${MAX_SSR_ROWS})`);
   });
 });

--- a/apps/web/src/components/factbase/entity-collection-table.tsx
+++ b/apps/web/src/components/factbase/entity-collection-table.tsx
@@ -9,6 +9,26 @@ import { FBCellValue } from "@/components/wiki/factbase/FBCellValue";
 
 import { SectionHeader } from "./entity-section-header";
 
+/**
+ * Maximum rows rendered server-side per collection. Beyond this, we show a
+ * "showing N of M" notice and require the user to navigate to the dedicated
+ * directory or sub-page to see the rest. Two reasons to cap this:
+ *
+ * - **Hydration safety (QUA-1052)**: rendering thousands of rows in the SSR
+ *   payload makes the HTML so large that React hydration intermittently fails
+ *   with #418 (observed at 75-90% rate on coefficient-giving's 2,626-grant
+ *   table). The 8.5MB page split across ~3,400 RSC chunks has a race between
+ *   hydration walker and chunk arrival.
+ * - **Page weight**: a flat unbounded table is rarely the right UX for an
+ *   entity profile — dedicated sub-pages (grants, personnel, etc.) handle
+ *   filtering and pagination properly.
+ *
+ * The limit is deliberately well below the smallest size that triggers
+ * the hydration race (somewhere between 545 and 1,649 rows on prod), with
+ * room for organic growth of normal entities without hitting it.
+ */
+const MAX_SSR_ROWS = 200;
+
 /** Generic collection table (for collections without special rendering). */
 export function GenericCollectionTable({
   collectionName,
@@ -32,6 +52,9 @@ export function GenericCollectionTable({
     ? [...schemaFieldNames, ...[...allFieldNames].filter((f) => !schemaFieldNames.includes(f))]
     : [...allFieldNames];
 
+  const truncated = items.length > MAX_SSR_ROWS;
+  const visibleItems = truncated ? items.slice(0, MAX_SSR_ROWS) : items;
+
   return (
     <section className="mb-6">
       <SectionHeader title={titleCase(collectionName)} count={items.length} id={`col-${collectionName}`} />
@@ -50,7 +73,7 @@ export function GenericCollectionTable({
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
-            {items.map((item) => {
+            {visibleItems.map((item) => {
               const recordId = String(item.key);
               const verdict = getRecordVerdict(collectionName, recordId);
               return (
@@ -86,6 +109,12 @@ export function GenericCollectionTable({
             })}
           </tbody>
         </table>
+        {truncated && (
+          <div className="border-t border-border/50 px-3 py-2 text-xs text-muted-foreground">
+            Showing first {MAX_SSR_ROWS.toLocaleString("en-US")} of{" "}
+            {items.length.toLocaleString("en-US")} rows.
+          </div>
+        )}
       </div>
     </section>
   );

--- a/apps/web/src/components/factbase/entity-collection-table.tsx
+++ b/apps/web/src/components/factbase/entity-collection-table.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { getKBRecordSchema } from "@/data/factbase";
 import type { FactBaseRecordEntry } from "@/data/factbase";
 import { getRecordVerdict } from "@/data/tablebase";
@@ -11,8 +13,7 @@ import { SectionHeader } from "./entity-section-header";
 
 /**
  * Maximum rows rendered server-side per collection. Beyond this, we show a
- * "showing N of M" notice and require the user to navigate to the dedicated
- * directory or sub-page to see the rest. Two reasons to cap this:
+ * "showing N of M" notice. Two reasons to cap this:
  *
  * - **Hydration safety (QUA-1052)**: rendering thousands of rows in the SSR
  *   payload makes the HTML so large that React hydration intermittently fails
@@ -23,11 +24,31 @@ import { SectionHeader } from "./entity-section-header";
  *   entity profile — dedicated sub-pages (grants, personnel, etc.) handle
  *   filtering and pagination properly.
  *
- * The limit is deliberately well below the smallest size that triggers
- * the hydration race (somewhere between 545 and 1,649 rows on prod), with
+ * The limit is deliberately well below the smallest size that triggered
+ * the hydration race on prod (somewhere between 545 and 1,649 rows), with
  * room for organic growth of normal entities without hitting it.
+ *
+ * Exported for tests so they can assert behavior at the boundary without
+ * hardcoding the literal in three places.
  */
-const MAX_SSR_ROWS = 200;
+export const MAX_SSR_ROWS = 200;
+
+/**
+ * Collection slugs that have their own browseable directory or sub-page.
+ * When `GenericCollectionTable` truncates one of these, the notice points
+ * users at the right place to see the full set instead of stranding them.
+ *
+ * Keys are FactBase collection names (`itemCollections` keys). The dedicated
+ * directories use the same slug as a path segment.
+ */
+const DIRECTORY_FOR_COLLECTION: Record<string, { href: string; label: string }> = {
+  grants: { href: "/grants", label: "Browse all grants in the Grants directory" },
+  publications: { href: "/publications", label: "Browse all publications in the Publications directory" },
+  investments: { href: "/investments", label: "Browse all investments in the Investments directory" },
+  "funding-rounds": { href: "/funding-rounds", label: "Browse all rounds in the Funding Rounds directory" },
+  "funding-programs": { href: "/funding-programs", label: "Browse all programs in the Funding Programs directory" },
+  divisions: { href: "/divisions", label: "Browse all divisions in the Divisions directory" },
+};
 
 /** Generic collection table (for collections without special rendering). */
 export function GenericCollectionTable({
@@ -113,6 +134,18 @@ export function GenericCollectionTable({
           <div className="border-t border-border/50 px-3 py-2 text-xs text-muted-foreground">
             Showing first {MAX_SSR_ROWS.toLocaleString("en-US")} of{" "}
             {items.length.toLocaleString("en-US")} rows.
+            {DIRECTORY_FOR_COLLECTION[collectionName] && (
+              <>
+                {" "}
+                <Link
+                  href={DIRECTORY_FOR_COLLECTION[collectionName].href}
+                  className="text-primary hover:underline"
+                >
+                  {DIRECTORY_FOR_COLLECTION[collectionName].label}
+                </Link>
+                .
+              </>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Fixes [QUA-1052](https://linear.app/quantifieduncertainty/issue/QUA-1052): React #418 hydration mismatch on `/organizations/coefficient-giving` and `/organizations/cea` after the QUA-1000 build-data fetch fix.

## Root cause

`GenericCollectionTable` (rendered by `FactBaseEntityBody` for the Facts tab) was emitting every row of every FactBase collection into the SSR HTML. Path-mode tab routing keeps each tab's body in the React tree at all times (no Suspense gate on tab switches), so the Facts tab's `grants` collection rendered:

- coefficient-giving: 2,626 grant rows → **8.5 MB SSR HTML, ~3,400 RSC `__next_f.push()` chunks**
- cea: 1,649 grant rows → **5.5 MB SSR HTML**

At that payload size, React hydration intermittently fired `Minified React error #418` (`args[]=HTML&args[]=`) — almost certainly a race between the hydration walker and the streamed RSC chunk decode of that many lazy refs. Reproduced locally at **15/20** (75%) on coefficient-giving, **5/8** on cea, **0** on every smaller org tested (anthropic, ltff, sff, deepmind, 80000-hours, …). Local prod build (`pnpm build && pnpm start`) reproduced the failure rate one-for-one with prod, ruling out Vercel-specific behavior.

QUA-1000 legitimately fetched the full grant set (per-page AbortSignal) — pre-fix, the array was silently truncated, masking the issue.

## Fix

`GenericCollectionTable` slices `items` to `MAX_SSR_ROWS = 200` server-side and renders a "Showing first 200 of 2,626 rows" notice. When the collection has a dedicated directory page (grants, publications, investments, funding-rounds, funding-programs, divisions), the notice includes a `<Link>` to it so users can browse the rest. Collections without a directory still get the bare notice — better than a stale or 404-ing href.

The `SectionHeader` keeps the **true total** (2,626) in its count badge so users always see the actual collection size.

The cap solves the hydration class — same race would have hit any other large generic collection (personnel, divisions, …) once it crossed the threshold, now gated by one constant.

## Verification

| Org | Before fix (HTML / hydration) | After fix |
| --- | --- | --- |
| coefficient-giving | 8.5 MB / 15 of 20 fail | **1.25 MB / 0 of 15 fail** |
| cea | 5.5 MB / 5 of 8 fail | **2.4 MB / 0 of 10 fail** |
| ltff | 1.2 MB / 0 fail | 558 KB / 0 fail |
| anthropic | 1.1 MB / 0 fail | 1.1 MB / 0 fail |
| 80000-hours | 481 KB / 0 fail | 481 KB / 0 fail |

Tests:
- 7 unit tests in `entity-collection-table.test.tsx` cover the cap at, below, exactly, and one above; the Browse-link path; the no-directory fallback path; and the SectionHeader-anchored count assertion (catches regressions that swap subset for total).
- Playwright-verified the truncation notice + Link renders in the Facts tab, and clicking the Link navigates to `/grants`.
- Full apps/web test suite: 9555 / 9555 passing.
- Wiki gate: 71 / 71 passing.
- `apps/web/e2e/org-pages.spec.ts` already asserts `pageerror` on cea + coefficient-giving — would catch a regression of this class.

## Test plan

- [x] Build + typecheck (apps/web, wiki-server, crux)
- [x] Unit tests (apps/web full suite + new entity-collection-table tests)
- [x] Wiki gate (71/71)
- [x] Local prod-build hydration regression test (coefficient-giving 0/15, cea 0/10)
- [x] Playwright-verified truncation notice and `/grants` Link navigation
- [x] /agent-review-pr completed (1 hostile-reviewer subagent pass; 3 MEDIUM + 1 LOW addressed)

Closes QUA-1052.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collection tables now limit displayed rows with a "first N of M" notice showing the true total count.
  * Added a "Browse all" link for collections with dedicated directories to help users access the complete listing.

* **Tests**
  * Added regression test suite for collection table row rendering limits and truncation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->