### PR TITLE
fix(crux): strip ANTHROPIC_API_KEY from spawned claude env (6 sites, QUA-1010)

### DIFF
--- a/crux/authoring/creator/deployment.ts
+++ b/crux/authoring/creator/deployment.ts
@@ -10,6 +10,7 @@ import { appendEditLog, getDefaultRequestedBy } from '../../lib/session/edit-log
 import type { DeployPhaseContext, ValidationPhaseContext } from './types.ts';
 import { ENTITY_LINK_RE, WIKI_ID_RE, FOOTNOTE_REF_RE, FOOTNOTE_DEF_RE } from '../../lib/patterns.ts';
 import { validateMdxContent } from '../../lib/validation/validate-mdx-content.ts';
+import { prepareClaudeSpawnEnv } from '../../lib/claude-cli.ts';
 
 let _slugToNumeric: Record<string, string> | null = null;
 
@@ -230,9 +231,7 @@ If you find any logicalIssues or temporalArtifacts, also fix them directly in th
 
   const { spawn } = await import('child_process');
 
-  // Unset CLAUDECODE to allow spawning Claude inside a Claude Code session
-  const env = { ...process.env };
-  delete env.CLAUDECODE;
+  const env = prepareClaudeSpawnEnv();
 
   return new Promise((resolve, reject) => {
     const TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes

--- a/crux/authoring/creator/synthesis.ts
+++ b/crux/authoring/creator/synthesis.ts
@@ -10,6 +10,7 @@ import { spawn } from 'child_process';
 import { inferEntityType } from '../../lib/category-entity-types.ts';
 import { buildEntityLookupForTopic } from '../../lib/entity-lookup.ts';
 import { resolveTemplate, formatTemplateForPrompt } from '../../lib/content/page-templates.ts';
+import { prepareClaudeSpawnEnv } from '../../lib/claude-cli.ts';
 import type { SynthesisPhaseContext, CreatorContext } from './types.ts';
 
 type LoadResultContext = Pick<Required<CreatorContext>, 'loadResult'>;
@@ -309,9 +310,7 @@ export async function runSynthesis(topic: string, quality: string, { log, ROOT }
     const budget = quality === 'quality' ? 3.0 : 2.0;
     const TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
-    // Unset CLAUDECODE to allow spawning Claude inside a Claude Code session
-    const env = { ...process.env };
-    delete env.CLAUDECODE;
+    const env = prepareClaudeSpawnEnv();
 
     const claude = spawn('claude', [
       '-p',

--- a/crux/authoring/creator/validation.ts
+++ b/crux/authoring/creator/validation.ts
@@ -10,6 +10,7 @@ import { spawn } from 'child_process';
 import { CRITICAL_RULES, QUALITY_RULES } from '../../lib/content-types.ts';
 import { componentImportsRule } from '../../lib/rules/component-imports.ts';
 import { ContentFile } from '../../lib/validation/validation-engine.ts';
+import { prepareClaudeSpawnEnv } from '../../lib/claude-cli.ts';
 import type { ValidationPhaseContext, CreatorContext } from './types.ts';
 
 type ValidationLoopContext = ValidationPhaseContext;
@@ -128,9 +129,7 @@ Read the draft article at: ${draftPath}
 
 Keep iterating until ALL checks pass. Run validation again after each fix.`;
 
-  // Unset CLAUDECODE to allow spawning Claude inside a Claude Code session
-  const env = { ...process.env };
-  delete env.CLAUDECODE;
+  const env = prepareClaudeSpawnEnv();
 
   return new Promise((resolve, reject) => {
     const TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes

--- a/crux/authoring/page-improver/api.ts
+++ b/crux/authoring/page-improver/api.ts
@@ -18,7 +18,7 @@ import {
   startHeartbeat, withRetry, type ToolHandler, isOpenRouterMode, streamLlmCall,
 } from '../../lib/llm.ts';
 import { MODELS } from '../../lib/anthropic.ts';
-import { shouldUseApiDirect, isClaudeCliAvailable } from '../../lib/claude-cli.ts';
+import { shouldUseApiDirect, isClaudeCliAvailable, prepareClaudeSpawnEnv } from '../../lib/claude-cli.ts';
 import type { RunAgentOptions } from './types.ts';
 import { ROOT, SCRY_PUBLIC_KEY, log } from './utils.ts';
 
@@ -190,11 +190,7 @@ async function runAgentViaCli(
   const budgetUsd = cliModel === 'haiku' ? '0.50' : '3.00';
 
   return new Promise((resolve, reject) => {
-    // Unset CLAUDECODE to allow spawning Claude inside a Claude Code session.
-    // No need to strip ANTHROPIC_API_KEY — this codebase uses
-    // ANTHROPIC_BILLING_KEY, which the claude CLI does not read.
-    const env = { ...process.env };
-    delete env.CLAUDECODE;
+    const env = prepareClaudeSpawnEnv();
 
     const args = [
       '-p',

--- a/crux/lib/agent-workspace/dispatch.ts
+++ b/crux/lib/agent-workspace/dispatch.ts
@@ -28,6 +28,7 @@ import {
   unlinkSync as fsUnlinkSync,
 } from 'fs';
 import { spawn as cpSpawn, type ChildProcess, type SpawnOptions } from 'child_process';
+import { prepareClaudeSpawnEnv } from '../claude-cli.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -228,11 +229,14 @@ export function realDispatchEnv(): DispatchEnv {
       }
     },
     spawnDetached: (cmd, args, { cwd, stdoutFd, stderrFd, env: spawnEnv }) => {
+      // Strip CLAUDECODE + ANTHROPIC_API_KEY from the child env so the dispatched
+      // worker uses our OAuth Claude Code subscription rather than silently
+      // switching to API-direct billing. See QUA-1010 / QUA-612.
       const spawnOpts: SpawnOptions = {
         cwd,
         detached: true,
         stdio: ['ignore', stdoutFd, stderrFd],
-        ...(spawnEnv ? { env: spawnEnv } : {}),
+        env: prepareClaudeSpawnEnv(spawnEnv),
       };
       const child: ChildProcess = cpSpawn(cmd, args, spawnOpts);
       if (typeof child.pid !== 'number') {

--- a/crux/lib/claude-cli.test.ts
+++ b/crux/lib/claude-cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { shouldUseApiDirect, isClaudeCliAvailable, isInsideClaudeCodeSession, resetCliDetectionCache } from './claude-cli.ts';
+import { shouldUseApiDirect, isClaudeCliAvailable, isInsideClaudeCodeSession, resetCliDetectionCache, prepareClaudeSpawnEnv } from './claude-cli.ts';
 
 describe('Claude CLI Detection', () => {
   beforeEach(() => {
@@ -68,6 +68,59 @@ describe('Claude CLI Detection', () => {
     it('shouldUseApiDirect: explicit false still overrides CLAUDECODE', () => {
       process.env.CLAUDECODE = '1';
       expect(shouldUseApiDirect(false)).toBe(false);
+    });
+  });
+
+  describe('prepareClaudeSpawnEnv', () => {
+    const originalClaudeCode = process.env.CLAUDECODE;
+    const apiKeyName = 'ANTHROPIC_API_KEY'; // anthropic-billing-key-remap-ok
+    const originalApiKey = process.env[apiKeyName];
+
+    afterEach(() => {
+      if (originalClaudeCode !== undefined) process.env.CLAUDECODE = originalClaudeCode;
+      else delete process.env.CLAUDECODE;
+      if (originalApiKey !== undefined) process.env[apiKeyName] = originalApiKey;
+      else delete process.env[apiKeyName];
+    });
+
+    it('strips CLAUDECODE from the returned env', () => {
+      process.env.CLAUDECODE = '1';
+      const env = prepareClaudeSpawnEnv();
+      expect(env.CLAUDECODE).toBeUndefined();
+    });
+
+    it('strips ANTHROPIC_API_KEY from the returned env', () => {
+      process.env[apiKeyName] = 'sk-ant-api03-test';
+      const env = prepareClaudeSpawnEnv();
+      expect(env[apiKeyName]).toBeUndefined();
+    });
+
+    it('does not mutate process.env', () => {
+      process.env.CLAUDECODE = '1';
+      process.env[apiKeyName] = 'sk-ant-api03-test';
+      prepareClaudeSpawnEnv();
+      expect(process.env.CLAUDECODE).toBe('1');
+      expect(process.env[apiKeyName]).toBe('sk-ant-api03-test');
+    });
+
+    it('preserves other env vars (PATH, HOME, ANTHROPIC_BILLING_KEY)', () => {
+      process.env[apiKeyName] = 'sk-ant-api03-test';
+      const env = prepareClaudeSpawnEnv();
+      expect(env.PATH).toBe(process.env.PATH);
+      expect(env.HOME).toBe(process.env.HOME);
+      // ANTHROPIC_BILLING_KEY is the legitimate key for crux SDK calls and must NOT be stripped
+      // (the claude CLI ignores it; only ANTHROPIC_API_KEY triggers the API-billing switch)
+      if (process.env.ANTHROPIC_BILLING_KEY) {
+        expect(env.ANTHROPIC_BILLING_KEY).toBe(process.env.ANTHROPIC_BILLING_KEY);
+      }
+    });
+
+    it('handles env where neither CLAUDECODE nor ANTHROPIC_API_KEY is set', () => {
+      delete process.env.CLAUDECODE;
+      delete process.env[apiKeyName];
+      const env = prepareClaudeSpawnEnv();
+      expect(env.CLAUDECODE).toBeUndefined();
+      expect(env[apiKeyName]).toBeUndefined();
     });
   });
 });

--- a/crux/lib/claude-cli.test.ts
+++ b/crux/lib/claude-cli.test.ts
@@ -73,14 +73,16 @@ describe('Claude CLI Detection', () => {
 
   describe('prepareClaudeSpawnEnv', () => {
     const originalClaudeCode = process.env.CLAUDECODE;
-    const apiKeyName = 'ANTHROPIC_API_KEY'; // anthropic-billing-key-remap-ok
-    const originalApiKey = process.env[apiKeyName];
+    const originalApiKey = process.env.ANTHROPIC_API_KEY;
+    const originalBillingKey = process.env.ANTHROPIC_BILLING_KEY;
 
     afterEach(() => {
       if (originalClaudeCode !== undefined) process.env.CLAUDECODE = originalClaudeCode;
       else delete process.env.CLAUDECODE;
-      if (originalApiKey !== undefined) process.env[apiKeyName] = originalApiKey;
-      else delete process.env[apiKeyName];
+      if (originalApiKey !== undefined) process.env.ANTHROPIC_API_KEY = originalApiKey;
+      else delete process.env.ANTHROPIC_API_KEY;
+      if (originalBillingKey !== undefined) process.env.ANTHROPIC_BILLING_KEY = originalBillingKey;
+      else delete process.env.ANTHROPIC_BILLING_KEY;
     });
 
     it('strips CLAUDECODE from the returned env', () => {
@@ -90,37 +92,58 @@ describe('Claude CLI Detection', () => {
     });
 
     it('strips ANTHROPIC_API_KEY from the returned env', () => {
-      process.env[apiKeyName] = 'sk-ant-api03-test';
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-api03-test';
       const env = prepareClaudeSpawnEnv();
-      expect(env[apiKeyName]).toBeUndefined();
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
     });
 
     it('does not mutate process.env', () => {
       process.env.CLAUDECODE = '1';
-      process.env[apiKeyName] = 'sk-ant-api03-test';
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-api03-test';
       prepareClaudeSpawnEnv();
       expect(process.env.CLAUDECODE).toBe('1');
-      expect(process.env[apiKeyName]).toBe('sk-ant-api03-test');
+      expect(process.env.ANTHROPIC_API_KEY).toBe('sk-ant-api03-test');
     });
 
-    it('preserves other env vars (PATH, HOME, ANTHROPIC_BILLING_KEY)', () => {
-      process.env[apiKeyName] = 'sk-ant-api03-test';
+    it('preserves ANTHROPIC_BILLING_KEY (the legitimate SDK key the CLI ignores)', () => {
+      // Set explicitly so the test passes/fails the same way regardless of whether
+      // the surrounding env had BILLING_KEY set — the previous version silently
+      // skipped this assertion in environments without it.
+      process.env.ANTHROPIC_BILLING_KEY = 'sk-ant-billing-test';
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-api03-test';
+      const env = prepareClaudeSpawnEnv();
+      expect(env.ANTHROPIC_BILLING_KEY).toBe('sk-ant-billing-test');
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    });
+
+    it('preserves PATH and HOME', () => {
       const env = prepareClaudeSpawnEnv();
       expect(env.PATH).toBe(process.env.PATH);
       expect(env.HOME).toBe(process.env.HOME);
-      // ANTHROPIC_BILLING_KEY is the legitimate key for crux SDK calls and must NOT be stripped
-      // (the claude CLI ignores it; only ANTHROPIC_API_KEY triggers the API-billing switch)
-      if (process.env.ANTHROPIC_BILLING_KEY) {
-        expect(env.ANTHROPIC_BILLING_KEY).toBe(process.env.ANTHROPIC_BILLING_KEY);
-      }
     });
 
     it('handles env where neither CLAUDECODE nor ANTHROPIC_API_KEY is set', () => {
       delete process.env.CLAUDECODE;
-      delete process.env[apiKeyName];
+      delete process.env.ANTHROPIC_API_KEY;
       const env = prepareClaudeSpawnEnv();
       expect(env.CLAUDECODE).toBeUndefined();
-      expect(env[apiKeyName]).toBeUndefined();
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    });
+
+    it('accepts a custom base env and strips from it (e.g. env with TMPDIR override)', () => {
+      const base: NodeJS.ProcessEnv = {
+        ...process.env,
+        TMPDIR: '/tmp/tsx-slot-a3',
+        ANTHROPIC_API_KEY: 'sk-ant-api03-test',
+        CLAUDECODE: '1',
+      };
+      const env = prepareClaudeSpawnEnv(base);
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(env.CLAUDECODE).toBeUndefined();
+      expect(env.TMPDIR).toBe('/tmp/tsx-slot-a3');
+      // Does not mutate the passed-in base
+      expect(base.ANTHROPIC_API_KEY).toBe('sk-ant-api03-test');
+      expect(base.CLAUDECODE).toBe('1');
     });
   });
 });

--- a/crux/lib/claude-cli.ts
+++ b/crux/lib/claude-cli.ts
@@ -36,8 +36,8 @@ export function isInsideClaudeCodeSession(): boolean {
  *
  * See QUA-1010 / QUA-612.
  */
-export function prepareClaudeSpawnEnv(): NodeJS.ProcessEnv {
-  const env = { ...process.env };
+export function prepareClaudeSpawnEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env = { ...base };
   delete env.CLAUDECODE;
   delete env.ANTHROPIC_API_KEY; // anthropic-billing-key-remap-ok
   return env;

--- a/crux/lib/claude-cli.ts
+++ b/crux/lib/claude-cli.ts
@@ -24,6 +24,26 @@ export function isInsideClaudeCodeSession(): boolean {
 }
 
 /**
+ * Prepare env vars for spawning the `claude` CLI as a subprocess.
+ *
+ * - Deletes CLAUDECODE so nested `claude` spawns work inside a Claude Code
+ *   session (without this, nested spawning hangs reliably).
+ * - Deletes ANTHROPIC_API_KEY so the subprocess uses our OAuth Claude Code
+ *   subscription, not API-direct billing. `.env.base` carries the key for
+ *   crux's internal API-direct callers (which use ANTHROPIC_BILLING_KEY but
+ *   may also have ANTHROPIC_API_KEY set for ad-hoc tools); the `claude` CLI
+ *   silently switches to API billing if it inherits the key.
+ *
+ * See QUA-1010 / QUA-612.
+ */
+export function prepareClaudeSpawnEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.CLAUDECODE;
+  delete env.ANTHROPIC_API_KEY; // anthropic-billing-key-remap-ok
+  return env;
+}
+
+/**
  * Check if the `claude` CLI binary is available and can be spawned.
  * Result is cached after the first call.
  *
@@ -35,10 +55,8 @@ export function isClaudeCliAvailable(): boolean {
 
   try {
     // Try to run `claude --version` — quick, no side effects
-    const env = { ...process.env };
-    delete env.CLAUDECODE; // Allow nested spawning check
     execSync('claude --version', {
-      env,
+      env: prepareClaudeSpawnEnv(),
       stdio: 'pipe',
       timeout: 5000,
     });


### PR DESCRIPTION
## Summary

Fixes QUA-1010

Six remaining `claude` CLI spawn sites in `crux/` were leaking `ANTHROPIC_API_KEY` from `.env.base` into the subprocess env, silently switching the spawned `claude` from OAuth subscription to API-direct billing. PR #4798 fixed the first site (`crux/pr-patrol/execution.ts`) — this PR fixes the remaining six.

## Changes

Extracted a `prepareClaudeSpawnEnv()` helper in `crux/lib/claude-cli.ts` that strips both `CLAUDECODE` and `ANTHROPIC_API_KEY` from a copy of `process.env`. Seven total spawn sites for the same pattern (6 fixed here + 1 in pr-patrol with extra unattended-run warning logic) is past the threshold where a helper is warranted by `.claude/rules/implementation-quality.md`.

Sites updated:
- `crux/authoring/creator/synthesis.ts`
- `crux/authoring/creator/validation.ts`
- `crux/authoring/creator/deployment.ts`
- `crux/authoring/page-improver/api.ts` (also drops a stale comment that incorrectly said "No need to strip ANTHROPIC_API_KEY")
- `crux/lib/claude-cli.ts` (the `claude --version` detection probe)
- `crux/lib/agent-workspace/dispatch.ts` — 7th spawn site, NOT in the original QUA-1010 audit; caught by `/agent-review-pr`. The `./ws dispatch` headless worker spawn was inheriting full `process.env` because `realDispatchEnv()` did not pass `env` to `cpSpawn`. This is exactly the kind of long-running automated agent the QUA-1010 fix is meant to protect.

`crux/pr-patrol/execution.ts` is intentionally **not** refactored to use the helper. It carries additional "fail-loud" warning logic specific to unattended overnight runs (warn loudly when the key was set so an operator can see the diagnostic). Folding that into the helper would either lose the warning at the 6 newly-migrated sites (which are typically operator-invoked with visible output) or add complexity to the helper for a single caller's needs.

## Why a helper?

`.claude/rules/implementation-quality.md` says "Three similar lines is better than a premature abstraction." Seven call sites of an identical pattern with a security-relevant invariant (don't leak the OAuth-bypassing key) is past that threshold — centralizing the pattern in one place prevents future spawn sites from regressing.

## Tests

Added 6 tests for `prepareClaudeSpawnEnv` covering:
- CLAUDECODE strip
- ANTHROPIC_API_KEY strip
- No `process.env` mutation invariant
- ANTHROPIC_BILLING_KEY (legitimate SDK key) preserved — set explicitly so the assertion always runs
- PATH and HOME preserved
- No-op when neither var is set

Plus the dispatch.ts fix runs against the existing 55 dispatch.ts tests (FakeDispatchEnv unaffected — it doesn't actually spawn). Total 81 tests pass for files touched in this PR.

Adversarial test confirmed: with `CLAUDECODE`, `ANTHROPIC_API_KEY`, `ANTHROPIC_BILLING_KEY`, `OPENROUTER_API_KEY`, and `LINEAR_API_KEY` all set in `process.env`, only `CLAUDECODE` and `ANTHROPIC_API_KEY` are removed from the returned env, and subsequent `process.env` mutations don't leak into the returned object.

## Did NOT pursue option B

QUA-1010 offered (A) Surgical: delete at each spawn site, or (B) Root: remove `ANTHROPIC_API_KEY` from `.env.base` entirely. Going with (A) — lower risk, matches the PR patrol fix already shipped. (B) would require auditing all internal callers that legitimately need the API-direct key.

## Test plan

- [x] All 81 affected tests pass (claude-cli.test.ts + dispatch.test.ts)
- [x] /agent-review-pr ran: caught the 7th site, fixed before merge
- [x] Adversarial red-team test confirmed correct env stripping + no mutation
- [x] `validate-no-anthropic-api-key-read` passes (1429 files)
- [ ] CI green
