### PR TITLE
fix(dispatch): warn + surface early-error when ANTHROPIC_API_KEY is set (QUA-1057)

### DIFF
--- a/crux/commands/agent-workspace.ts
+++ b/crux/commands/agent-workspace.ts
@@ -982,16 +982,27 @@ async function dispatchCmd(args: string[], options: DispatchCliOptions): Promise
   }
 
   const { handle } = result;
+  const warnings = apiKeyWarning ? [apiKeyWarning] : [];
+  const basePayload = {
+    slot,
+    runId: handle.runId,
+    sessionId: handle.sessionId,
+    pid: handle.pid,
+    runDir: handle.runDir,
+    cwd,
+    startedAt: handle.startedAt,
+    cmd: handle.cmd,
+  };
 
   // Briefly poll for early errors so credit-low / auth failures surface as
   // dispatch failures instead of "Dispatched to slot aN" + silent death. See
-  // QUA-1057 for the original symptom.
-  const earlyError = await pollForEarlyDispatchError(env, handle.eventsFile);
+  // QUA-1057 for the original symptom. Healthy workers exit on the first
+  // events.jsonl write (~100ms); cold-spawn-die paths use the pidAlive guard.
+  const earlyError = await pollForEarlyDispatchError(env, handle.eventsFile, { pid: handle.pid });
   if (earlyError) {
     const statusSuffix = earlyError.status !== undefined ? ` (HTTP ${earlyError.status})` : '';
-    const apiKeyEnvName = 'ANTHROPIC_API_KEY'; // anthropic-billing-key-remap-ok
     const stripHint = apiKeyWarning
-      ? `\n  hint: parent env had ${apiKeyEnvName} set; even after stripping, the OAuth subscription itself may have failed (check 'claude /login').`
+      ? `\n  hint: parent env had the API key set; even after stripping, the OAuth subscription itself may have failed (check 'claude /login').`
       : '';
     const errorOutput =
       `Error: dispatched worker exited early on slot a${slot}: ${earlyError.message}${statusSuffix}\n` +
@@ -1002,22 +1013,7 @@ async function dispatchCmd(args: string[], options: DispatchCliOptions): Promise
     if (options.json) {
       return {
         exitCode: 2,
-        output: JSON.stringify(
-          {
-            slot,
-            runId: handle.runId,
-            sessionId: handle.sessionId,
-            pid: handle.pid,
-            runDir: handle.runDir,
-            cwd,
-            startedAt: handle.startedAt,
-            cmd: handle.cmd,
-            earlyError,
-            warnings: apiKeyWarning ? [apiKeyWarning] : [],
-          },
-          null,
-          2,
-        ),
+        output: JSON.stringify({ ...basePayload, earlyError, warnings }, null, 2),
       };
     }
     return { exitCode: 2, output: errorOutput };
@@ -1039,21 +1035,7 @@ async function dispatchCmd(args: string[], options: DispatchCliOptions): Promise
   if (options.json) {
     return {
       exitCode: 0,
-      output: JSON.stringify(
-        {
-          slot,
-          runId: handle.runId,
-          sessionId: handle.sessionId,
-          pid: handle.pid,
-          runDir: handle.runDir,
-          cwd,
-          startedAt: handle.startedAt,
-          cmd: handle.cmd,
-          warnings: apiKeyWarning ? [apiKeyWarning] : [],
-        },
-        null,
-        2,
-      ),
+      output: JSON.stringify({ ...basePayload, warnings }, null, 2),
     };
   }
   return { exitCode: 0, output };

--- a/crux/commands/agent-workspace.ts
+++ b/crux/commands/agent-workspace.ts
@@ -62,6 +62,8 @@ import {
   finalizeIfComplete as finalizeDispatchIfComplete,
   realDispatchEnv,
   isPermissionMode,
+  formatApiKeyWarning,
+  pollForEarlyDispatchError,
   type DispatchOptions,
   type PermissionMode,
 } from '../lib/agent-workspace/dispatch.ts';
@@ -965,6 +967,13 @@ async function dispatchCmd(args: string[], options: DispatchCliOptions): Promise
     tmpDir: ensureSlotTmpDir(slot),
   };
 
+  // Alarm bell for QUA-1010/QUA-1057: a parent shell with ANTHROPIC_API_KEY set
+  // (e.g., inherited from .env.base) used to make the dispatched worker silently
+  // die in ~160ms with "Credit balance is too low" because claude reads the key
+  // and switches to API-direct billing. We strip it inside spawnDetached, but
+  // also surface a warning so an operator can untangle the env if desired.
+  const apiKeyWarning = formatApiKeyWarning(process.env);
+
   let result;
   try {
     result = spawnDispatch(env, paths, dispatchOpts);
@@ -973,7 +982,50 @@ async function dispatchCmd(args: string[], options: DispatchCliOptions): Promise
   }
 
   const { handle } = result;
+
+  // Briefly poll for early errors so credit-low / auth failures surface as
+  // dispatch failures instead of "Dispatched to slot aN" + silent death. See
+  // QUA-1057 for the original symptom.
+  const earlyError = await pollForEarlyDispatchError(env, handle.eventsFile);
+  if (earlyError) {
+    const statusSuffix = earlyError.status !== undefined ? ` (HTTP ${earlyError.status})` : '';
+    const apiKeyEnvName = 'ANTHROPIC_API_KEY'; // anthropic-billing-key-remap-ok
+    const stripHint = apiKeyWarning
+      ? `\n  hint: parent env had ${apiKeyEnvName} set; even after stripping, the OAuth subscription itself may have failed (check 'claude /login').`
+      : '';
+    const errorOutput =
+      `Error: dispatched worker exited early on slot a${slot}: ${earlyError.message}${statusSuffix}\n` +
+      `  run:    ${handle.runId}\n` +
+      `  events: ${handle.eventsFile}\n` +
+      `  stderr: ${handle.stderrFile}` +
+      stripHint;
+    if (options.json) {
+      return {
+        exitCode: 2,
+        output: JSON.stringify(
+          {
+            slot,
+            runId: handle.runId,
+            sessionId: handle.sessionId,
+            pid: handle.pid,
+            runDir: handle.runDir,
+            cwd,
+            startedAt: handle.startedAt,
+            cmd: handle.cmd,
+            earlyError,
+            warnings: apiKeyWarning ? [apiKeyWarning] : [],
+          },
+          null,
+          2,
+        ),
+      };
+    }
+    return { exitCode: 2, output: errorOutput };
+  }
+
+  const successHeader = apiKeyWarning ? `${apiKeyWarning}\n\n` : '';
   const output =
+    successHeader +
     `Dispatched to slot a${slot}${cwdNote}\n` +
     `  run:      ${handle.runId}\n` +
     `  session:  ${handle.sessionId}\n` +
@@ -997,6 +1049,7 @@ async function dispatchCmd(args: string[], options: DispatchCliOptions): Promise
           cwd,
           startedAt: handle.startedAt,
           cmd: handle.cmd,
+          warnings: apiKeyWarning ? [apiKeyWarning] : [],
         },
         null,
         2,

--- a/crux/lib/agent-workspace/__tests__/dispatch.test.ts
+++ b/crux/lib/agent-workspace/__tests__/dispatch.test.ts
@@ -20,6 +20,8 @@ import {
   finalizeIfComplete,
   isPermissionMode,
   PERMISSION_MODES,
+  formatApiKeyWarning,
+  pollForEarlyDispatchError,
   type DispatchEnv,
   type RunMeta,
 } from '../dispatch.ts';
@@ -794,5 +796,181 @@ describe('finalizeIfComplete', () => {
     const out = finalizeIfComplete(env, paths, rp, BASE_META);
     expect(out.completedAt).toBeUndefined();
     expect(readCurrent(env, paths)).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatApiKeyWarning + pollForEarlyDispatchError (QUA-1010 / QUA-1057)
+// ---------------------------------------------------------------------------
+
+describe('formatApiKeyWarning', () => {
+  it('returns null when ANTHROPIC_API_KEY is not set', () => {
+    expect(formatApiKeyWarning({})).toBeNull();
+    expect(formatApiKeyWarning({ PATH: '/usr/bin', HOME: '/root' })).toBeNull();
+  });
+
+  it('returns a warning string referencing both QUA tickets when the key is set', () => {
+    const warning = formatApiKeyWarning({ ANTHROPIC_API_KEY: 'sk-ant-api03-test' });
+    expect(warning).not.toBeNull();
+    expect(warning).toContain('ANTHROPIC_API_KEY');
+    expect(warning).toContain('OAuth');
+    // Cross-link both tickets so future-grep can find this codepath.
+    expect(warning).toContain('QUA-1010');
+    expect(warning).toContain('QUA-1057');
+  });
+
+  it('treats an empty-string key as "not set" (matches the operator workaround)', () => {
+    // The documented workaround is `ANTHROPIC_API_KEY="" ./ws dispatch ...`,
+    // which leaves the env var present-but-empty. Empty string is falsy in
+    // `claude` itself (it falls back to OAuth), so the warning should not fire.
+    expect(formatApiKeyWarning({ ANTHROPIC_API_KEY: '' })).toBeNull();
+  });
+});
+
+describe('pollForEarlyDispatchError', () => {
+  /** Synchronous wait shim for the poll loop — yields to the microtask queue. */
+  const noWait = async (_ms: number) => { /* no-op */ };
+
+  it('returns null when no error result has been written before the deadline', async () => {
+    const env = new FakeEnv();
+    const paths = dispatchPaths('/lw/a1');
+    const rp = runPaths(paths, 'r1');
+    // No events file at all → poll runs to completion and returns null.
+    const r = await pollForEarlyDispatchError(env, rp.eventsFile, {
+      deadlineMs: 5,
+      intervalMs: 1,
+      wait: noWait,
+    });
+    expect(r).toBeNull();
+  });
+
+  it('returns null when only non-error events have been written (worker is healthy)', async () => {
+    const env = new FakeEnv();
+    const paths = dispatchPaths('/lw/a1');
+    const rp = runPaths(paths, 'r1');
+    env.files.set(
+      rp.eventsFile,
+      JSON.stringify({ type: 'system', subtype: 'init', model: 'sonnet' }) + '\n' +
+        JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'working' }] } }) + '\n',
+    );
+    const r = await pollForEarlyDispatchError(env, rp.eventsFile, {
+      deadlineMs: 5,
+      intervalMs: 1,
+      wait: noWait,
+    });
+    expect(r).toBeNull();
+  });
+
+  it('surfaces a credit-low error result with both message and HTTP status', async () => {
+    const env = new FakeEnv();
+    const paths = dispatchPaths('/lw/a1');
+    const rp = runPaths(paths, 'r1');
+    // The exact shape we observe in events.jsonl when ANTHROPIC_API_KEY has zero credits.
+    env.files.set(
+      rp.eventsFile,
+      JSON.stringify({
+        type: 'result',
+        is_error: true,
+        api_error_status: 400,
+        result: 'Credit balance is too low',
+        duration_ms: 160,
+      }) + '\n',
+    );
+    const r = await pollForEarlyDispatchError(env, rp.eventsFile, {
+      deadlineMs: 50,
+      intervalMs: 1,
+      wait: noWait,
+    });
+    expect(r).toEqual({ message: 'Credit balance is too low', status: 400 });
+  });
+
+  it('surfaces an error without status when api_error_status is absent', async () => {
+    const env = new FakeEnv();
+    const paths = dispatchPaths('/lw/a1');
+    const rp = runPaths(paths, 'r1');
+    env.files.set(
+      rp.eventsFile,
+      JSON.stringify({ type: 'result', is_error: true, result: 'something else broke' }) + '\n',
+    );
+    const r = await pollForEarlyDispatchError(env, rp.eventsFile, {
+      deadlineMs: 50,
+      intervalMs: 1,
+      wait: noWait,
+    });
+    expect(r).toEqual({ message: 'something else broke' });
+  });
+
+  it('falls back to "unknown error" when the error result has no `result` string', async () => {
+    const env = new FakeEnv();
+    const paths = dispatchPaths('/lw/a1');
+    const rp = runPaths(paths, 'r1');
+    env.files.set(rp.eventsFile, JSON.stringify({ type: 'result', is_error: true }) + '\n');
+    const r = await pollForEarlyDispatchError(env, rp.eventsFile, {
+      deadlineMs: 50,
+      intervalMs: 1,
+      wait: noWait,
+    });
+    expect(r).toEqual({ message: 'unknown error' });
+  });
+
+  it('returns null when the result event reports success (is_error: false)', async () => {
+    // A worker that completed successfully in <1s during the poll window
+    // should NOT be flagged as an early error.
+    const env = new FakeEnv();
+    const paths = dispatchPaths('/lw/a1');
+    const rp = runPaths(paths, 'r1');
+    env.files.set(
+      rp.eventsFile,
+      JSON.stringify({
+        type: 'result',
+        is_error: false,
+        stop_reason: 'end_turn',
+        num_turns: 1,
+        duration_ms: 200,
+        total_cost_usd: 0.01,
+      }) + '\n',
+    );
+    const r = await pollForEarlyDispatchError(env, rp.eventsFile, {
+      deadlineMs: 5,
+      intervalMs: 1,
+      wait: noWait,
+    });
+    expect(r).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: realDispatchEnv must call prepareClaudeSpawnEnv (QUA-1010)
+// ---------------------------------------------------------------------------
+
+describe('realDispatchEnv ANTHROPIC_API_KEY stripping (QUA-1010 / QUA-1057)', () => {
+  it('strips ANTHROPIC_API_KEY from the env passed to the underlying spawn', async () => {
+    // We can't easily mock `child_process.spawn` without a module-level mock,
+    // so instead we exercise the same code path through the helper that
+    // realDispatchEnv uses (`prepareClaudeSpawnEnv`) and assert the contract
+    // that dispatch.ts depends on. This catches the regression of removing
+    // the import or accidentally passing raw `spawnEnv` again.
+    const { prepareClaudeSpawnEnv } = await import('../../claude-cli.ts');
+    const stripped = prepareClaudeSpawnEnv({
+      ANTHROPIC_API_KEY: 'sk-ant-api03-test',
+      CLAUDECODE: '1',
+      PATH: '/usr/bin',
+      TMPDIR: '/tmp/tsx-slot-a3',
+    });
+    expect(stripped.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(stripped.CLAUDECODE).toBeUndefined();
+    expect(stripped.PATH).toBe('/usr/bin');
+    expect(stripped.TMPDIR).toBe('/tmp/tsx-slot-a3');
+  });
+
+  it('source-level: dispatch.ts imports prepareClaudeSpawnEnv from claude-cli', async () => {
+    // Belt-and-braces: if a future refactor accidentally drops the import,
+    // this test fails. Reading the source is cheaper than a module mock.
+    const { readFileSync } = await import('fs');
+    const { fileURLToPath } = await import('url');
+    const here = fileURLToPath(import.meta.url);
+    const dispatchSrc = readFileSync(here.replace(/__tests__\/dispatch\.test\.ts$/, 'dispatch.ts'), 'utf-8');
+    expect(dispatchSrc).toMatch(/import\s*\{\s*prepareClaudeSpawnEnv\s*\}\s*from\s*['"]\.\.\/claude-cli\.ts['"]/);
+    expect(dispatchSrc).toMatch(/env:\s*prepareClaudeSpawnEnv\s*\(/);
   });
 });

--- a/crux/lib/agent-workspace/__tests__/dispatch.test.ts
+++ b/crux/lib/agent-workspace/__tests__/dispatch.test.ts
@@ -810,7 +810,7 @@ describe('formatApiKeyWarning', () => {
   });
 
   it('returns a warning string referencing both QUA tickets when the key is set', () => {
-    const warning = formatApiKeyWarning({ ANTHROPIC_API_KEY: 'sk-ant-api03-test' });
+    const warning = formatApiKeyWarning({ ANTHROPIC_API_KEY: 'fake-key-for-test' });
     expect(warning).not.toBeNull();
     expect(warning).toContain('ANTHROPIC_API_KEY');
     expect(warning).toContain('OAuth');
@@ -828,15 +828,23 @@ describe('formatApiKeyWarning', () => {
 });
 
 describe('pollForEarlyDispatchError', () => {
-  /** Synchronous wait shim for the poll loop — yields to the microtask queue. */
+  /** Synchronous wait shim for the poll loop. */
   const noWait = async (_ms: number) => { /* no-op */ };
+  const HEALTHY_PID = 99;
 
-  it('returns null when no error result has been written before the deadline', async () => {
+  function setupFakeEnv(opts?: { pidAlive?: boolean }): { env: FakeEnv; eventsFile: string } {
     const env = new FakeEnv();
     const paths = dispatchPaths('/lw/a1');
     const rp = runPaths(paths, 'r1');
-    // No events file at all → poll runs to completion and returns null.
-    const r = await pollForEarlyDispatchError(env, rp.eventsFile, {
+    if (opts?.pidAlive ?? true) env.alivePids.add(HEALTHY_PID);
+    return { env, eventsFile: rp.eventsFile };
+  }
+
+  it('returns null when no events have been written and the worker is still alive', async () => {
+    // Slow boot scenario — pid is alive, just hasn't emitted yet. Don't flag.
+    const { env, eventsFile } = setupFakeEnv();
+    const r = await pollForEarlyDispatchError(env, eventsFile, {
+      pid: HEALTHY_PID,
       deadlineMs: 5,
       intervalMs: 1,
       wait: noWait,
@@ -844,16 +852,45 @@ describe('pollForEarlyDispatchError', () => {
     expect(r).toBeNull();
   });
 
-  it('returns null when only non-error events have been written (worker is healthy)', async () => {
-    const env = new FakeEnv();
-    const paths = dispatchPaths('/lw/a1');
-    const rp = runPaths(paths, 'r1');
+  it('returns synthetic error when worker died before emitting any events', async () => {
+    // Cold-spawn-die: binary missing, OAuth expired with no API fallback, etc.
+    // No events.jsonl content + dead pid at deadline → flag it.
+    const { env, eventsFile } = setupFakeEnv({ pidAlive: false });
+    const r = await pollForEarlyDispatchError(env, eventsFile, {
+      pid: 99,
+      deadlineMs: 5,
+      intervalMs: 1,
+      wait: noWait,
+    });
+    expect(r).not.toBeNull();
+    expect(r?.message).toContain('exited before emitting any events');
+    expect(r?.status).toBeUndefined();
+  });
+
+  it('returns null on the first poll once the worker emits an init event (healthy fast path)', async () => {
+    const { env, eventsFile } = setupFakeEnv();
     env.files.set(
-      rp.eventsFile,
+      eventsFile,
+      JSON.stringify({ type: 'system', subtype: 'init', model: 'sonnet' }) + '\n',
+    );
+    const r = await pollForEarlyDispatchError(env, eventsFile, {
+      pid: HEALTHY_PID,
+      deadlineMs: 50,
+      intervalMs: 1,
+      wait: noWait,
+    });
+    expect(r).toBeNull();
+  });
+
+  it('returns null when the latest event is a non-error assistant message', async () => {
+    const { env, eventsFile } = setupFakeEnv();
+    env.files.set(
+      eventsFile,
       JSON.stringify({ type: 'system', subtype: 'init', model: 'sonnet' }) + '\n' +
         JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'working' }] } }) + '\n',
     );
-    const r = await pollForEarlyDispatchError(env, rp.eventsFile, {
+    const r = await pollForEarlyDispatchError(env, eventsFile, {
+      pid: HEALTHY_PID,
       deadlineMs: 5,
       intervalMs: 1,
       wait: noWait,
@@ -862,12 +899,10 @@ describe('pollForEarlyDispatchError', () => {
   });
 
   it('surfaces a credit-low error result with both message and HTTP status', async () => {
-    const env = new FakeEnv();
-    const paths = dispatchPaths('/lw/a1');
-    const rp = runPaths(paths, 'r1');
     // The exact shape we observe in events.jsonl when ANTHROPIC_API_KEY has zero credits.
+    const { env, eventsFile } = setupFakeEnv();
     env.files.set(
-      rp.eventsFile,
+      eventsFile,
       JSON.stringify({
         type: 'result',
         is_error: true,
@@ -876,7 +911,8 @@ describe('pollForEarlyDispatchError', () => {
         duration_ms: 160,
       }) + '\n',
     );
-    const r = await pollForEarlyDispatchError(env, rp.eventsFile, {
+    const r = await pollForEarlyDispatchError(env, eventsFile, {
+      pid: HEALTHY_PID,
       deadlineMs: 50,
       intervalMs: 1,
       wait: noWait,
@@ -885,14 +921,13 @@ describe('pollForEarlyDispatchError', () => {
   });
 
   it('surfaces an error without status when api_error_status is absent', async () => {
-    const env = new FakeEnv();
-    const paths = dispatchPaths('/lw/a1');
-    const rp = runPaths(paths, 'r1');
+    const { env, eventsFile } = setupFakeEnv();
     env.files.set(
-      rp.eventsFile,
+      eventsFile,
       JSON.stringify({ type: 'result', is_error: true, result: 'something else broke' }) + '\n',
     );
-    const r = await pollForEarlyDispatchError(env, rp.eventsFile, {
+    const r = await pollForEarlyDispatchError(env, eventsFile, {
+      pid: HEALTHY_PID,
       deadlineMs: 50,
       intervalMs: 1,
       wait: noWait,
@@ -900,12 +935,27 @@ describe('pollForEarlyDispatchError', () => {
     expect(r).toEqual({ message: 'something else broke' });
   });
 
+  it('drops a non-numeric api_error_status rather than passing it through unsanitized', async () => {
+    // Defensive: tolerate stream-json malformations without surfacing a wrongly-typed status.
+    const { env, eventsFile } = setupFakeEnv();
+    env.files.set(
+      eventsFile,
+      JSON.stringify({ type: 'result', is_error: true, result: 'broke', api_error_status: '500' }) + '\n',
+    );
+    const r = await pollForEarlyDispatchError(env, eventsFile, {
+      pid: HEALTHY_PID,
+      deadlineMs: 50,
+      intervalMs: 1,
+      wait: noWait,
+    });
+    expect(r).toEqual({ message: 'broke' });
+  });
+
   it('falls back to "unknown error" when the error result has no `result` string', async () => {
-    const env = new FakeEnv();
-    const paths = dispatchPaths('/lw/a1');
-    const rp = runPaths(paths, 'r1');
-    env.files.set(rp.eventsFile, JSON.stringify({ type: 'result', is_error: true }) + '\n');
-    const r = await pollForEarlyDispatchError(env, rp.eventsFile, {
+    const { env, eventsFile } = setupFakeEnv();
+    env.files.set(eventsFile, JSON.stringify({ type: 'result', is_error: true }) + '\n');
+    const r = await pollForEarlyDispatchError(env, eventsFile, {
+      pid: HEALTHY_PID,
       deadlineMs: 50,
       intervalMs: 1,
       wait: noWait,
@@ -916,11 +966,9 @@ describe('pollForEarlyDispatchError', () => {
   it('returns null when the result event reports success (is_error: false)', async () => {
     // A worker that completed successfully in <1s during the poll window
     // should NOT be flagged as an early error.
-    const env = new FakeEnv();
-    const paths = dispatchPaths('/lw/a1');
-    const rp = runPaths(paths, 'r1');
+    const { env, eventsFile } = setupFakeEnv();
     env.files.set(
-      rp.eventsFile,
+      eventsFile,
       JSON.stringify({
         type: 'result',
         is_error: false,
@@ -930,7 +978,8 @@ describe('pollForEarlyDispatchError', () => {
         total_cost_usd: 0.01,
       }) + '\n',
     );
-    const r = await pollForEarlyDispatchError(env, rp.eventsFile, {
+    const r = await pollForEarlyDispatchError(env, eventsFile, {
+      pid: HEALTHY_PID,
       deadlineMs: 5,
       intervalMs: 1,
       wait: noWait,
@@ -948,11 +997,11 @@ describe('realDispatchEnv ANTHROPIC_API_KEY stripping (QUA-1010 / QUA-1057)', ()
     // We can't easily mock `child_process.spawn` without a module-level mock,
     // so instead we exercise the same code path through the helper that
     // realDispatchEnv uses (`prepareClaudeSpawnEnv`) and assert the contract
-    // that dispatch.ts depends on. This catches the regression of removing
-    // the import or accidentally passing raw `spawnEnv` again.
+    // that dispatch.ts depends on. The TypeScript import in dispatch.ts is
+    // the structural enforcement; this test confirms behavior.
     const { prepareClaudeSpawnEnv } = await import('../../claude-cli.ts');
     const stripped = prepareClaudeSpawnEnv({
-      ANTHROPIC_API_KEY: 'sk-ant-api03-test',
+      ANTHROPIC_API_KEY: 'fake-key-for-test',
       CLAUDECODE: '1',
       PATH: '/usr/bin',
       TMPDIR: '/tmp/tsx-slot-a3',
@@ -961,16 +1010,5 @@ describe('realDispatchEnv ANTHROPIC_API_KEY stripping (QUA-1010 / QUA-1057)', ()
     expect(stripped.CLAUDECODE).toBeUndefined();
     expect(stripped.PATH).toBe('/usr/bin');
     expect(stripped.TMPDIR).toBe('/tmp/tsx-slot-a3');
-  });
-
-  it('source-level: dispatch.ts imports prepareClaudeSpawnEnv from claude-cli', async () => {
-    // Belt-and-braces: if a future refactor accidentally drops the import,
-    // this test fails. Reading the source is cheaper than a module mock.
-    const { readFileSync } = await import('fs');
-    const { fileURLToPath } = await import('url');
-    const here = fileURLToPath(import.meta.url);
-    const dispatchSrc = readFileSync(here.replace(/__tests__\/dispatch\.test\.ts$/, 'dispatch.ts'), 'utf-8');
-    expect(dispatchSrc).toMatch(/import\s*\{\s*prepareClaudeSpawnEnv\s*\}\s*from\s*['"]\.\.\/claude-cli\.ts['"]/);
-    expect(dispatchSrc).toMatch(/env:\s*prepareClaudeSpawnEnv\s*\(/);
   });
 });

--- a/crux/lib/agent-workspace/dispatch.ts
+++ b/crux/lib/agent-workspace/dispatch.ts
@@ -555,6 +555,8 @@ export interface EarlyDispatchError {
 }
 
 export interface PollForEarlyDispatchErrorOptions {
+  /** Pid of the spawned worker — used to distinguish "alive, just slow" from "dead, never emitted". */
+  pid: number;
   /** Total budget for the poll loop in ms. Default: 1000. */
   deadlineMs?: number;
   /** Sleep between poll attempts in ms. Default: 100. */
@@ -564,22 +566,31 @@ export interface PollForEarlyDispatchErrorOptions {
 }
 
 /**
- * Briefly poll the events file for an early `result` event with `is_error: true`.
+ * Briefly poll the events file for an early failure of a freshly-spawned worker.
  *
- * Catches the credit-low / auth-failure case where the spawned worker dies in
- * ~160ms with `is_error: true, api_error_status: 400, result: "Credit balance
- * is too low"` — without this surfacing, the dispatch command returns
- * "Dispatched to slot aN" successfully and the operator only learns of the
- * failure by tailing `events.jsonl`. See QUA-1057.
+ * Three cases:
+ * - Worker emits a `result` event with `is_error: true` (credit-low, auth-fail,
+ *   API-side rejection) → returns the decoded error. This is the original
+ *   QUA-1057 symptom: spawned `claude --print` dies in ~160ms with
+ *   `is_error: true, api_error_status: 400, result: "Credit balance is too low"`.
+ * - Worker writes any non-error event (init, assistant, etc.) → returns null
+ *   immediately. The presence of *any* event proves the worker booted; a
+ *   healthy run is then off the dispatcher's critical path.
+ * - Worker writes nothing at all and the pid is dead by deadline → returns a
+ *   synthetic "exited before emitting any events" error. Catches binary-missing,
+ *   OAuth-expired-with-no-API-fallback, and similar fail-before-stream-init
+ *   modes that QUA-1057's symptom-shaped detector would have missed.
+ * - Worker writes nothing but is still alive at deadline → returns null.
+ *   Slow boots (e.g. MCP servers initializing) shouldn't be flagged as failures.
  *
- * Returns null if no error is observed before the deadline. Returns the
- * decoded error otherwise. Healthy workers cost ~100ms of latency on the
- * happy path (one poll interval); credit-low etc. resolve in ~200ms.
+ * Latency: healthy dispatches incur one poll interval (~100ms) before returning
+ * because `claude` writes the `init` event well within the first interval.
+ * Credit-low etc. resolve in ~200ms. Cold-spawn-die cases pay the full deadline.
  */
 export async function pollForEarlyDispatchError(
   env: DispatchEnv,
   eventsFile: string,
-  opts: PollForEarlyDispatchErrorOptions = {},
+  opts: PollForEarlyDispatchErrorOptions,
 ): Promise<EarlyDispatchError | null> {
   const deadlineMs = opts.deadlineMs ?? 1000;
   const intervalMs = opts.intervalMs ?? 100;
@@ -587,20 +598,37 @@ export async function pollForEarlyDispatchError(
   const start = Date.now();
   while (Date.now() - start < deadlineMs) {
     await wait(intervalMs);
-    const result = readFinalResultEvent(env, eventsFile);
-    if (!result) continue;
-    // Any result event (error or success) means the worker has terminated:
-    // exit the poll early. We only surface the error case to the operator;
-    // a fast successful run just falls through to the normal "Dispatched" path.
-    if (result.kind === 'error' && result.raw) {
-      const raw = result.raw as Record<string, unknown>;
-      const msg = typeof raw.result === 'string' ? (raw.result as string) : 'unknown error';
-      const status = typeof raw.api_error_status === 'number' ? (raw.api_error_status as number) : undefined;
-      return status !== undefined ? { message: msg, status } : { message: msg };
+    const raw = env.readFile(eventsFile);
+    if (raw && raw.trim()) {
+      // Worker emitted at least one event — it's alive. If the *last* event is
+      // a terminal error result, surface it; otherwise the worker is making
+      // progress and the dispatcher can return immediately.
+      const result = readFinalResultEvent(env, eventsFile);
+      if (result && result.kind === 'error' && result.raw) {
+        return decodeEarlyError(result.raw as Record<string, unknown>);
+      }
+      return null;
     }
-    return null;
+  }
+  // Deadline reached with no events. Distinguish "alive but slow boot" (return
+  // null, dispatcher proceeds) from "died before stream-init" (synthetic error).
+  if (!env.pidAlive(opts.pid)) {
+    return {
+      message: 'worker exited before emitting any events (likely auth failure or missing binary — check stderr.log)',
+    };
   }
   return null;
+}
+
+/**
+ * Pull the operator-relevant fields out of a stream-json `result` event
+ * payload. Tolerant of missing/wrong-typed fields.
+ */
+function decodeEarlyError(raw: Record<string, unknown>): EarlyDispatchError {
+  const msg = typeof raw.result === 'string' ? raw.result : 'unknown error';
+  const out: EarlyDispatchError = { message: msg };
+  if (typeof raw.api_error_status === 'number') out.status = raw.api_error_status;
+  return out;
 }
 
 /**

--- a/crux/lib/agent-workspace/dispatch.ts
+++ b/crux/lib/agent-workspace/dispatch.ts
@@ -519,6 +519,91 @@ export function findResultEvent(events: EventSummary[]): EventSummary | null {
 }
 
 /**
+ * Sleep helper for poll loops. Extracted so tests can substitute a fake clock.
+ * Production callers pass `setTimeout` directly via the optional `wait` param.
+ */
+type WaitFn = (ms: number) => Promise<void>;
+const realWait: WaitFn = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Format the operator-facing warning that fires when ANTHROPIC_API_KEY is set
+ * in the parent env. The strip itself happens in `prepareClaudeSpawnEnv`; this
+ * helper produces the alarm-bell line so a successful dispatch leaves a trail
+ * an operator can see (per QUA-1010 patrol pattern). Returns `null` when no
+ * warning is needed.
+ *
+ * The warning lives here (not at the spawn site) because dispatch is async
+ * and the spawn site logs nowhere visible — we want the message to land in the
+ * `dispatchCmd` user-facing output.
+ */
+export function formatApiKeyWarning(env: NodeJS.ProcessEnv): string | null {
+  const apiKeyName = 'ANTHROPIC_API_KEY'; // anthropic-billing-key-remap-ok
+  if (!env[apiKeyName]) return null;
+  return (
+    `⚠ ${apiKeyName} was set in dispatch env — stripping it before spawning ` +
+    `claude so the OAuth subscription is used (see QUA-1010/QUA-1057). ` +
+    `Unset the key to silence this warning.`
+  );
+}
+
+/** Decoded early-error pulled out of the dispatched worker's first events. */
+export interface EarlyDispatchError {
+  /** Human-readable message lifted from the result event (`result` field). */
+  message: string;
+  /** API status code if present (`api_error_status`). */
+  status?: number;
+}
+
+export interface PollForEarlyDispatchErrorOptions {
+  /** Total budget for the poll loop in ms. Default: 1000. */
+  deadlineMs?: number;
+  /** Sleep between poll attempts in ms. Default: 100. */
+  intervalMs?: number;
+  /** Replaceable timer for tests. Default: real setTimeout. */
+  wait?: WaitFn;
+}
+
+/**
+ * Briefly poll the events file for an early `result` event with `is_error: true`.
+ *
+ * Catches the credit-low / auth-failure case where the spawned worker dies in
+ * ~160ms with `is_error: true, api_error_status: 400, result: "Credit balance
+ * is too low"` — without this surfacing, the dispatch command returns
+ * "Dispatched to slot aN" successfully and the operator only learns of the
+ * failure by tailing `events.jsonl`. See QUA-1057.
+ *
+ * Returns null if no error is observed before the deadline. Returns the
+ * decoded error otherwise. Healthy workers cost ~100ms of latency on the
+ * happy path (one poll interval); credit-low etc. resolve in ~200ms.
+ */
+export async function pollForEarlyDispatchError(
+  env: DispatchEnv,
+  eventsFile: string,
+  opts: PollForEarlyDispatchErrorOptions = {},
+): Promise<EarlyDispatchError | null> {
+  const deadlineMs = opts.deadlineMs ?? 1000;
+  const intervalMs = opts.intervalMs ?? 100;
+  const wait = opts.wait ?? realWait;
+  const start = Date.now();
+  while (Date.now() - start < deadlineMs) {
+    await wait(intervalMs);
+    const result = readFinalResultEvent(env, eventsFile);
+    if (!result) continue;
+    // Any result event (error or success) means the worker has terminated:
+    // exit the poll early. We only surface the error case to the operator;
+    // a fast successful run just falls through to the normal "Dispatched" path.
+    if (result.kind === 'error' && result.raw) {
+      const raw = result.raw as Record<string, unknown>;
+      const msg = typeof raw.result === 'string' ? (raw.result as string) : 'unknown error';
+      const status = typeof raw.api_error_status === 'number' ? (raw.api_error_status as number) : undefined;
+      return status !== undefined ? { message: msg, status } : { message: msg };
+    }
+    return null;
+  }
+  return null;
+}
+
+/**
  * Read only the final event line from the events file. Used by
  * `finalizeIfComplete` to avoid O(N) re-parsing the whole stream on every
  * dispatch-status call. The `result` event is always the *last* JSON line, so


### PR DESCRIPTION
## Summary

Finishes the QUA-1057 scope. The strip itself shipped earlier today in `378c03adf`; this PR makes the strip + downstream API-key failures observable to the operator instead of "Dispatched to slot aN" + silent ~160ms worker death.

- `formatApiKeyWarning` emits an alarm-bell line whenever the parent env has `ANTHROPIC_API_KEY` set, mirroring the QUA-1010 patrol pattern. Empty-string is treated as "not set" so the documented workaround (`ANTHROPIC_API_KEY="" ./ws dispatch`) doesn't keep yelling.
- `pollForEarlyDispatchError` briefly tails `events.jsonl` after spawn and returns at the first sign of life (any non-empty file), with a `pidAlive` cross-check at deadline. Three failure modes are caught:
  - error result event with `is_error: true` (credit-low, auth-fail) → exit 2 with decoded message + HTTP status
  - worker died before emitting any events (binary missing, OAuth expired) → exit 2 with synthetic "exited before emitting any events" message
  - slow boot (alive, no events yet) → null, dispatcher proceeds normally
- `dispatchCmd` exits **2** on early failure and prepends the warning to the standard "Dispatched..." output on success. JSON output gains `warnings: string[]` (and `earlyError` on the error path).

Latency: healthy dispatches incur one poll interval (~100ms) before returning because `claude` writes the `init` event well within the first interval. Credit-low etc. resolve in ~200ms.

Cross-links: QUA-1010 (patrol fix), QUA-612 (billing-key remap rule).

Fixes QUA-1057

## Test plan

- [x] `pnpm vitest run crux/lib/agent-workspace` — 230 tests pass (70 in `dispatch.test.ts`, including 13 new tests covering happy path, slow boot, cold-spawn-die, credit-low, malformed event payloads, and `prepareClaudeSpawnEnv` behavior)
- [x] `pnpm vitest run crux/lib/claude-cli.test.ts crux/commands/__tests__/agent-workspace-dispatch.test.ts` — pass
- [x] `npx tsx crux/validate/validate-no-anthropic-api-key-read.ts` — clean
- [x] Hostile reviewer subagent (`/agent-review-pr` Phase 3b) — 3 HIGH findings addressed in second commit (perf regression, narrow detection scope, latency docstring); MEDIUM cleanups (DRY payload, redundant casts, brittle source regex test) also addressed
- [ ] CI green
- [ ] Manual smoke after merge: `./ws dispatch <slot> "<short prompt>"` from a shell with `ANTHROPIC_API_KEY` set should print the alarm-bell warning, then either succeed (OAuth subscription) or surface "Credit balance is too low" + hint within ~200ms, never silently exit 0
