### PR TITLE
withPipelineRun accepts optional CostTracker (QUA-1013)

### DIFF
--- a/crux/lib/pipeline-runs/lifecycle.test.ts
+++ b/crux/lib/pipeline-runs/lifecycle.test.ts
@@ -316,6 +316,110 @@ describe('withPipelineRun', () => {
     });
   });
 
+  describe('CostTracker integration (QUA-1013)', () => {
+    it('writes tracker totals to /end on success', async () => {
+      mockStart.mockResolvedValue({ ok: true, data: {} });
+      mockEnd.mockResolvedValue({ ok: true, data: {} });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+      const { CostTracker } = await import('../cost-tracker.ts');
+
+      const tracker = new CostTracker();
+      // Two recorded LLM calls — pricing module computes the cost; we
+      // only assert that totals match what the tracker reports rather
+      // than hardcoding a price (decoupled from pricing-table churn).
+      tracker.record('claude-sonnet-4-5', {
+        input_tokens: 1000,
+        output_tokens: 200,
+        cache_creation_input_tokens: 50,
+        cache_read_input_tokens: 30,
+      }, 'phase-1');
+      tracker.record('claude-sonnet-4-5', {
+        input_tokens: 500,
+        output_tokens: 100,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 80,
+      }, 'phase-2');
+
+      await withPipelineRun(
+        {
+          pipelineName: 'improve-page',
+          tracker,
+          heartbeatIntervalMs: 1_000_000_000,
+        },
+        async () => 'done',
+      );
+
+      expect(mockEnd).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          status: 'committed',
+          costUsd: tracker.totalCost,
+          tokensInput: 1500,
+          tokensOutput: 300,
+          tokensCacheRead: 110,
+          tokensCacheWrite: 50,
+        }),
+      );
+    });
+
+    it('writes tracker totals to /end when the body throws', async () => {
+      mockStart.mockResolvedValue({ ok: true, data: {} });
+      mockEnd.mockResolvedValue({ ok: true, data: {} });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+      const { CostTracker } = await import('../cost-tracker.ts');
+
+      const tracker = new CostTracker();
+      tracker.recordExternalCost('perplexity/sonar', 0.42, 'gap-search');
+
+      await expect(
+        withPipelineRun(
+          {
+            pipelineName: 'improve-page',
+            tracker,
+            heartbeatIntervalMs: 1_000_000_000,
+          },
+          async () => {
+            throw new Error('mid-run abort');
+          },
+        ),
+      ).rejects.toThrow('mid-run abort');
+
+      expect(mockEnd).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          status: 'aborted',
+          costUsd: 0.42,
+          tokensInput: 0,
+          tokensOutput: 0,
+        }),
+      );
+    });
+
+    it('omits cost fields entirely when no tracker is configured', async () => {
+      mockStart.mockResolvedValue({ ok: true, data: {} });
+      mockEnd.mockResolvedValue({ ok: true, data: {} });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+
+      await withPipelineRun(
+        { pipelineName: 'improve-page', heartbeatIntervalMs: 1_000_000_000 },
+        async () => 'done',
+      );
+
+      const [, endPayload] = mockEnd.mock.calls[0];
+      // Fields are absent — distinct from `null`. The QUA-1012 typed
+      // client treats omitted as "preserve existing value", which is
+      // what untracked pipelines should produce.
+      expect(endPayload).not.toHaveProperty('costUsd');
+      expect(endPayload).not.toHaveProperty('tokensInput');
+      expect(endPayload).not.toHaveProperty('tokensOutput');
+      expect(endPayload).not.toHaveProperty('tokensCacheRead');
+      expect(endPayload).not.toHaveProperty('tokensCacheWrite');
+    });
+  });
+
   describe('/end failure handling', () => {
     it('logs error but still returns body result on /end failure', async () => {
       mockStart.mockResolvedValue({ ok: true, data: {} });

--- a/crux/lib/pipeline-runs/lifecycle.test.ts
+++ b/crux/lib/pipeline-runs/lifecycle.test.ts
@@ -317,29 +317,36 @@ describe('withPipelineRun', () => {
   });
 
   describe('CostTracker integration (QUA-1013)', () => {
-    it('writes tracker totals to /end on success', async () => {
+    it('writes tracker totals to /end on success and the payload satisfies EndPipelineRunSchema', async () => {
       mockStart.mockResolvedValue({ ok: true, data: {} });
       mockEnd.mockResolvedValue({ ok: true, data: {} });
 
       const { withPipelineRun } = await import('./lifecycle.ts');
       const { CostTracker } = await import('../cost-tracker.ts');
+      const { EndPipelineRunSchema } = await import('../../../apps/wiki-server/src/api-types.ts');
 
       const tracker = new CostTracker();
-      // Two recorded LLM calls — pricing module computes the cost; we
-      // only assert that totals match what the tracker reports rather
-      // than hardcoding a price (decoupled from pricing-table churn).
-      tracker.record('claude-sonnet-4-5', {
+      // Use a real model from the pricing table so calculateCost does
+      // NOT silently fall through to 0 — that masking is what made the
+      // pre-review version of this test a tautology.
+      tracker.record('claude-sonnet-4-6', {
         input_tokens: 1000,
         output_tokens: 200,
         cache_creation_input_tokens: 50,
         cache_read_input_tokens: 30,
       }, 'phase-1');
-      tracker.record('claude-sonnet-4-5', {
+      tracker.record('claude-sonnet-4-6', {
         input_tokens: 500,
         output_tokens: 100,
         cache_creation_input_tokens: 0,
         cache_read_input_tokens: 80,
       }, 'phase-2');
+
+      // Sanity guard: this combination must produce an FP-imprecise
+      // total — that's what proves the rounding is exercised. If
+      // pricing math ever lands on a clean 4-dp value, swap to inputs
+      // that don't (e.g. add a cache-read token).
+      expect((tracker.totalCost * 10000) % 1).not.toBe(0);
 
       await withPipelineRun(
         {
@@ -354,13 +361,20 @@ describe('withPipelineRun', () => {
         expect.any(String),
         expect.objectContaining({
           status: 'committed',
-          costUsd: tracker.totalCost,
+          costUsd: Math.round(tracker.totalCost * 10000) / 10000,
           tokensInput: 1500,
           tokensOutput: 300,
           tokensCacheRead: 110,
           tokensCacheWrite: 50,
         }),
       );
+
+      // Server-side regression guard: the payload must satisfy the
+      // exact Zod schema the wiki-server uses. Catches FP precision
+      // drift, integer-coercion bugs, and accidental field renames.
+      const [, endPayload] = mockEnd.mock.calls[0];
+      const parsed = EndPipelineRunSchema.safeParse(endPayload);
+      expect(parsed.success).toBe(true);
     });
 
     it('writes tracker totals to /end when the body throws', async () => {
@@ -397,6 +411,35 @@ describe('withPipelineRun', () => {
       );
     });
 
+    it('sends zero totals when tracker exists but recorded nothing', async () => {
+      // An empty tracker reports `costUsd: 0` rather than omitting the
+      // field, matching the api-types.ts convention that 0 means
+      // "tracked spend was zero" and null/omitted means "not tracked".
+      mockStart.mockResolvedValue({ ok: true, data: {} });
+      mockEnd.mockResolvedValue({ ok: true, data: {} });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+      const { CostTracker } = await import('../cost-tracker.ts');
+
+      const tracker = new CostTracker();
+
+      await withPipelineRun(
+        { pipelineName: 'improve-page', tracker, heartbeatIntervalMs: 1_000_000_000 },
+        async () => 'done',
+      );
+
+      expect(mockEnd).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          costUsd: 0,
+          tokensInput: 0,
+          tokensOutput: 0,
+          tokensCacheRead: 0,
+          tokensCacheWrite: 0,
+        }),
+      );
+    });
+
     it('omits cost fields entirely when no tracker is configured', async () => {
       mockStart.mockResolvedValue({ ok: true, data: {} });
       mockEnd.mockResolvedValue({ ok: true, data: {} });
@@ -417,6 +460,37 @@ describe('withPipelineRun', () => {
       expect(endPayload).not.toHaveProperty('tokensOutput');
       expect(endPayload).not.toHaveProperty('tokensCacheRead');
       expect(endPayload).not.toHaveProperty('tokensCacheWrite');
+    });
+
+    it('warns and skips tracker persistence when allowOffline=true and /start fails', async () => {
+      mockStart.mockResolvedValue({
+        ok: false,
+        error: 'unavailable',
+        message: 'connection refused',
+      });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+      const { CostTracker } = await import('../cost-tracker.ts');
+
+      const tracker = new CostTracker();
+      tracker.recordExternalCost('perplexity/sonar', 0.10, 'phase');
+
+      await withPipelineRun(
+        {
+          pipelineName: 'improve-page',
+          allowOffline: true,
+          tracker,
+          heartbeatIntervalMs: 1_000_000_000,
+        },
+        async () => 'done',
+      );
+
+      expect(mockEnd).not.toHaveBeenCalled();
+      // Surface the silent drop in logs — caller has no run row to
+      // attach the totals to, so they need to know they were lost.
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('tracker totals will NOT be persisted'),
+      );
     });
   });
 

--- a/crux/lib/pipeline-runs/lifecycle.ts
+++ b/crux/lib/pipeline-runs/lifecycle.ts
@@ -46,6 +46,7 @@ import {
   endPipelineRun,
   type PipelineRunEndStatus,
 } from '../wiki-server/pipeline-runs.ts';
+import type { CostTracker } from '../cost-tracker.ts';
 
 // Crux libs log via console (validate-no-console-log only blocks server
 // code under apps/wiki-server). Structured fields are stringified into
@@ -69,6 +70,13 @@ export interface WithPipelineRunOptions {
   allowOffline?: boolean;
   /** Override the heartbeat interval (ms). Test-only. */
   heartbeatIntervalMs?: number;
+  /**
+   * Optional CostTracker. When provided, totals are written to the
+   * pipeline_runs row on end-of-run (success or throw) — see QUA-1013 /
+   * QUA-1038. The tracker is read once in `finalize`; callers that mutate
+   * it after the body returns will not affect the persisted totals.
+   */
+  tracker?: CostTracker;
 }
 
 export interface PipelineRunCtx {
@@ -191,6 +199,7 @@ export async function withPipelineRun<T>(
       errorCode: overrideErrorCode,
       errorPayload: null,
       followups,
+      costTotals: trackerTotals(options.tracker),
     });
     return result;
   } catch (err: unknown) {
@@ -210,6 +219,7 @@ export async function withPipelineRun<T>(
         errorCode: overrideErrorCode ?? errorCodeFor(err),
         errorPayload: errorPayload(err),
         followups,
+        costTotals: trackerTotals(options.tracker),
       });
     } catch (finalizeErr: unknown) {
       error(
@@ -242,6 +252,41 @@ function makeOfflineCtx(runId: string): PipelineRunCtx {
   };
 }
 
+interface CostTotals {
+  costUsd: number;
+  tokensInput: number;
+  tokensOutput: number;
+  tokensCacheRead: number;
+  tokensCacheWrite: number;
+}
+
+/**
+ * Snapshot the tracker's current totals. Returns null when no tracker is
+ * configured so `finalize` can omit the cost fields entirely (preserving
+ * the typed-client semantic that omitted ≠ null — see QUA-1012 comment in
+ * `EndPipelineRunInput`).
+ */
+function trackerTotals(tracker: CostTracker | undefined): CostTotals | null {
+  if (!tracker) return null;
+  let tokensInput = 0;
+  let tokensOutput = 0;
+  let tokensCacheRead = 0;
+  let tokensCacheWrite = 0;
+  for (const entry of tracker.entries) {
+    tokensInput += entry.inputTokens;
+    tokensOutput += entry.outputTokens;
+    tokensCacheRead += entry.cacheReadInputTokens;
+    tokensCacheWrite += entry.cacheCreationInputTokens;
+  }
+  return {
+    costUsd: tracker.totalCost,
+    tokensInput,
+    tokensOutput,
+    tokensCacheRead,
+    tokensCacheWrite,
+  };
+}
+
 interface FinalizeArgs {
   runId: string;
   pipelineName: string;
@@ -250,6 +295,7 @@ interface FinalizeArgs {
   errorCode: string | null;
   errorPayload: Record<string, unknown> | null;
   followups: Array<Record<string, unknown>>;
+  costTotals: CostTotals | null;
 }
 
 async function finalize(args: FinalizeArgs): Promise<void> {
@@ -259,6 +305,7 @@ async function finalize(args: FinalizeArgs): Promise<void> {
     errorCode: args.errorCode,
     errorPayload: args.errorPayload,
     followupActions: args.followups,
+    ...(args.costTotals ?? {}),
   });
   if (!result.ok) {
     // End-call failure is non-fatal: we already swallowed the body's

--- a/crux/lib/pipeline-runs/lifecycle.ts
+++ b/crux/lib/pipeline-runs/lifecycle.ts
@@ -71,10 +71,14 @@ export interface WithPipelineRunOptions {
   /** Override the heartbeat interval (ms). Test-only. */
   heartbeatIntervalMs?: number;
   /**
-   * Optional CostTracker. When provided, totals are written to the
-   * pipeline_runs row on end-of-run (success or throw) — see QUA-1013 /
-   * QUA-1038. The tracker is read once in `finalize`; callers that mutate
-   * it after the body returns will not affect the persisted totals.
+   * Optional CostTracker. When provided, totals are snapshotted after
+   * the body returns/throws and forwarded to the /end call so the
+   * pipeline_runs row records cost + token spend (QUA-1013 / QUA-1038).
+   *
+   * `allowOffline + tracker`: if `/start` fails and `allowOffline=true`,
+   * the body runs in no-op mode and the tracker is NOT persisted (no
+   * run row exists to attach the totals to). A warning is logged when
+   * a tracker is dropped this way so the silent loss is visible.
    */
   tracker?: CostTracker;
 }
@@ -120,6 +124,12 @@ export async function withPipelineRun<T>(
         pipelineName: options.pipelineName,
         err: startResult.message,
       });
+      if (options.tracker) {
+        warn(
+          'withPipelineRun: tracker totals will NOT be persisted — no run row exists in offline mode',
+          { runId, pipelineName: options.pipelineName },
+        );
+      }
       return body(makeOfflineCtx(runId));
     }
 
@@ -265,21 +275,30 @@ interface CostTotals {
  * configured so `finalize` can omit the cost fields entirely (preserving
  * the typed-client semantic that omitted ≠ null — see QUA-1012 comment in
  * `EndPipelineRunInput`).
+ *
+ * `costUsd` is rounded to 4 decimal places. The pricing module produces
+ * costs like `0.006196500000000001` from per-token math + FP imprecision,
+ * which fail the server's `.multipleOf(0.0001)` Zod validator and would
+ * cause /end to 422 mid-flight. The numeric(10,4) PG column would also
+ * silently truncate, so rounding client-side keeps caller-side and
+ * persisted values equal.
  */
 function trackerTotals(tracker: CostTracker | undefined): CostTotals | null {
   if (!tracker) return null;
+  let costUsd = 0;
   let tokensInput = 0;
   let tokensOutput = 0;
   let tokensCacheRead = 0;
   let tokensCacheWrite = 0;
   for (const entry of tracker.entries) {
+    costUsd += entry.cost;
     tokensInput += entry.inputTokens;
     tokensOutput += entry.outputTokens;
     tokensCacheRead += entry.cacheReadInputTokens;
     tokensCacheWrite += entry.cacheCreationInputTokens;
   }
   return {
-    costUsd: tracker.totalCost,
+    costUsd: Math.round(costUsd * 10000) / 10000,
     tokensInput,
     tokensOutput,
     tokensCacheRead,


### PR DESCRIPTION
## Summary

- Extend `withPipelineRun` lifecycle helper with an optional `tracker?: CostTracker` parameter (QUA-1013 / QUA-1038).
- When provided, `finalize` snapshots `tracker.totalCost` + per-token-bucket sums after the body returns or throws and forwards them to `endPipelineRun` so cost telemetry lands in the `pipeline_runs` row.
- Round `costUsd` to 4 decimal places before sending — pricing-module math produces FP-imprecise totals like `0.006196500000000001` that fail the server's `EndPipelineRunSchema.costUsd.multipleOf(0.0001)` Zod validator and would silently lose the audit trail.
- Existing callers without `tracker` produce identical /end payloads to before — the cost fields are omitted, not nulled, preserving the QUA-1012 typed-client semantic that omitted ≠ null.
- Document and warn-log the `allowOffline + tracker` silent-drop case (no run row exists in offline mode, so totals can't be persisted).

## Test plan

- [x] `pnpm vitest run crux/lib/pipeline-runs/lifecycle.test.ts` (15 tests, was 12)
- [x] New tests cover: success-path totals + Zod schema validation, body-throw still records pre-abort totals, no-tracker omits fields, empty-tracker sends zeros, offline-with-tracker warns
- [x] Sanity-guarded that the success-path test inputs produce an FP-imprecise total — this is what proves the rounding is exercised (the previous `claude-sonnet-4-5` typo silently fell through to `cost = 0`)
- [x] `pnpm crux w validate gate --fix` (all 70 checks pass)
- [x] `npx tsc --noEmit -p crux/tsconfig.json` (14 errors, baseline 25 — no new errors)
- [x] Red-teamed the `trackerTotals` path: 1000-entry batch, near-MAX_COST_USD external cost, sub-cent costs that round to zero — all produce schema-valid payloads.

Fixes QUA-1013

## Review Phases Skipped

- phase-5-category: N/A: pure lib helper change, no UI/API/CLI/data/infra files in diff

Full tracker: `.claude/review-phases-done` (gitignored, session-local).
