### PR TITLE
fix(table-states): address CodeRabbit review feedback (QUA-1008 follow-up)

### DIFF
--- a/apps/web/src/app/events/page.tsx
+++ b/apps/web/src/app/events/page.tsx
@@ -67,7 +67,7 @@ export default function EventsPage() {
         ))}
       </div>
 
-      <Suspense fallback={<TableSkeleton rows={10} columns={5} />}>
+      <Suspense fallback={<TableSkeleton rows={10} columns={7} />}>
         <EventsTable rows={rows} />
       </Suspense>
     </div>

--- a/apps/web/src/components/ui/__tests__/table-states.test.tsx
+++ b/apps/web/src/components/ui/__tests__/table-states.test.tsx
@@ -11,7 +11,7 @@ import {
   DEFAULT_LOADING_LABEL,
   DEFAULT_EMPTY_LABEL,
   DEFAULT_ERROR_LABEL,
-} from "../table-states";
+} from "@/components/ui/table-states";
 
 function renderInTable(node: React.ReactNode) {
   return render(
@@ -62,13 +62,22 @@ describe("TableErrorRow", () => {
     expect(cell).toHaveTextContent("API down");
   });
 
-  it("renders error message from Error instance", () => {
+  it("renders DEFAULT_ERROR_LABEL for Error instances (does not surface error.message)", () => {
+    // Error instances often carry transport/runtime details unsuitable for end-users.
+    // The canonical primitive collapses them to the safe fallback; callers wanting a
+    // custom message must pass an explicit string.
     renderInTable(<TableErrorRow colSpan={3} error={new Error("boom")} />);
-    expect(screen.getByText("boom")).toBeInTheDocument();
+    expect(screen.getByText(DEFAULT_ERROR_LABEL)).toBeInTheDocument();
+    expect(screen.queryByText("boom")).not.toBeInTheDocument();
   });
 
-  it("falls back to default error label when error message is empty", () => {
+  it("falls back to default error label when error string is empty", () => {
     renderInTable(<TableErrorRow colSpan={3} error="" />);
+    expect(screen.getByText(DEFAULT_ERROR_LABEL)).toBeInTheDocument();
+  });
+
+  it("falls back to default error label when error string is whitespace-only", () => {
+    renderInTable(<TableErrorRow colSpan={3} error="   " />);
     expect(screen.getByText(DEFAULT_ERROR_LABEL)).toBeInTheDocument();
   });
 });
@@ -124,5 +133,11 @@ describe("TableErrorBlock", () => {
     const btn = screen.getByRole("button", { name: /retry/i });
     btn.click();
     expect(retry).toHaveBeenCalledOnce();
+  });
+
+  it("renders DEFAULT_ERROR_LABEL for Error instances (does not surface error.message)", () => {
+    render(<TableErrorBlock error={new Error("internal stack details")} />);
+    expect(screen.getByText(DEFAULT_ERROR_LABEL)).toBeInTheDocument();
+    expect(screen.queryByText("internal stack details")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/ui/data-table.tsx
+++ b/apps/web/src/components/ui/data-table.tsx
@@ -28,7 +28,7 @@ import {
 // Note: kept on shadcn TableRow/TableCell instead of TableEmptyRow because
 // shadcn rows carry hover/border/data-state styling that the bare-<tr>
 // canonical row would strip. See QUA-1008 review notes.
-import { DEFAULT_EMPTY_LABEL } from "./table-states"
+import { DEFAULT_EMPTY_LABEL } from "@/components/ui/table-states"
 
 // New API: accepts table instance directly
 interface DataTableWithTableProps<TData> {

--- a/apps/web/src/components/ui/table-states.tsx
+++ b/apps/web/src/components/ui/table-states.tsx
@@ -87,7 +87,13 @@ export function TableErrorRow({
   error,
   className,
 }: TableRowStateProps & { error: string | Error }) {
-  const message = error instanceof Error ? error.message : error;
+  // Only render caller-supplied non-empty strings verbatim. `Error` instances
+  // collapse to the canonical fallback to avoid surfacing internal details
+  // (transport stacks, schema names, etc.) to end-users from a generic primitive.
+  const message =
+    typeof error === "string" && error.trim()
+      ? error
+      : DEFAULT_ERROR_LABEL;
   return (
     <tr>
       <td
@@ -97,7 +103,7 @@ export function TableErrorRow({
       >
         <span className="inline-flex items-center gap-2 text-destructive">
           <AlertTriangle className="h-4 w-4" aria-hidden="true" />
-          <span>{message || DEFAULT_ERROR_LABEL}</span>
+          <span>{message}</span>
         </span>
       </td>
     </tr>
@@ -204,7 +210,11 @@ export function TableErrorBlock({
   error: string | Error;
   retry?: () => void;
 }) {
-  const message = error instanceof Error ? error.message : error;
+  // Only render caller-supplied non-empty strings verbatim. See TableErrorRow.
+  const message =
+    typeof error === "string" && error.trim()
+      ? error
+      : DEFAULT_ERROR_LABEL;
   return (
     <div
       role="alert"
@@ -217,9 +227,7 @@ export function TableErrorBlock({
         className="mx-auto mb-2 h-6 w-6 text-destructive"
         aria-hidden="true"
       />
-      <p className="text-sm font-medium text-destructive">
-        {message || DEFAULT_ERROR_LABEL}
-      </p>
+      <p className="text-sm font-medium text-destructive">{message}</p>
       {retry && (
         <button
           type="button"

--- a/crux/validate/validate-table-states.test.ts
+++ b/crux/validate/validate-table-states.test.ts
@@ -150,5 +150,49 @@ describe("validate-table-states", () => {
       const result = runCheck({ roots: [scanRoot], quiet: true });
       expect(result.passed).toBe(true);
     });
+
+    it("does not flag banned literals inside JSX block comments ({/* ... */})", () => {
+      // `{/* historical Loading... */}` should not trigger the validator.
+      writeTargetFile(
+        "block-comment-table.tsx",
+        `function Foo() {\n  return (\n    <div>\n      {/* historical Loading... before QUA-1008 */}\n      <TableSkeleton rows={10} columns={5} />\n    </div>\n  );\n}\n`,
+      );
+      const result = runCheck({ roots: [scanRoot], quiet: true });
+      expect(result.passed).toBe(true);
+    });
+
+    it("does not flag banned literals inside multi-line JSX block comments", () => {
+      // A `{/* ... */}` block comment that spans multiple lines, with the banned
+      // literal on a continuation line, must also be ignored.
+      writeTargetFile(
+        "multi-block-comment-table.tsx",
+        `function Foo() {\n  return (\n    <div>\n      {/*\n        old code: <div>Loading...</div>\n        retained for context\n      */}\n      <TableSkeleton rows={10} columns={5} />\n    </div>\n  );\n}\n`,
+      );
+      const result = runCheck({ roots: [scanRoot], quiet: true });
+      expect(result.passed).toBe(true);
+    });
+
+    it("does not flag attribute lines inside a multi-line canonical JSX element", () => {
+      // `<TableSkeleton` opens on one line, `label="Loading users..."` follows on
+      // the next, then `/>` closes. The continuation line carries the banned literal
+      // as a prop value of the canonical component — not a violation.
+      writeTargetFile(
+        "multiline-jsx-table.tsx",
+        `function Foo() {\n  return (\n    <TableSkeleton\n      rows={10}\n      columns={5}\n      label="Loading users..."\n    />\n  );\n}\n`,
+      );
+      const result = runCheck({ roots: [scanRoot], quiet: true });
+      expect(result.passed).toBe(true);
+    });
+
+    it("still flags banned literals in non-canonical multi-line JSX", () => {
+      // After a multi-line non-canonical element ends, subsequent banned literals
+      // must still flag (proves we're not stuck in skip-everything mode).
+      writeTargetFile(
+        "still-flags-table.tsx",
+        `function Foo() {\n  return (\n    <SomethingElse\n      foo="bar"\n    />\n    /* not a real one */\n    <div>Loading...</div>\n  );\n}\n`,
+      );
+      const result = runCheck({ roots: [scanRoot], quiet: true });
+      expect(result.passed).toBe(false);
+    });
   });
 });

--- a/crux/validate/validate-table-states.ts
+++ b/crux/validate/validate-table-states.ts
@@ -108,6 +108,8 @@ const IMPORT_RE = /from\s+["']@\/components\/ui\/table-states["']/;
  * `\b` lets `"<TableLoadingRow"` (a string literal) bypass.
  */
 const CANONICAL_JSX_RE = /<(?:TableLoadingRow|TableEmptyRow|TableErrorRow|TableSkeleton|TableEmptyBlock|TableErrorBlock)(?:\s|\/?>)/;
+/** Looser open-tag form used for multiline tracking (no immediate close required). */
+const CANONICAL_JSX_OPEN_RE = /<(?:TableLoadingRow|TableEmptyRow|TableErrorRow|TableSkeleton|TableEmptyBlock|TableErrorBlock)\b/;
 /**
  * Opt-out comment: requires a `//`, `/*`, or `{/*` comment marker followed by
  * a non-empty reason after `table-states-ok:`. Plain `"table-states-ok:"`
@@ -138,8 +140,68 @@ function checkFile(filePath: string): Violation[] {
   const lines = content.split("\n");
   const violations: Violation[] = [];
 
+  // State carried across lines so multiline JSX block comments and multiline
+  // canonical-element openings don't false-flag continuation lines that
+  // contain the banned literal in attributes (e.g. `label="Loading users..."`).
+  let inBlockComment = false; // inside `{/* ... */}` JSX block comment
+  let inCanonicalElement = false; // inside `<TableLoadingRow ...>` spanning multiple lines
+
   for (let i = 0; i < lines.length; i++) {
     const rawLine = lines[i];
+
+    // Update block-comment state. We process opens and closes in order so a
+    // single-line `{/* ... */}` (or `/* ... */`) toggles in and out within the
+    // same iteration. Multi-line forms leave `inBlockComment` true until the
+    // line containing `*/}` (or `*/`) is reached.
+    let cursor = 0;
+    let lineHasContentOutsideComment = false;
+    while (cursor < rawLine.length) {
+      if (inBlockComment) {
+        const closeJsx = rawLine.indexOf("*/}", cursor);
+        const closeC = rawLine.indexOf("*/", cursor);
+        const close = closeJsx >= 0 && (closeC < 0 || closeJsx <= closeC) ? closeJsx + 3 : (closeC >= 0 ? closeC + 2 : -1);
+        if (close < 0) {
+          cursor = rawLine.length;
+        } else {
+          inBlockComment = false;
+          cursor = close;
+        }
+      } else {
+        const openJsx = rawLine.indexOf("{/*", cursor);
+        const openC = rawLine.indexOf("/*", cursor);
+        const open = openJsx >= 0 && (openC < 0 || openJsx <= openC) ? openJsx : openC;
+        if (open < 0) {
+          if (rawLine.slice(cursor).trim().length > 0) lineHasContentOutsideComment = true;
+          cursor = rawLine.length;
+        } else {
+          if (rawLine.slice(cursor, open).trim().length > 0) lineHasContentOutsideComment = true;
+          inBlockComment = true;
+          cursor = open + (rawLine.startsWith("{/*", open) ? 3 : 2);
+        }
+      }
+    }
+
+    // If the entire line was inside a block comment (no content outside), skip it.
+    if (!lineHasContentOutsideComment) continue;
+
+    // Update canonical-element state.
+    // Open: a multiline `<TableLoadingRow` etc. without an immediate `>` or `/>`
+    // on the same line. Close: `>` or `/>` while we're tracking.
+    if (!inCanonicalElement && CANONICAL_JSX_OPEN_RE.test(rawLine) && !CANONICAL_JSX_RE.test(rawLine)) {
+      // Found `<TableLoadingRow` (or similar) but not the immediate-close form —
+      // this is a multiline element. Skip the rest of the loop body and start tracking.
+      // We still need to check this opening line for closure in case the open and
+      // close are split by attributes on the same line ending in `>`.
+      const closesOnSameLine = /[/>]>/.test(rawLine) || /\s>\s*$/.test(rawLine);
+      inCanonicalElement = !closesOnSameLine;
+      continue;
+    }
+    if (inCanonicalElement) {
+      // Inside a canonical element body — skip until we see the closing `>` or `/>`.
+      if (/\/?>/.test(rawLine)) inCanonicalElement = false;
+      continue;
+    }
+
     if (isComment(rawLine)) continue;
     // Skip lines that import from the canonical module.
     if (IMPORT_RE.test(rawLine)) continue;


### PR DESCRIPTION
## Summary

Follow-up to #4813 (QUA-1008). The CodeRabbit findings on the original PR were authored locally but never pushed before the PR merged. This PR lands those fixes.

- `events/page.tsx`: TableSkeleton columns 5 → 7 to match EventsTable's 7 headers (eliminates layout jump)
- `table-states.test.tsx`, `data-table.tsx`: use `@/` path alias instead of relative import
- `table-states.tsx`: don't surface raw `Error.message` from generic primitives. `TableErrorRow` + `TableErrorBlock` now render `DEFAULT_ERROR_LABEL` for `Error` instances and only render caller-supplied non-empty/non-whitespace strings verbatim
- `validate-table-states.ts`: track `inBlockComment` and `inCanonicalElement` state across lines so banned literals inside JSX block comments and multi-line `<TableSkeleton ... />` attribute blocks aren't false-positive flagged; new tests cover both scenarios + a non-canonical-multiline regression check

## Test plan

- [x] 15/15 component tests pass (`apps/web/src/components/ui/__tests__/table-states.test.tsx`)
- [x] 17/17 validator tests pass (`crux/validate/validate-table-states.test.ts`)
- [x] Validator finds 0 violations across 185 scanned files
- [ ] CI green

Refs QUA-1008.

Fixes QUA-1008
