### PR TITLE
Human-readable URL slugs for /funding-programs and /funding-rounds (QUA-908)

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -731,7 +731,7 @@ async function main() {
 
   // Merge PG-backed personnel and grants into KB records (overrides YAML for these collections)
   if (database.kb && !CONTENT_ONLY) {
-    const pgRecordCounts = await mergePGRecordsIntoKB(database.kb);
+    const pgRecordCounts = await mergePGRecordsIntoKB(database.kb, { stableIdToSlug });
     const pgTotal = pgRecordCounts.personnel + pgRecordCounts.grants + pgRecordCounts.fundingRounds + pgRecordCounts.investments + pgRecordCounts.equityPositions + pgRecordCounts.divisions + pgRecordCounts.fundingPrograms + pgRecordCounts.divisionPersonnel + pgRecordCounts.entityEvents + pgRecordCounts.entityAssessments + pgRecordCounts.publications;
     if (pgTotal > 0) {
       const parts = [

--- a/apps/web/scripts/lib/__tests__/record-slugs.test.mjs
+++ b/apps/web/scripts/lib/__tests__/record-slugs.test.mjs
@@ -1,0 +1,199 @@
+/**
+ * Tests for record-slugs.mjs (QUA-908).
+ */
+
+import { describe, it, expect } from "vitest";
+import { slugify, candidateSlugs, assignSlugs } from "../record-slugs.mjs";
+
+describe("slugify", () => {
+  it("lowercases and hyphenates", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+  });
+
+  it("collapses runs of non-alphanumerics", () => {
+    expect(slugify("Foo --- Bar // Baz")).toBe("foo-bar-baz");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(slugify("--Hello--")).toBe("hello");
+  });
+
+  it("strips diacritics", () => {
+    expect(slugify("Café Naïve")).toBe("cafe-naive");
+  });
+
+  it("returns empty string for null/undefined/empty", () => {
+    expect(slugify(null)).toBe("");
+    expect(slugify(undefined)).toBe("");
+    expect(slugify("")).toBe("");
+  });
+
+  it("truncates to 80 chars without trailing hyphen", () => {
+    const long = "a".repeat(100);
+    expect(slugify(long).length).toBe(80);
+    const longMixed = "ab-".repeat(40);
+    const result = slugify(longMixed);
+    expect(result.length).toBeLessThanOrEqual(80);
+    expect(result.endsWith("-")).toBe(false);
+  });
+
+  it("handles names with currency and punctuation", () => {
+    expect(slugify("Series A — $50M Round")).toBe("series-a-50m-round");
+  });
+});
+
+describe("candidateSlugs", () => {
+  const ownerSlugs = new Map([
+    ["sid_anthropic1", "anthropic"],
+    ["sid_xai1234567", "xai"],
+  ]);
+  const getOwnerSlug = (id) => ownerSlugs.get(id) ?? null;
+
+  it("for funding-rounds, always namespaces by owner when owner exists", () => {
+    const record = {
+      key: "vjzygxG2V9",
+      ownerEntityId: "sid_anthropic1",
+      fields: { name: "Series G" },
+    };
+    const { base, withOwner } = candidateSlugs(record, "funding-rounds", getOwnerSlug);
+    expect(base).toBe("anthropic-series-g");
+    expect(withOwner).toBe("anthropic-series-g");
+  });
+
+  it("for funding-programs, base is the bare slug when no collision", () => {
+    const record = {
+      key: "pJ9oHvQ1Bb",
+      ownerEntityId: "sid_anthropic1",
+      fields: { name: "Rise Global Talent Program" },
+    };
+    const { base, withOwner } = candidateSlugs(record, "funding-programs", getOwnerSlug);
+    expect(base).toBe("rise-global-talent-program");
+    expect(withOwner).toBe("anthropic-rise-global-talent-program");
+  });
+
+  it("does not double-prefix when name already starts with owner slug", () => {
+    const record = {
+      key: "abc",
+      ownerEntityId: "sid_anthropic1",
+      fields: { name: "Anthropic Series G" },
+    };
+    const { withOwner } = candidateSlugs(record, "funding-rounds", getOwnerSlug);
+    expect(withOwner).toBe("anthropic-series-g");
+  });
+
+  it("falls back to bare slug when owner has no slug", () => {
+    const record = {
+      key: "abc",
+      ownerEntityId: "sid_unknown",
+      fields: { name: "Series A" },
+    };
+    const { base } = candidateSlugs(record, "funding-rounds", getOwnerSlug);
+    expect(base).toBe("series-a");
+  });
+
+  it("falls back to record.key when name is missing", () => {
+    const record = {
+      key: "abc1234567",
+      ownerEntityId: "sid_anthropic1",
+      fields: {},
+    };
+    const { base } = candidateSlugs(record, "funding-programs", getOwnerSlug);
+    // slugify("abc1234567") strips nothing — it's already alphanumeric
+    expect(base).toBe("abc1234567");
+  });
+});
+
+describe("assignSlugs", () => {
+  const owners = new Map([
+    ["sid_anthropic1", "anthropic"],
+    ["sid_xai1234567", "xai"],
+    ["sid_openai0000", "openai"],
+  ]);
+  const getOwnerSlug = (id) => owners.get(id) ?? null;
+
+  it("assigns unique slugs to distinct funding-programs records", () => {
+    const records = [
+      { key: "AAAAAAAAAA", ownerEntityId: "sid_anthropic1", fields: { name: "Rise Talent" } },
+      { key: "BBBBBBBBBB", ownerEntityId: "sid_openai0000", fields: { name: "Superalignment Fast Grants" } },
+    ];
+    assignSlugs(records, "funding-programs", getOwnerSlug);
+    expect(records[0].slug).toBe("rise-talent");
+    expect(records[1].slug).toBe("superalignment-fast-grants");
+  });
+
+  it("namespaces colliding funding-program names by owner", () => {
+    const records = [
+      { key: "AAAAAAAAAA", ownerEntityId: "sid_anthropic1", fields: { name: "Open Call" } },
+      { key: "BBBBBBBBBB", ownerEntityId: "sid_openai0000", fields: { name: "Open Call" } },
+    ];
+    assignSlugs(records, "funding-programs", getOwnerSlug);
+    const slugs = records.map((r) => r.slug).sort();
+    expect(slugs).toEqual(["anthropic-open-call", "openai-open-call"]);
+    expect(new Set(slugs).size).toBe(2);
+  });
+
+  it("namespaces all funding-rounds by company even without collision", () => {
+    const records = [
+      { key: "AAAAAAAAAA", ownerEntityId: "sid_xai1234567", fields: { name: "Series E" } },
+      { key: "BBBBBBBBBB", ownerEntityId: "sid_anthropic1", fields: { name: "Series G" } },
+    ];
+    assignSlugs(records, "funding-rounds", getOwnerSlug);
+    const slugs = records.map((r) => r.slug).sort();
+    expect(slugs).toEqual(["anthropic-series-g", "xai-series-e"]);
+  });
+
+  it("appends a 4-char suffix when even owner-prefixed slug collides", () => {
+    // Two rounds with the same name at the same company
+    const records = [
+      { key: "AAAAAAAAAA", ownerEntityId: "sid_anthropic1", fields: { name: "Series A" } },
+      { key: "BBBBBBBBBB", ownerEntityId: "sid_anthropic1", fields: { name: "Series A" } },
+    ];
+    assignSlugs(records, "funding-rounds", getOwnerSlug);
+    const slugs = records.map((r) => r.slug).sort();
+    // First wins the un-suffixed slot (sorted by key); second gets suffix.
+    expect(slugs).toEqual(["anthropic-series-a", "anthropic-series-a-bbbb"]);
+  });
+
+  it("is deterministic regardless of input order", () => {
+    const r1 = { key: "AAAAAAAAAA", ownerEntityId: "sid_anthropic1", fields: { name: "Open Call" } };
+    const r2 = { key: "BBBBBBBBBB", ownerEntityId: "sid_openai0000", fields: { name: "Open Call" } };
+
+    const forward = [{ ...r1 }, { ...r2 }];
+    const reverse = [{ ...r2 }, { ...r1 }];
+    assignSlugs(forward, "funding-programs", getOwnerSlug);
+    assignSlugs(reverse, "funding-programs", getOwnerSlug);
+
+    const fwd = new Map(forward.map((r) => [r.key, r.slug]));
+    const rev = new Map(reverse.map((r) => [r.key, r.slug]));
+    expect(fwd.get("AAAAAAAAAA")).toBe(rev.get("AAAAAAAAAA"));
+    expect(fwd.get("BBBBBBBBBB")).toBe(rev.get("BBBBBBBBBB"));
+  });
+
+  it("falls back gracefully when name and owner both missing", () => {
+    const records = [
+      { key: "ABCDEFGHIJ", ownerEntityId: "", fields: {} },
+    ];
+    assignSlugs(records, "funding-programs", () => null);
+    expect(records[0].slug).toBeTruthy();
+    expect(records[0].slug).toBe("abcdefghij");
+  });
+
+  it("handles empty record list", () => {
+    /** @type {any[]} */
+    const records = [];
+    expect(() => assignSlugs(records, "funding-programs", getOwnerSlug)).not.toThrow();
+  });
+
+  it("produces only URL-safe characters", () => {
+    const records = [
+      { key: "AAAAAAAAAA", ownerEntityId: "sid_xai1234567", fields: { name: "Series E — $6B / lead Valor!" } },
+      { key: "BBBBBBBBBB", ownerEntityId: "sid_anthropic1", fields: { name: "Investments in (claude)?" } },
+    ];
+    assignSlugs(records, "funding-rounds", getOwnerSlug);
+    for (const r of records) {
+      expect(r.slug).toMatch(/^[a-z0-9-]+$/);
+      expect(r.slug.startsWith("-")).toBe(false);
+      expect(r.slug.endsWith("-")).toBe(false);
+    }
+  });
+});

--- a/apps/web/scripts/lib/__tests__/record-slugs.test.mjs
+++ b/apps/web/scripts/lib/__tests__/record-slugs.test.mjs
@@ -49,25 +49,14 @@ describe("candidateSlugs", () => {
   ]);
   const getOwnerSlug = (id) => ownerSlugs.get(id) ?? null;
 
-  it("for funding-rounds, always namespaces by owner when owner exists", () => {
-    const record = {
-      key: "vjzygxG2V9",
-      ownerEntityId: "sid_anthropic1",
-      fields: { name: "Series G" },
-    };
-    const { base, withOwner } = candidateSlugs(record, "funding-rounds", getOwnerSlug);
-    expect(base).toBe("anthropic-series-g");
-    expect(withOwner).toBe("anthropic-series-g");
-  });
-
-  it("for funding-programs, base is the bare slug when no collision", () => {
+  it("returns both bare and owner-prefixed forms", () => {
     const record = {
       key: "pJ9oHvQ1Bb",
       ownerEntityId: "sid_anthropic1",
       fields: { name: "Rise Global Talent Program" },
     };
-    const { base, withOwner } = candidateSlugs(record, "funding-programs", getOwnerSlug);
-    expect(base).toBe("rise-global-talent-program");
+    const { bare, withOwner } = candidateSlugs(record, getOwnerSlug);
+    expect(bare).toBe("rise-global-talent-program");
     expect(withOwner).toBe("anthropic-rise-global-talent-program");
   });
 
@@ -77,7 +66,8 @@ describe("candidateSlugs", () => {
       ownerEntityId: "sid_anthropic1",
       fields: { name: "Anthropic Series G" },
     };
-    const { withOwner } = candidateSlugs(record, "funding-rounds", getOwnerSlug);
+    const { bare, withOwner } = candidateSlugs(record, getOwnerSlug);
+    expect(bare).toBe("anthropic-series-g");
     expect(withOwner).toBe("anthropic-series-g");
   });
 
@@ -87,8 +77,9 @@ describe("candidateSlugs", () => {
       ownerEntityId: "sid_unknown",
       fields: { name: "Series A" },
     };
-    const { base } = candidateSlugs(record, "funding-rounds", getOwnerSlug);
-    expect(base).toBe("series-a");
+    const { bare, withOwner } = candidateSlugs(record, getOwnerSlug);
+    expect(bare).toBe("series-a");
+    expect(withOwner).toBe("series-a");
   });
 
   it("falls back to record.key when name is missing", () => {
@@ -97,9 +88,20 @@ describe("candidateSlugs", () => {
       ownerEntityId: "sid_anthropic1",
       fields: {},
     };
-    const { base } = candidateSlugs(record, "funding-programs", getOwnerSlug);
-    // slugify("abc1234567") strips nothing — it's already alphanumeric
-    expect(base).toBe("abc1234567");
+    const { bare } = candidateSlugs(record, getOwnerSlug);
+    // slugify("abc1234567") strips nothing — already alphanumeric
+    expect(bare).toBe("abc1234567");
+  });
+
+  it("returns owner slug alone when name is empty after slugifying", () => {
+    const record = {
+      key: "abc1234567",
+      ownerEntityId: "sid_anthropic1",
+      fields: { name: "   " },
+    };
+    const { withOwner } = candidateSlugs(record, getOwnerSlug);
+    // Whitespace-only name → empty bare slug → withOwner falls back to owner
+    expect(withOwner).toBe("anthropic-abc1234567");
   });
 });
 
@@ -152,6 +154,40 @@ describe("assignSlugs", () => {
     const slugs = records.map((r) => r.slug).sort();
     // First wins the un-suffixed slot (sorted by key); second gets suffix.
     expect(slugs).toEqual(["anthropic-series-a", "anthropic-series-a-bbbb"]);
+  });
+
+  it("never assigns a slug that shadows another record's legacy key", () => {
+    // Record B's name slugifies to a string that matches record A's key.
+    // Without the shadowing guard, /funding-programs/aaaaaaaaaa would
+    // resolve to B (slug match) instead of A (legacy key URL).
+    const records = [
+      { key: "aaaaaaaaaa", ownerEntityId: "sid_anthropic1", fields: { name: "Real Program" } },
+      { key: "BBBBBBBBBB", ownerEntityId: "sid_openai0000", fields: { name: "AAAAAAAAAA" } },
+    ];
+    assignSlugs(records, "funding-programs", getOwnerSlug);
+    const aSlug = records.find((r) => r.key === "aaaaaaaaaa").slug;
+    const bSlug = records.find((r) => r.key === "BBBBBBBBBB").slug;
+    expect(bSlug).not.toBe("aaaaaaaaaa");
+    // A keeps its bare slug; B falls through to owner-prefixed or suffixed
+    expect(aSlug).toBe("real-program");
+    expect(bSlug.startsWith("openai-aaaaaaaaaa") || bSlug.startsWith("aaaaaaaaaa-")).toBe(true);
+  });
+
+  it("falls through cleanly when both first and second choice are taken by other records", () => {
+    // Three records in the same collection, all colliding on bare name.
+    const records = [
+      { key: "AAAAAAAAAA", ownerEntityId: "sid_anthropic1", fields: { name: "Open Call" } },
+      { key: "BBBBBBBBBB", ownerEntityId: "sid_openai0000", fields: { name: "Open Call" } },
+      { key: "CCCCCCCCCC", ownerEntityId: "sid_xai1234567", fields: { name: "Open Call" } },
+    ];
+    assignSlugs(records, "funding-programs", getOwnerSlug);
+    const slugs = records.map((r) => r.slug);
+    // All three unique
+    expect(new Set(slugs).size).toBe(3);
+    // Each has the owner prefix (since bare collides 3-way)
+    for (const r of records) {
+      expect(r.slug).toMatch(/^(anthropic|openai|xai)-open-call/);
+    }
   });
 
   it("is deterministic regardless of input order", () => {

--- a/apps/web/scripts/lib/record-slugs.mjs
+++ b/apps/web/scripts/lib/record-slugs.mjs
@@ -1,33 +1,20 @@
 /**
- * Record slug generation for FactBase records served from PG.
- *
- * QUA-908: `/funding-programs/<10-char-id>` and `/funding-rounds/<10-char-id>`
- * exposed raw stableIds in the URL. This module generates human-readable URL
- * slugs from the record's display name (and owner-entity slug for namespacing
- * generic round names like "Series A").
- *
- * Slugs are assigned at build-time and stored on FactBaseRecordEntry.slug.
- * The 10-char `key` is preserved for verdict lookups, React keys, and
- * legacy-URL redirects in [id]/page.tsx.
+ * URL-slug generation for FactBase records served from PG (funding-programs
+ * and funding-rounds). Slugs are derived from the record's display name at
+ * build-time. The 10-char `key` is preserved for verdict lookups and
+ * legacy-URL redirects.
  *
  * Stability contract: same (name, ownerEntity, key) → same slug across
- * builds. Collisions are resolved deterministically by appending a 4-char
- * suffix derived from the record's key, never by build order.
+ * builds. Collisions are resolved deterministically (sorted by key), never
+ * by build order.
  */
 
-/**
- * Slugify a string: lowercase, replace non-alphanumerics with hyphens,
- * collapse runs, and trim to a reasonable URL length.
- *
- * @param {string} text
- * @returns {string}
- */
 export function slugify(text) {
   if (!text) return "";
   return String(text)
     .toLowerCase()
     .normalize("NFKD")
-    .replace(/\p{M}+/gu, "") // strip combining marks (diacritics)
+    .replace(/\p{M}+/gu, "")
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 80)
@@ -35,12 +22,11 @@ export function slugify(text) {
 }
 
 /**
- * Compute candidate slugs for a record: the bare-name slug and the
- * owner-prefixed form. Caller picks which to assign based on collisions.
+ * Compute candidate slugs for a record. `assignSlugs` picks `bare` or
+ * `withOwner` based on the collection's policy and collision state.
  *
- * If the bare-name slug already starts with (or equals) the owner slug —
- * e.g. name="Anthropic Series G" with ownerSlug="anthropic" — no double-
- * prefixing.
+ * Skips double-prefixing when the bare slug already starts with the owner
+ * slug (e.g. name "Anthropic Series G" + owner "anthropic").
  *
  * @param {{key: string, ownerEntityId: string, fields: Record<string, unknown>}} record
  * @param {(stableId: string) => string | null} getOwnerSlug
@@ -48,37 +34,33 @@ export function slugify(text) {
  */
 export function candidateSlugs(record, getOwnerSlug) {
   const rawName = typeof record.fields.name === "string" ? record.fields.name : "";
-  const baseSlug = slugify(rawName) || slugify(record.key);
+  const bare = slugify(rawName) || slugify(record.key);
   const ownerSlug = record.ownerEntityId ? getOwnerSlug(record.ownerEntityId) : null;
 
   let withOwner;
-  if (!ownerSlug) {
-    withOwner = baseSlug;
-  } else if (baseSlug === ownerSlug || baseSlug.startsWith(`${ownerSlug}-`)) {
-    withOwner = baseSlug;
+  if (!ownerSlug || bare === ownerSlug || bare.startsWith(`${ownerSlug}-`)) {
+    withOwner = bare;
   } else {
-    withOwner = baseSlug ? `${ownerSlug}-${baseSlug}` : ownerSlug;
+    withOwner = bare ? `${ownerSlug}-${bare}` : ownerSlug;
   }
 
-  return { bare: baseSlug, withOwner };
+  return { bare, withOwner };
 }
 
 /**
- * Assign a unique slug to every record in a collection. Mutates each record
- * to add a `slug` field. Two-pass: first try the preferred slug for the
- * collection; collisions cascade to owner-prefixed → 4-char key suffix.
+ * Assign a unique URL slug to every record in a collection. Mutates each
+ * record to add a `slug` field.
  *
- * For `funding-rounds`, the preferred slug is owner-prefixed (round names
- * like "Series A" recur at every funder, so namespacing is the default).
- * For `funding-programs`, the preferred slug is the bare name (program
- * names like "Rise Global Talent Program" are usually distinctive); a
- * cross-funder collision falls back to the owner-prefixed form.
+ * Cascade per record: first-choice → fallback → 4-char key-prefix suffix.
+ * For `funding-rounds`, first-choice is the owner-prefixed slug (round
+ * names like "Series A" recur at every funder, so namespacing is the
+ * contract — no fallback to bare). For `funding-programs`, first-choice
+ * is the bare name; cross-funder collisions fall back to owner-prefixed.
  *
- * Slugs are also guarded against shadowing other records' 10-char `key`
- * values: if a slugified name happens to equal another record's key, we
- * apply the suffix immediately so legacy `/funding-*\/<key>` URLs always
- * resolve to the right record. Without the guard, slug-first lookup in
- * `findProgramRecord` could return the wrong record.
+ * Slugs are guarded against equalling another record's 10-char `key` so
+ * legacy `/funding-*\/<key>` URLs always resolve to the right record (the
+ * detail-page lookup prefers slug; without the guard a slugified name
+ * matching a sibling's key could shadow the legacy URL).
  *
  * @param {Array<{key: string, ownerEntityId: string, fields: Record<string, unknown>, slug?: string}>} records
  * @param {string} collection
@@ -86,42 +68,28 @@ export function candidateSlugs(record, getOwnerSlug) {
  * @returns {Map<string, string>} Map of record.key → assigned slug.
  */
 export function assignSlugs(records, collection, getOwnerSlug) {
+  const preferOwner = collection === "funding-rounds";
   const candidates = records.map((r) => ({
     record: r,
     ...candidateSlugs(r, getOwnerSlug),
   }));
 
-  // For funding-rounds, the preferred slug is owner-prefixed — base names
-  // ("Series A") recur at every company. For funding-programs the bare
-  // form is preferred; only colliding ones need owner-prefixing.
-  const preferOwner = collection === "funding-rounds";
-
-  // Count first-choice slug occurrences so we know which need disambiguation.
   const firstChoiceCounts = new Map();
   for (const c of candidates) {
     const first = preferOwner ? c.withOwner : c.bare;
     firstChoiceCounts.set(first, (firstChoiceCounts.get(first) ?? 0) + 1);
   }
 
-  // Slug-vs-key shadowing guard: collect every record key so we never assign
-  // a slug that equals some other record's legacy URL identifier.
   const keys = new Set(records.map((r) => r.key));
-
   const taken = new Set();
   const assigned = new Map();
 
-  // Sort by record key so collision suffixes are stable across builds.
   candidates.sort((a, b) => a.record.key.localeCompare(b.record.key));
 
   for (const c of candidates) {
     const first = preferOwner ? c.withOwner : c.bare;
-    const second = preferOwner ? c.withOwner : c.withOwner;
-    // For funding-rounds (preferOwner): second === first, so no second-choice
-    // cascade — collisions go straight to the suffix path. Owner-prefixed
-    // slug is the contract; we never strip back to a bare round name.
-    // For funding-programs: second is withOwner (a real fallback before suffix).
+    const fallback = c.withOwner; // collapses to `first` for funding-rounds
 
-    // Cascade: first-choice → second-choice (when distinct) → suffixed.
     let candidate;
     if (
       (firstChoiceCounts.get(first) ?? 0) === 1 &&
@@ -130,11 +98,11 @@ export function assignSlugs(records, collection, getOwnerSlug) {
     ) {
       candidate = first;
     } else if (
-      first !== second &&
-      !taken.has(second) &&
-      !shadowsOtherKey(second, c.record.key, keys)
+      first !== fallback &&
+      !taken.has(fallback) &&
+      !shadowsOtherKey(fallback, c.record.key, keys)
     ) {
-      candidate = second;
+      candidate = fallback;
     } else {
       candidate = first;
     }
@@ -146,9 +114,9 @@ export function assignSlugs(records, collection, getOwnerSlug) {
       continue;
     }
 
-    // Need a suffix to disambiguate. Use the canonical 4-char prefix of the
-    // record's own key (lowercased, filtered) — deterministic across builds
-    // and ties the suffix to the right record.
+    // Suffix from the record's own key — deterministic and ties uniqueness
+    // back to the canonical id. The "|| 'x'" only fires for keys that are
+    // entirely non-alphanumeric, which 10-char base62 keys never are.
     const suffix = c.record.key.toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 4) || "x";
     let final = `${candidate}-${suffix}`;
     let n = 1;
@@ -163,11 +131,6 @@ export function assignSlugs(records, collection, getOwnerSlug) {
   return assigned;
 }
 
-/**
- * True when `slug` equals an existing record's `key`, but not the owning
- * record's own key. Prevents `/funding-rounds/<slug>` from shadowing the
- * legacy `/funding-rounds/<key>` URL of a different record.
- */
 function shadowsOtherKey(slug, ownKey, keys) {
   return slug !== ownKey && keys.has(slug);
 }

--- a/apps/web/scripts/lib/record-slugs.mjs
+++ b/apps/web/scripts/lib/record-slugs.mjs
@@ -35,54 +35,50 @@ export function slugify(text) {
 }
 
 /**
- * Compute a candidate slug for a single record.
+ * Compute candidate slugs for a record: the bare-name slug and the
+ * owner-prefixed form. Caller picks which to assign based on collisions.
  *
- * For funding-rounds, generic round names ("Series A", "Seed") are namespaced
- * by the owning company's slug. For funding-programs, names are usually
- * distinctive (e.g. "Rise Global Talent Program"), so we only namespace when
- * the base slug would collide.
+ * If the bare-name slug already starts with (or equals) the owner slug —
+ * e.g. name="Anthropic Series G" with ownerSlug="anthropic" — no double-
+ * prefixing.
  *
  * @param {{key: string, ownerEntityId: string, fields: Record<string, unknown>}} record
- * @param {string} collection - "funding-programs" or "funding-rounds"
  * @param {(stableId: string) => string | null} getOwnerSlug
- * @returns {{base: string, withOwner: string}}
+ * @returns {{bare: string, withOwner: string}}
  */
-export function candidateSlugs(record, collection, getOwnerSlug) {
-  const name =
-    typeof record.fields.name === "string" && record.fields.name.length > 0
-      ? record.fields.name
-      : record.key;
-  const baseSlug = slugify(name);
-  const ownerSlug = record.ownerEntityId
-    ? getOwnerSlug(record.ownerEntityId)
-    : null;
+export function candidateSlugs(record, getOwnerSlug) {
+  const rawName = typeof record.fields.name === "string" ? record.fields.name : "";
+  const baseSlug = slugify(rawName) || slugify(record.key);
+  const ownerSlug = record.ownerEntityId ? getOwnerSlug(record.ownerEntityId) : null;
 
-  // Compose the owner-prefixed candidate. If the base slug already starts
-  // with the owner slug (name has the company/org name baked in), don't
-  // double-prefix.
   let withOwner;
   if (!ownerSlug) {
     withOwner = baseSlug;
-  } else if (baseSlug.startsWith(`${ownerSlug}-`) || baseSlug === ownerSlug) {
+  } else if (baseSlug === ownerSlug || baseSlug.startsWith(`${ownerSlug}-`)) {
     withOwner = baseSlug;
   } else {
     withOwner = baseSlug ? `${ownerSlug}-${baseSlug}` : ownerSlug;
   }
 
-  // For funding-rounds, prefer the owner-prefixed form because round names
-  // are generic ("Series A" recurs at every funder). For funding-programs,
-  // the base form is fine until a collision forces us to disambiguate.
-  if (collection === "funding-rounds") {
-    return { base: withOwner, withOwner };
-  }
-  return { base: baseSlug || withOwner, withOwner };
+  return { bare: baseSlug, withOwner };
 }
 
 /**
  * Assign a unique slug to every record in a collection. Mutates each record
- * to add a `slug` field. Two-pass: first try the base slug; collisions get
- * the owner-prefixed slug; remaining collisions get a 4-char suffix from
- * the record key.
+ * to add a `slug` field. Two-pass: first try the preferred slug for the
+ * collection; collisions cascade to owner-prefixed → 4-char key suffix.
+ *
+ * For `funding-rounds`, the preferred slug is owner-prefixed (round names
+ * like "Series A" recur at every funder, so namespacing is the default).
+ * For `funding-programs`, the preferred slug is the bare name (program
+ * names like "Rise Global Talent Program" are usually distinctive); a
+ * cross-funder collision falls back to the owner-prefixed form.
+ *
+ * Slugs are also guarded against shadowing other records' 10-char `key`
+ * values: if a slugified name happens to equal another record's key, we
+ * apply the suffix immediately so legacy `/funding-*\/<key>` URLs always
+ * resolve to the right record. Without the guard, slug-first lookup in
+ * `findProgramRecord` could return the wrong record.
  *
  * @param {Array<{key: string, ownerEntityId: string, fields: Record<string, unknown>, slug?: string}>} records
  * @param {string} collection
@@ -90,50 +86,73 @@ export function candidateSlugs(record, collection, getOwnerSlug) {
  * @returns {Map<string, string>} Map of record.key → assigned slug.
  */
 export function assignSlugs(records, collection, getOwnerSlug) {
-  // Pre-compute candidates so we can detect collisions before assignment.
   const candidates = records.map((r) => ({
     record: r,
-    ...candidateSlugs(r, collection, getOwnerSlug),
+    ...candidateSlugs(r, getOwnerSlug),
   }));
 
-  // Count base-slug occurrences to decide which records need owner prefixing.
-  const baseCounts = new Map();
+  // For funding-rounds, the preferred slug is owner-prefixed — base names
+  // ("Series A") recur at every company. For funding-programs the bare
+  // form is preferred; only colliding ones need owner-prefixing.
+  const preferOwner = collection === "funding-rounds";
+
+  // Count first-choice slug occurrences so we know which need disambiguation.
+  const firstChoiceCounts = new Map();
   for (const c of candidates) {
-    baseCounts.set(c.base, (baseCounts.get(c.base) ?? 0) + 1);
+    const first = preferOwner ? c.withOwner : c.bare;
+    firstChoiceCounts.set(first, (firstChoiceCounts.get(first) ?? 0) + 1);
   }
+
+  // Slug-vs-key shadowing guard: collect every record key so we never assign
+  // a slug that equals some other record's legacy URL identifier.
+  const keys = new Set(records.map((r) => r.key));
 
   const taken = new Set();
   const assigned = new Map();
 
-  // Sort deterministically by record key so collision suffixes are stable
-  // across builds regardless of input order. Records are walked in this
-  // order; the first sees the un-suffixed slug, later collisions get the
-  // 4-char hash suffix.
+  // Sort by record key so collision suffixes are stable across builds.
   candidates.sort((a, b) => a.record.key.localeCompare(b.record.key));
 
   for (const c of candidates) {
+    const first = preferOwner ? c.withOwner : c.bare;
+    const second = preferOwner ? c.withOwner : c.withOwner;
+    // For funding-rounds (preferOwner): second === first, so no second-choice
+    // cascade — collisions go straight to the suffix path. Owner-prefixed
+    // slug is the contract; we never strip back to a bare round name.
+    // For funding-programs: second is withOwner (a real fallback before suffix).
+
+    // Cascade: first-choice → second-choice (when distinct) → suffixed.
     let candidate;
-    if ((baseCounts.get(c.base) ?? 0) > 1 && c.withOwner !== c.base) {
-      // Base slug is shared across multiple records — disambiguate by owner.
-      candidate = c.withOwner;
+    if (
+      (firstChoiceCounts.get(first) ?? 0) === 1 &&
+      !taken.has(first) &&
+      !shadowsOtherKey(first, c.record.key, keys)
+    ) {
+      candidate = first;
+    } else if (
+      first !== second &&
+      !taken.has(second) &&
+      !shadowsOtherKey(second, c.record.key, keys)
+    ) {
+      candidate = second;
     } else {
-      candidate = c.base;
+      candidate = first;
     }
 
-    if (!taken.has(candidate)) {
+    if (!taken.has(candidate) && !shadowsOtherKey(candidate, c.record.key, keys)) {
       taken.add(candidate);
       assigned.set(c.record.key, candidate);
       c.record.slug = candidate;
       continue;
     }
 
-    // Owner-prefix didn't disambiguate (e.g. two rounds at the same
-    // company with the same name, or two records with no owner slug).
-    // Fall back to a 4-char suffix from the record key.
+    // Need a suffix to disambiguate. Use the canonical 4-char prefix of the
+    // record's own key (lowercased, filtered) — deterministic across builds
+    // and ties the suffix to the right record.
     const suffix = c.record.key.toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 4) || "x";
     let final = `${candidate}-${suffix}`;
     let n = 1;
-    while (taken.has(final)) {
+    while (taken.has(final) || shadowsOtherKey(final, c.record.key, keys)) {
       final = `${candidate}-${suffix}-${n++}`;
     }
     taken.add(final);
@@ -142,4 +161,13 @@ export function assignSlugs(records, collection, getOwnerSlug) {
   }
 
   return assigned;
+}
+
+/**
+ * True when `slug` equals an existing record's `key`, but not the owning
+ * record's own key. Prevents `/funding-rounds/<slug>` from shadowing the
+ * legacy `/funding-rounds/<key>` URL of a different record.
+ */
+function shadowsOtherKey(slug, ownKey, keys) {
+  return slug !== ownKey && keys.has(slug);
 }

--- a/apps/web/scripts/lib/record-slugs.mjs
+++ b/apps/web/scripts/lib/record-slugs.mjs
@@ -1,0 +1,145 @@
+/**
+ * Record slug generation for FactBase records served from PG.
+ *
+ * QUA-908: `/funding-programs/<10-char-id>` and `/funding-rounds/<10-char-id>`
+ * exposed raw stableIds in the URL. This module generates human-readable URL
+ * slugs from the record's display name (and owner-entity slug for namespacing
+ * generic round names like "Series A").
+ *
+ * Slugs are assigned at build-time and stored on FactBaseRecordEntry.slug.
+ * The 10-char `key` is preserved for verdict lookups, React keys, and
+ * legacy-URL redirects in [id]/page.tsx.
+ *
+ * Stability contract: same (name, ownerEntity, key) → same slug across
+ * builds. Collisions are resolved deterministically by appending a 4-char
+ * suffix derived from the record's key, never by build order.
+ */
+
+/**
+ * Slugify a string: lowercase, replace non-alphanumerics with hyphens,
+ * collapse runs, and trim to a reasonable URL length.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function slugify(text) {
+  if (!text) return "";
+  return String(text)
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/\p{M}+/gu, "") // strip combining marks (diacritics)
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80)
+    .replace(/-+$/g, "");
+}
+
+/**
+ * Compute a candidate slug for a single record.
+ *
+ * For funding-rounds, generic round names ("Series A", "Seed") are namespaced
+ * by the owning company's slug. For funding-programs, names are usually
+ * distinctive (e.g. "Rise Global Talent Program"), so we only namespace when
+ * the base slug would collide.
+ *
+ * @param {{key: string, ownerEntityId: string, fields: Record<string, unknown>}} record
+ * @param {string} collection - "funding-programs" or "funding-rounds"
+ * @param {(stableId: string) => string | null} getOwnerSlug
+ * @returns {{base: string, withOwner: string}}
+ */
+export function candidateSlugs(record, collection, getOwnerSlug) {
+  const name =
+    typeof record.fields.name === "string" && record.fields.name.length > 0
+      ? record.fields.name
+      : record.key;
+  const baseSlug = slugify(name);
+  const ownerSlug = record.ownerEntityId
+    ? getOwnerSlug(record.ownerEntityId)
+    : null;
+
+  // Compose the owner-prefixed candidate. If the base slug already starts
+  // with the owner slug (name has the company/org name baked in), don't
+  // double-prefix.
+  let withOwner;
+  if (!ownerSlug) {
+    withOwner = baseSlug;
+  } else if (baseSlug.startsWith(`${ownerSlug}-`) || baseSlug === ownerSlug) {
+    withOwner = baseSlug;
+  } else {
+    withOwner = baseSlug ? `${ownerSlug}-${baseSlug}` : ownerSlug;
+  }
+
+  // For funding-rounds, prefer the owner-prefixed form because round names
+  // are generic ("Series A" recurs at every funder). For funding-programs,
+  // the base form is fine until a collision forces us to disambiguate.
+  if (collection === "funding-rounds") {
+    return { base: withOwner, withOwner };
+  }
+  return { base: baseSlug || withOwner, withOwner };
+}
+
+/**
+ * Assign a unique slug to every record in a collection. Mutates each record
+ * to add a `slug` field. Two-pass: first try the base slug; collisions get
+ * the owner-prefixed slug; remaining collisions get a 4-char suffix from
+ * the record key.
+ *
+ * @param {Array<{key: string, ownerEntityId: string, fields: Record<string, unknown>, slug?: string}>} records
+ * @param {string} collection
+ * @param {(stableId: string) => string | null} getOwnerSlug
+ * @returns {Map<string, string>} Map of record.key → assigned slug.
+ */
+export function assignSlugs(records, collection, getOwnerSlug) {
+  // Pre-compute candidates so we can detect collisions before assignment.
+  const candidates = records.map((r) => ({
+    record: r,
+    ...candidateSlugs(r, collection, getOwnerSlug),
+  }));
+
+  // Count base-slug occurrences to decide which records need owner prefixing.
+  const baseCounts = new Map();
+  for (const c of candidates) {
+    baseCounts.set(c.base, (baseCounts.get(c.base) ?? 0) + 1);
+  }
+
+  const taken = new Set();
+  const assigned = new Map();
+
+  // Sort deterministically by record key so collision suffixes are stable
+  // across builds regardless of input order. Records are walked in this
+  // order; the first sees the un-suffixed slug, later collisions get the
+  // 4-char hash suffix.
+  candidates.sort((a, b) => a.record.key.localeCompare(b.record.key));
+
+  for (const c of candidates) {
+    let candidate;
+    if ((baseCounts.get(c.base) ?? 0) > 1 && c.withOwner !== c.base) {
+      // Base slug is shared across multiple records — disambiguate by owner.
+      candidate = c.withOwner;
+    } else {
+      candidate = c.base;
+    }
+
+    if (!taken.has(candidate)) {
+      taken.add(candidate);
+      assigned.set(c.record.key, candidate);
+      c.record.slug = candidate;
+      continue;
+    }
+
+    // Owner-prefix didn't disambiguate (e.g. two rounds at the same
+    // company with the same name, or two records with no owner slug).
+    // Fall back to a 4-char suffix from the record key.
+    const suffix = c.record.key.toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 4) || "x";
+    let final = `${candidate}-${suffix}`;
+    let n = 1;
+    while (taken.has(final)) {
+      final = `${candidate}-${suffix}-${n++}`;
+    }
+    taken.add(final);
+    assigned.set(c.record.key, final);
+    c.record.slug = final;
+  }
+
+  return assigned;
+}

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -11,6 +11,7 @@
 
 import { createHash } from 'node:crypto';
 import { getServerUrl, getApiKey } from './wiki-server-env.mjs';
+import { assignSlugs as assignRecordSlugs } from './record-slugs.mjs';
 
 // ---------------------------------------------------------------------------
 // Shared ID detection helpers
@@ -1574,7 +1575,15 @@ export async function fetchFactsFromPG() {
   }
 }
 
-export async function mergePGRecordsIntoKB(kb) {
+/**
+ * @param {object} kb - The serialized KB object (mutated).
+ * @param {object} [opts]
+ * @param {Record<string, string>} [opts.stableIdToSlug] - Map of entity stableId → slug, used
+ *   to namespace funding-rounds slugs by their owning company (QUA-908). When omitted,
+ *   funding records still get slugs but cannot be owner-prefixed for collision resolution.
+ */
+export async function mergePGRecordsIntoKB(kb, opts = {}) {
+  const stableIdToSlug = opts.stableIdToSlug ?? {};
   const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  kb-pg: skipped (LONGTERMWIKI_SERVER_URL not set)');
@@ -1867,6 +1876,23 @@ export async function mergePGRecordsIntoKB(kb) {
     () => 'publications',
     publicationRowToRecordEntry,
   );
+
+  // --- Assign URL slugs to funding-programs and funding-rounds (QUA-908) ---
+  // Records' canonical 10-char keys leaked into URLs (`/funding-programs/pJ9oHvQ1Bb`).
+  // Generate human-readable slugs from the record name (and owner-entity slug for
+  // collision resolution). The 10-char key is preserved for verdict lookups and
+  // legacy-URL redirects in [id]/page.tsx.
+  const getOwnerSlug = (stableId) => stableIdToSlug[stableId] ?? null;
+  for (const collection of ['funding-programs', 'funding-rounds']) {
+    const allRecords = [];
+    for (const entityRecords of Object.values(kb.records)) {
+      const list = entityRecords[collection];
+      if (Array.isArray(list)) allRecords.push(...list);
+    }
+    if (allRecords.length > 0) {
+      assignRecordSlugs(allRecords, collection, getOwnerSlug);
+    }
+  }
 
   return {
     personnel: personnelCount,

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -1578,9 +1578,9 @@ export async function fetchFactsFromPG() {
 /**
  * @param {object} kb - The serialized KB object (mutated).
  * @param {object} [opts]
- * @param {Record<string, string>} [opts.stableIdToSlug] - Map of entity stableId → slug, used
- *   to namespace funding-rounds slugs by their owning company (QUA-908). When omitted,
- *   funding records still get slugs but cannot be owner-prefixed for collision resolution.
+ * @param {Record<string, string>} [opts.stableIdToSlug] - Map of entity stableId → slug.
+ *   Used to namespace funding-rounds slugs by their owning company. When omitted,
+ *   funding records still get slugs but cannot be owner-prefixed for collisions.
  */
 export async function mergePGRecordsIntoKB(kb, opts = {}) {
   const stableIdToSlug = opts.stableIdToSlug ?? {};
@@ -1877,11 +1877,9 @@ export async function mergePGRecordsIntoKB(kb, opts = {}) {
     publicationRowToRecordEntry,
   );
 
-  // --- Assign URL slugs to funding-programs and funding-rounds (QUA-908) ---
-  // Records' canonical 10-char keys leaked into URLs (`/funding-programs/pJ9oHvQ1Bb`).
-  // Generate human-readable slugs from the record name (and owner-entity slug for
-  // collision resolution). The 10-char key is preserved for verdict lookups and
-  // legacy-URL redirects in [id]/page.tsx.
+  // Assign URL slugs to funding-programs and funding-rounds. Records' canonical
+  // 10-char keys are preserved for verdict lookups and legacy-URL redirects in
+  // [id]/page.tsx; the slug becomes the user-facing URL identifier.
   const getOwnerSlug = (stableId) => stableIdToSlug[stableId] ?? null;
   for (const collection of ['funding-programs', 'funding-rounds']) {
     const allRecords = [];

--- a/apps/web/src/app/funding-programs/[id]/page.tsx
+++ b/apps/web/src/app/funding-programs/[id]/page.tsx
@@ -1,7 +1,7 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { getAllKBRecords } from "@/data/factbase";
+import { getAllKBRecords, type KBRecordEntry } from "@/data/factbase";
 import { getRecordVerdict } from "@/data/tablebase";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { ProfileStatCard } from "@/components/directory";
@@ -30,7 +30,18 @@ import { GrantsAwardedSection } from "./program-sections";
 
 export function generateStaticParams() {
   const allPrograms = getAllKBRecords("funding-programs");
-  return allPrograms.map((record) => ({ id: record.key }));
+  return allPrograms.map((record) => ({ id: record.slug ?? record.key }));
+}
+
+// ── Lookup helpers ─────────────────────────────────────────────────────
+
+/** Find a record by slug (preferred) or fall back to legacy 10-char key. */
+function findProgramRecord(idOrSlug: string): KBRecordEntry | undefined {
+  const allPrograms = getAllKBRecords("funding-programs");
+  return (
+    allPrograms.find((r) => r.slug === idOrSlug) ??
+    allPrograms.find((r) => r.key === idOrSlug)
+  );
 }
 
 // ── Metadata ───────────────────────────────────────────────────────────
@@ -41,8 +52,7 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const allPrograms = getAllKBRecords("funding-programs");
-  const record = allPrograms.find((r) => r.key === id);
+  const record = findProgramRecord(id);
   if (!record) {
     return { title: "Funding Program Not Found" };
   }
@@ -62,10 +72,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function FundingProgramDetailPage({ params }: PageProps) {
   const { id } = await params;
-  const allPrograms = getAllKBRecords("funding-programs");
-  const record = allPrograms.find((r) => r.key === id);
+  const record = findProgramRecord(id);
 
   if (!record) return notFound();
+
+  // Legacy URL: `/funding-programs/<10-char-key>` redirects to slug URL.
+  if (record.slug && record.slug !== id && record.key === id) {
+    redirect(`/funding-programs/${record.slug}`);
+  }
 
   const data = loadProgramPageData(record);
   const programVerdict = getRecordVerdict("funding-program", String(data.program.key));

--- a/apps/web/src/app/funding-programs/[id]/page.tsx
+++ b/apps/web/src/app/funding-programs/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound, redirect } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { getAllKBRecords, type KBRecordEntry } from "@/data/factbase";
+import { getAllKBRecords, findFactBaseRecordBySlugOrKey } from "@/data/factbase";
 import { getRecordVerdict } from "@/data/tablebase";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { ProfileStatCard } from "@/components/directory";
@@ -33,17 +33,6 @@ export function generateStaticParams() {
   return allPrograms.map((record) => ({ id: record.slug ?? record.key }));
 }
 
-// ── Lookup helpers ─────────────────────────────────────────────────────
-
-/** Find a record by slug (preferred) or fall back to legacy 10-char key. */
-function findProgramRecord(idOrSlug: string): KBRecordEntry | undefined {
-  const allPrograms = getAllKBRecords("funding-programs");
-  return (
-    allPrograms.find((r) => r.slug === idOrSlug) ??
-    allPrograms.find((r) => r.key === idOrSlug)
-  );
-}
-
 // ── Metadata ───────────────────────────────────────────────────────────
 
 interface PageProps {
@@ -52,7 +41,7 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const record = findProgramRecord(id);
+  const record = findFactBaseRecordBySlugOrKey("funding-programs", id);
   if (!record) {
     return { title: "Funding Program Not Found" };
   }
@@ -72,13 +61,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function FundingProgramDetailPage({ params }: PageProps) {
   const { id } = await params;
-  const record = findProgramRecord(id);
+  const record = findFactBaseRecordBySlugOrKey("funding-programs", id);
 
   if (!record) return notFound();
 
-  // Legacy URL: `/funding-programs/<10-char-key>` redirects to slug URL.
-  // findProgramRecord prefers slug match, so reaching `record.key === id`
-  // means slug match missed → request was by legacy key.
+  // Redirect legacy /funding-programs/<key> → /funding-programs/<slug>.
   if (record.slug && record.key === id) {
     redirect(`/funding-programs/${record.slug}`);
   }

--- a/apps/web/src/app/funding-programs/[id]/page.tsx
+++ b/apps/web/src/app/funding-programs/[id]/page.tsx
@@ -77,7 +77,9 @@ export default async function FundingProgramDetailPage({ params }: PageProps) {
   if (!record) return notFound();
 
   // Legacy URL: `/funding-programs/<10-char-key>` redirects to slug URL.
-  if (record.slug && record.slug !== id && record.key === id) {
+  // findProgramRecord prefers slug match, so reaching `record.key === id`
+  // means slug match missed → request was by legacy key.
+  if (record.slug && record.key === id) {
     redirect(`/funding-programs/${record.slug}`);
   }
 

--- a/apps/web/src/app/funding-programs/[id]/program-data.ts
+++ b/apps/web/src/app/funding-programs/[id]/program-data.ts
@@ -14,6 +14,8 @@ import { resolveEntityName } from "@/lib/resolve-entity-name";
 
 export interface ParsedFundingProgram {
   key: string;
+  /** URL slug assigned at build-time; falls back to `key` for legacy records. */
+  slug: string | null;
   ownerEntityId: string;
   name: string;
   programType: string;
@@ -58,6 +60,7 @@ export function parseFundingProgram(record: KBRecordEntry): ParsedFundingProgram
   const f = record.fields;
   return {
     key: record.key,
+    slug: record.slug ?? null,
     ownerEntityId: record.ownerEntityId,
     name: (f.name as string) ?? record.key,
     programType: (f.programType as string) ?? "grant-round",

--- a/apps/web/src/app/funding-programs/funding-programs-table.tsx
+++ b/apps/web/src/app/funding-programs/funding-programs-table.tsx
@@ -13,7 +13,7 @@ import { FP_STATUS_COLORS, PROGRAM_TYPE_LABELS } from "./funding-programs-consta
 
 export interface FundingProgramListRow {
   id: string;
-  /** URL-safe slug used for `/funding-programs/<slug>` (QUA-908). Falls back to id when missing. */
+  /** URL-safe slug; falls back to id when missing. */
   slug?: string | null;
   name: string;
   orgId: string;

--- a/apps/web/src/app/funding-programs/funding-programs-table.tsx
+++ b/apps/web/src/app/funding-programs/funding-programs-table.tsx
@@ -13,6 +13,8 @@ import { FP_STATUS_COLORS, PROGRAM_TYPE_LABELS } from "./funding-programs-consta
 
 export interface FundingProgramListRow {
   id: string;
+  /** URL-safe slug used for `/funding-programs/<slug>` (QUA-908). Falls back to id when missing. */
+  slug?: string | null;
   name: string;
   orgId: string;
   orgName: string;
@@ -307,7 +309,7 @@ export function FundingProgramsListTable({
                 <td className="py-2.5 px-3">
                   <span className="flex items-center gap-1.5">
                     <Link
-                      href={`/funding-programs/${row.id}`}
+                      href={`/funding-programs/${row.slug ?? row.id}`}
                       className="font-medium text-foreground hover:text-primary transition-colors"
                     >
                       {row.name}

--- a/apps/web/src/app/funding-programs/page.tsx
+++ b/apps/web/src/app/funding-programs/page.tsx
@@ -36,11 +36,15 @@ export default function FundingProgramsPage() {
   const allRecords = getAllKBRecords("funding-programs");
   const programs = allRecords.map(parseFundingProgram);
 
-  // Build enriched rows for the table
+  // Build enriched rows for the table.
+  // `id` is the canonical 10-char key (used for verdict lookups and the React row key).
+  // `slug` is the human-readable URL slug (QUA-908) — falls back to id when missing.
   const rows: FundingProgramListRow[] = programs.map((p) => {
     const org = resolveOrg(p.ownerEntityId);
+    const record = allRecords.find((r) => r.key === p.key);
     return {
       id: p.key,
+      slug: record?.slug ?? null,
       name: p.name,
       orgId: p.ownerEntityId,
       orgName: org.name,

--- a/apps/web/src/app/funding-programs/page.tsx
+++ b/apps/web/src/app/funding-programs/page.tsx
@@ -38,13 +38,12 @@ export default function FundingProgramsPage() {
 
   // Build enriched rows for the table.
   // `id` is the canonical 10-char key (used for verdict lookups and the React row key).
-  // `slug` is the human-readable URL slug (QUA-908) — falls back to id when missing.
-  const recordByKey = new Map(allRecords.map((r) => [r.key, r]));
+  // `slug` is the human-readable URL slug — falls back to id when missing.
   const rows: FundingProgramListRow[] = programs.map((p) => {
     const org = resolveOrg(p.ownerEntityId);
     return {
       id: p.key,
-      slug: recordByKey.get(p.key)?.slug ?? null,
+      slug: p.slug,
       name: p.name,
       orgId: p.ownerEntityId,
       orgName: org.name,

--- a/apps/web/src/app/funding-programs/page.tsx
+++ b/apps/web/src/app/funding-programs/page.tsx
@@ -39,12 +39,12 @@ export default function FundingProgramsPage() {
   // Build enriched rows for the table.
   // `id` is the canonical 10-char key (used for verdict lookups and the React row key).
   // `slug` is the human-readable URL slug (QUA-908) — falls back to id when missing.
+  const recordByKey = new Map(allRecords.map((r) => [r.key, r]));
   const rows: FundingProgramListRow[] = programs.map((p) => {
     const org = resolveOrg(p.ownerEntityId);
-    const record = allRecords.find((r) => r.key === p.key);
     return {
       id: p.key,
-      slug: record?.slug ?? null,
+      slug: recordByKey.get(p.key)?.slug ?? null,
       name: p.name,
       orgId: p.ownerEntityId,
       orgName: org.name,

--- a/apps/web/src/app/funding-rounds/[id]/page.tsx
+++ b/apps/web/src/app/funding-rounds/[id]/page.tsx
@@ -1,12 +1,12 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 import {
   getAllKBRecords,
   getKBRecords,
+  type KBRecordEntry,
 } from "@/data/factbase";
 import { formatStake } from "@/app/organizations/[slug]/org-data";
-import type { KBRecordEntry } from "@/data/factbase";
 import { getTypedEntityById, getRecordVerdict } from "@/data/tablebase";
 import { formatCompactCurrency } from "@/lib/format-compact";
 import { ProfileStatCard } from "@/components/directory";
@@ -31,6 +31,7 @@ import {
 
 interface ParsedFundingRound {
   key: string;
+  slug: string | null;
   ownerEntityId: string;
   name: string;
   companyName: string;
@@ -72,6 +73,7 @@ function parseFundingRound(record: KBRecordEntry): ParsedFundingRound {
 
   return {
     key: record.key,
+    slug: record.slug ?? null,
     ownerEntityId: record.ownerEntityId,
     name: typeof f.name === "string" ? f.name : record.key,
     companyName: company.name,
@@ -109,6 +111,24 @@ function parseInvestment(record: KBRecordEntry): ParsedInvestment {
   };
 }
 
+// ── Lookup helpers ─────────────────────────────────────────────────────
+
+/** Find a record by slug (preferred) or fall back to legacy 10-char key. */
+function findRoundRecord(idOrSlug: string): KBRecordEntry | undefined {
+  const allRounds = getAllKBRecords("funding-rounds");
+  return (
+    allRounds.find((r) => r.slug === idOrSlug) ??
+    allRounds.find((r) => r.key === idOrSlug)
+  );
+}
+
+// ── Static params ──────────────────────────────────────────────────────
+
+export function generateStaticParams() {
+  const allRounds = getAllKBRecords("funding-rounds");
+  return allRounds.map((record) => ({ id: record.slug ?? record.key }));
+}
+
 // ── Metadata ───────────────────────────────────────────────────────────
 
 interface PageProps {
@@ -117,8 +137,7 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const allRounds = getAllKBRecords("funding-rounds");
-  const record = allRounds.find((r) => r.key === id);
+  const record = findRoundRecord(id);
   if (!record) {
     return { title: "Funding Round Not Found" };
   }
@@ -138,9 +157,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function FundingRoundDetailPage({ params }: PageProps) {
   const { id } = await params;
   const allRounds = getAllKBRecords("funding-rounds");
-  const record = allRounds.find((r) => r.key === id);
+  const record = findRoundRecord(id);
 
   if (!record) notFound();
+
+  // Legacy URL: `/funding-rounds/<10-char-key>` redirects to slug URL.
+  if (record.slug && record.slug !== id && record.key === id) {
+    redirect(`/funding-rounds/${record.slug}`);
+  }
 
   const round = parseFundingRound(record);
   const roundVerdict = getRecordVerdict("funding-round", String(round.key));
@@ -345,7 +369,7 @@ export default async function FundingRoundDetailPage({ params }: PageProps) {
                     <tr key={r.key} className="hover:bg-muted/20 transition-colors">
                       <td className="py-2 px-3">
                         <Link
-                          href={`/funding-rounds/${r.key}`}
+                          href={`/funding-rounds/${r.slug ?? r.key}`}
                           className="font-medium text-foreground text-xs hover:text-primary transition-colors"
                         >
                           {r.name}

--- a/apps/web/src/app/funding-rounds/[id]/page.tsx
+++ b/apps/web/src/app/funding-rounds/[id]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import {
   getAllKBRecords,
   getKBRecords,
+  findFactBaseRecordBySlugOrKey,
   type KBRecordEntry,
 } from "@/data/factbase";
 import { formatStake } from "@/app/organizations/[slug]/org-data";
@@ -111,17 +112,6 @@ function parseInvestment(record: KBRecordEntry): ParsedInvestment {
   };
 }
 
-// ── Lookup helpers ─────────────────────────────────────────────────────
-
-/** Find a record by slug (preferred) or fall back to legacy 10-char key. */
-function findRoundRecord(idOrSlug: string): KBRecordEntry | undefined {
-  const allRounds = getAllKBRecords("funding-rounds");
-  return (
-    allRounds.find((r) => r.slug === idOrSlug) ??
-    allRounds.find((r) => r.key === idOrSlug)
-  );
-}
-
 // ── Static params ──────────────────────────────────────────────────────
 
 export function generateStaticParams() {
@@ -137,7 +127,7 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const record = findRoundRecord(id);
+  const record = findFactBaseRecordBySlugOrKey("funding-rounds", id);
   if (!record) {
     return { title: "Funding Round Not Found" };
   }
@@ -157,13 +147,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function FundingRoundDetailPage({ params }: PageProps) {
   const { id } = await params;
   const allRounds = getAllKBRecords("funding-rounds");
-  const record = findRoundRecord(id);
+  const record = findFactBaseRecordBySlugOrKey("funding-rounds", id);
 
   if (!record) notFound();
 
-  // Legacy URL: `/funding-rounds/<10-char-key>` redirects to slug URL.
-  // findRoundRecord prefers slug match, so reaching `record.key === id`
-  // means slug match missed → request was by legacy key.
+  // Redirect legacy /funding-rounds/<key> → /funding-rounds/<slug>.
   if (record.slug && record.key === id) {
     redirect(`/funding-rounds/${record.slug}`);
   }

--- a/apps/web/src/app/funding-rounds/[id]/page.tsx
+++ b/apps/web/src/app/funding-rounds/[id]/page.tsx
@@ -162,7 +162,9 @@ export default async function FundingRoundDetailPage({ params }: PageProps) {
   if (!record) notFound();
 
   // Legacy URL: `/funding-rounds/<10-char-key>` redirects to slug URL.
-  if (record.slug && record.slug !== id && record.key === id) {
+  // findRoundRecord prefers slug match, so reaching `record.key === id`
+  // means slug match missed → request was by legacy key.
+  if (record.slug && record.key === id) {
     redirect(`/funding-rounds/${record.slug}`);
   }
 

--- a/apps/web/src/app/funding-rounds/funding-rounds-table.tsx
+++ b/apps/web/src/app/funding-rounds/funding-rounds-table.tsx
@@ -26,7 +26,7 @@ function instrumentLabel(s: string): string {
 
 export interface FundingRoundRow {
   key: string;
-  /** URL-safe slug used for `/funding-rounds/<slug>` (QUA-908). Falls back to key when missing. */
+  /** URL-safe slug; falls back to key when missing. */
   slug?: string | null;
   name: string;
   companyName: string;

--- a/apps/web/src/app/funding-rounds/funding-rounds-table.tsx
+++ b/apps/web/src/app/funding-rounds/funding-rounds-table.tsx
@@ -26,6 +26,8 @@ function instrumentLabel(s: string): string {
 
 export interface FundingRoundRow {
   key: string;
+  /** URL-safe slug used for `/funding-rounds/<slug>` (QUA-908). Falls back to key when missing. */
+  slug?: string | null;
   name: string;
   companyName: string;
   companyHref: string | null;
@@ -177,7 +179,7 @@ export function FundingRoundsTable({ rows }: { rows: FundingRoundRow[] }) {
                 <td className="py-2 px-3">
                   <span className="flex items-center gap-1.5">
                     <Link
-                      href={`/funding-rounds/${row.key}`}
+                      href={`/funding-rounds/${row.slug ?? row.key}`}
                       className="font-medium text-foreground text-xs hover:text-primary transition-colors"
                     >
                       {row.name}

--- a/apps/web/src/app/funding-rounds/page.tsx
+++ b/apps/web/src/app/funding-rounds/page.tsx
@@ -39,6 +39,7 @@ export default function FundingRoundsPage() {
 
     return {
       key: record.key,
+      slug: record.slug ?? null,
       name: typeof f.name === "string" ? f.name : record.key,
       companyName: company.name,
       companyHref: company.href,

--- a/apps/web/src/app/investments/[id]/page.tsx
+++ b/apps/web/src/app/investments/[id]/page.tsx
@@ -154,7 +154,7 @@ export default async function InvestmentDetailPage({ params }: PageProps) {
       (r) => typeof r.fields.name === "string" && r.fields.name === investment.roundName,
     );
     if (matchedRound) {
-      fundingRoundHref = `/funding-rounds/${matchedRound.key}`;
+      fundingRoundHref = `/funding-rounds/${matchedRound.slug ?? matchedRound.key}`;
     }
   }
 

--- a/apps/web/src/app/organizations/[slug]/_data/funding-programs.ts
+++ b/apps/web/src/app/organizations/[slug]/_data/funding-programs.ts
@@ -4,6 +4,7 @@ export function parseFundingProgramRecord(record: KBRecordEntry) {
   const f = record.fields;
   return {
     key: record.key,
+    slug: record.slug ?? null,
     name: (f.name as string) ?? record.key,
     programType: (f.programType as string) ?? "grant-round",
     description: (f.description as string) ?? null,

--- a/apps/web/src/app/organizations/[slug]/grants/[grantId]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/grants/[grantId]/page.tsx
@@ -105,6 +105,17 @@ export default async function OrgGrantDetailPage({ params }: PageProps) {
   const funderTypedEntity = getTypedEntityById(grant.ownerEntityId);
   const funderWikiPageId = funderTypedEntity?.wikiId ?? null;
 
+  // Resolve the funding program's URL slug (QUA-908). Grants store the
+  // program's 10-char key; the [id]/page.tsx route accepts both, but linking
+  // straight to the slug avoids a redirect hop.
+  let programHref: string | null = null;
+  if (grant.programId) {
+    const programRecord = getAllKBRecords("funding-programs").find(
+      (p) => p.key === grant.programId,
+    );
+    programHref = `/funding-programs/${programRecord?.slug ?? grant.programId}`;
+  }
+
   return (
     <div className="max-w-4xl mx-auto px-6 py-8">
       {/* Breadcrumbs */}
@@ -184,9 +195,9 @@ export default async function OrgGrantDetailPage({ params }: PageProps) {
 
           {(grant.program || grant.programId) && (
             <DetailSection title="Program">
-              {grant.programId ? (
+              {programHref ? (
                 <Link
-                  href={`/funding-programs/${grant.programId}`}
+                  href={programHref}
                   className="text-sm font-medium text-primary hover:underline"
                 >
                   {grant.program ?? grant.programId}

--- a/apps/web/src/app/organizations/[slug]/grants/[grantId]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/grants/[grantId]/page.tsx
@@ -105,9 +105,7 @@ export default async function OrgGrantDetailPage({ params }: PageProps) {
   const funderTypedEntity = getTypedEntityById(grant.ownerEntityId);
   const funderWikiPageId = funderTypedEntity?.wikiId ?? null;
 
-  // Resolve the funding program's URL slug (QUA-908). Grants store the
-  // program's 10-char key; the [id]/page.tsx route accepts both, but linking
-  // straight to the slug avoids a redirect hop.
+  // Link straight to the program's slug to avoid the legacy-key redirect hop.
   let programHref: string | null = null;
   if (grant.programId) {
     const programRecord = getAllKBRecords("funding-programs").find(

--- a/apps/web/src/app/organizations/[slug]/main-content-sections.tsx
+++ b/apps/web/src/app/organizations/[slug]/main-content-sections.tsx
@@ -81,7 +81,7 @@ export function FundingHistorySection({
               return (
                 <tr key={round.key} className="hover:bg-muted/20 transition-colors">
                   <td className="py-2 px-3 font-medium">
-                    <Link href={`/funding-rounds/${round.key}`} className="text-foreground hover:text-primary transition-colors">
+                    <Link href={`/funding-rounds/${round.slug ?? round.key}`} className="text-foreground hover:text-primary transition-colors">
                       {name}
                     </Link>
                   </td>

--- a/apps/web/src/app/organizations/[slug]/programs-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/programs-section.tsx
@@ -61,7 +61,7 @@ export function FundingProgramsSection({
                   <td className="py-2 px-3">
                     <span className="font-medium text-foreground text-xs">
                       <Link
-                        href={`/funding-programs/${p.key}`}
+                        href={`/funding-programs/${p.slug ?? p.key}`}
                         className="text-primary hover:underline"
                       >
                         {p.name}

--- a/apps/web/src/data/factbase.ts
+++ b/apps/web/src/data/factbase.ts
@@ -424,8 +424,8 @@ export interface FactBaseRecordEntry {
   /**
    * URL-friendly slug derived from the record's display name. Assigned at
    * build-time for collections that route on the slug (funding-programs,
-   * funding-rounds — QUA-908). The 10-char `key` remains the canonical
-   * identifier for verdict lookups, React keys, and legacy-URL redirects.
+   * funding-rounds). The 10-char `key` remains the canonical identifier
+   * for verdict lookups, React keys, and legacy-URL redirects.
    */
   slug?: string;
 }
@@ -507,6 +507,19 @@ export function getAllFactBaseRecords(collection: string): FactBaseRecordEntry[]
  */
 export function getAllFactBaseRecordsByCollection(collection: string): FactBaseRecordEntry[] {
   return getAllFactBaseRecords(collection);
+}
+
+/**
+ * Find a record by URL slug or by its 10-char legacy `key`. Used by detail
+ * pages that accept either form. The shadow guard in `assignSlugs` ensures
+ * a slug never equals another record's key, so the OR branch order is safe.
+ */
+export function findFactBaseRecordBySlugOrKey(
+  collection: string,
+  idOrSlug: string,
+): FactBaseRecordEntry | undefined {
+  const all = getAllFactBaseRecords(collection);
+  return all.find((r) => r.slug === idOrSlug || r.key === idOrSlug);
 }
 
 // ── Entity Events (PG-sourced timeline events per entity) ──

--- a/apps/web/src/data/factbase.ts
+++ b/apps/web/src/data/factbase.ts
@@ -421,6 +421,13 @@ export interface FactBaseRecordEntry {
   fields: Record<string, unknown>;
   /** Display name for non-entity participants (when allow_display_name is true) */
   displayName?: string;
+  /**
+   * URL-friendly slug derived from the record's display name. Assigned at
+   * build-time for collections that route on the slug (funding-programs,
+   * funding-rounds — QUA-908). The 10-char `key` remains the canonical
+   * identifier for verdict lookups, React keys, and legacy-URL redirects.
+   */
+  slug?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

QA sweep [QUA-908](https://linear.app/quantifieduncertainty/issue/QUA-908) found `/funding-programs/<10-char-id>` and `/funding-rounds/<10-char-id>` URLs leaking raw stableIds (`pJ9oHvQ1Bb`, `vjzygxG2V9`, …). Hurts SEO, sharing, and human-readable URLs.

This PR generates URL slugs at build-time from each FactBase record's display name. The 10-char `key` is preserved for verdict lookups, React keys, and legacy-URL redirects (308 from `/funding-*\/<key>` → `/funding-*\/<slug>`).

### Slug policy

- **funding-rounds** — owner-prefixed (`anthropic-series-g`). Round names like "Series A" recur at every funder; namespacing is the contract.
- **funding-programs** — bare name (`rise-global-talent-program`). Cross-funder collisions fall back to owner-prefixed.
- **Cascade**: first-choice → fallback (when distinct) → 4-char key-prefix suffix.
- **Stability contract**: same `(name, ownerEntity, key)` → same slug across builds. Sort by record key before assignment so collision suffixes are deterministic regardless of input order.
- **Slug-vs-key shadow guard**: a slugified name is never assigned if it equals another record's 10-char `key`, so legacy URL lookups always resolve to the right record.

### Verified against prod

- 161/161 records (100 rounds + 61 programs) get unique slugs
- 0 within-collection collisions, 0 shadow conflicts
- Examples: `pJ9oHvQ1Bb` → `rise-global-talent-program`, `T-kX3k7mKD` → `ai-in-science-postdoctoral-fellowship`, `vjzygxG2V9` → `anthropic-series-g`

### Key changes

- New `apps/web/scripts/lib/record-slugs.mjs` with `slugify`, `candidateSlugs`, `assignSlugs`
- `mergePGRecordsIntoKB` now accepts `{ stableIdToSlug }` and assigns slugs to both collections after the merge
- `findFactBaseRecordBySlugOrKey` shared helper in `@/data/factbase` — used by both detail pages
- Detail pages: `generateStaticParams` emits slug, accept slug-or-key, redirect legacy-key requests
- Internal callers updated: tables, organization profile sections, investments→round href, grants→program href

## Test plan

- [x] 22 unit tests for slug module (collisions, Unicode, diacritics, determinism, owner-prefix dedup, shadow guard)
- [x] 15 red-team scenarios (XSS, SQL injection, path traversal, oversized inputs, 100-way collision, slug-shadow attack)
- [x] In-process merge test against prod data — 161/161 records get unique non-shadowing slugs
- [x] `pnpm crux w validate gate --fix` passes (full mode, 475s)
- [x] TypeScript clean across web + wiki-server
- [x] All 268 build-script lib tests pass
- [x] Playwright `e2e/render-audit.spec.ts` (59 tests) — all green against prod baseline
- [ ] Post-merge: confirm `database.json` carries `slug` field on funding records and Vercel build picks them up

Fixes QUA-908


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `build` build-data.mjs changed — verify build-data produces correct database.json after deploy — `pnpm build-data:content && echo "Build data OK"`
<!-- /deploy-tasks -->