### PR TITLE
fix(content): promote 7 FMTI stub orgs to YAML (QUA-869)

### DIFF
--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -9632,3 +9632,112 @@
     - transparency
   lastUpdated: 2026-04
 
+# QUA-869 — FMTI-only orgs promoted from PG stubs so /organizations/<slug>
+# resolves. stableIds match the existing PG rows (created by `fmti-ingest
+# --ensure-stubs` in QUA-748) so the scorecard_grades FKs stay valid; that's
+# why they don't carry the canonical sid_ prefix the newer entries use.
+- id: ai21-labs
+  stableId: JKhtN999IF
+  type: organization
+  orgType: frontier-lab
+  title: AI21 Labs
+  website: https://www.ai21.com
+  description: >-
+    Israeli AI lab founded in 2017 by Yoav Shoham, Ori Goshen, and Amnon
+    Shashua. Develops the Jurassic and Jamba families of large language
+    models for enterprise NLP, with a focus on retrieval-augmented and
+    structured-reasoning applications.
+  lastUpdated: 2026-05
+
+- id: midjourney
+  stableId: SbllNiZtTX
+  type: organization
+  orgType: startup
+  title: Midjourney
+  website: https://www.midjourney.com
+  description: >-
+    Independent research lab founded in 2021 by David Holz that operates
+    the Midjourney image-generation service, originally distributed
+    through Discord. Self-funded and known for stylised image outputs
+    used widely in concept art and marketing.
+  lastUpdated: 2026-05
+
+- id: writer
+  stableId: MVMR4oL7Wj
+  type: organization
+  orgType: startup
+  title: Writer
+  aliases:
+    - Writer.com
+    - Writer AI
+  website: https://writer.com
+  description: >-
+    San Francisco-based enterprise generative-AI startup founded in 2020
+    by May Habib and Waseem AlShikh. Develops the Palmyra family of
+    domain-specific large language models and a B2B platform for
+    AI-assisted writing, knowledge work, and agent workflows.
+  lastUpdated: 2026-05
+
+- id: adept
+  stableId: vnxlRm3c1P
+  type: organization
+  orgType: startup
+  title: Adept
+  aliases:
+    - Adept AI
+    - Adept AI Labs
+  website: https://www.adept.ai
+  description: >-
+    San Francisco AI lab founded in 2022 by David Luan and former
+    Transformer co-authors to build agent models that drive software
+    interfaces. Best known for the ACT-1 and Fuyu model families. In
+    2024 most of its leadership and a non-exclusive technology licence
+    were acquired by Amazon, leaving a residual research team.
+  lastUpdated: 2026-05
+
+- id: bigcode
+  stableId: yAMKxvX5Y4
+  type: organization
+  orgType: academic
+  title: BigCode
+  aliases:
+    - BigCode Project
+  website: https://www.bigcode-project.org
+  description: >-
+    Open scientific collaboration between Hugging Face and ServiceNow
+    Research focused on the responsible development of large language
+    models for code. Released the StarCoder and StarCoder2 model
+    families along with The Stack training corpus, with explicit
+    attention to data provenance and opt-out tooling.
+  lastUpdated: 2026-05
+
+- id: aleph-alpha
+  stableId: ntEukcEAql
+  type: organization
+  orgType: frontier-lab
+  title: Aleph Alpha
+  website: https://aleph-alpha.com
+  description: >-
+    German AI company founded in 2019 by Jonas Andrulis and Samuel
+    Weinbach, headquartered in Heidelberg. Develops the Luminous family
+    of large language models and positions itself around European data
+    sovereignty, sovereign-AI deployments, and government and industrial
+    customers.
+  lastUpdated: 2026-05
+
+- id: stability-ai
+  stableId: TYBHN35TCA
+  type: organization
+  orgType: frontier-lab
+  title: Stability AI
+  aliases:
+    - Stability
+  website: https://stability.ai
+  description: >-
+    UK-based generative-AI company founded in 2019 by Emad Mostaque.
+    Best known for funding and releasing Stable Diffusion (in
+    collaboration with the CompVis group at LMU Munich and Runway), and
+    for subsequent open-weight image, video, and audio generative model
+    families.
+  lastUpdated: 2026-05
+

--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -9672,10 +9672,12 @@
     - Writer AI
   website: https://writer.com
   description: >-
-    San Francisco-based enterprise generative-AI startup founded in 2020
-    by May Habib and Waseem AlShikh. Develops the Palmyra family of
-    domain-specific large language models and a B2B platform for
-    AI-assisted writing, knowledge work, and agent workflows.
+    San Francisco-based enterprise generative-AI startup founded by May
+    Habib and Waseem AlShikh, who previously co-founded Qordoba (2015)
+    and rebranded to Writer in 2020 around their own large language
+    models. Develops the Palmyra family of domain-specific LLMs and a
+    B2B platform for AI-assisted writing, knowledge work, and agent
+    workflows.
   lastUpdated: 2026-05
 
 - id: adept
@@ -9688,11 +9690,12 @@
     - Adept AI Labs
   website: https://www.adept.ai
   description: >-
-    San Francisco AI lab founded in 2022 by David Luan and former
-    Transformer co-authors to build agent models that drive software
-    interfaces. Best known for the ACT-1 and Fuyu model families. In
-    2024 most of its leadership and a non-exclusive technology licence
-    were acquired by Amazon, leaving a residual research team.
+    San Francisco AI lab founded in 2022 by David Luan together with
+    Transformer co-authors Ashish Vaswani and Niki Parmar (among others)
+    to build agent models that drive software interfaces. Best known
+    for the ACT-1 and Fuyu model families. In 2024 most of its
+    leadership and a non-exclusive technology licence were acquired by
+    Amazon, leaving a residual research team.
   lastUpdated: 2026-05
 
 - id: bigcode


### PR DESCRIPTION
## Summary

The FMTI ingester's `--ensure-stubs` path (QUA-748) created lightweight PG-only entities for 7 orgs that aren't in YAML. They surfaced as rows on `/scorecards` but their `/organizations/<slug>` link returned 404, because that route reads `database.json` (built from YAML) and the stubs had no YAML entries.

This PR adds minimal YAML entries for: AI21 Labs, Midjourney, Writer, Adept, BigCode, Aleph Alpha, Stability AI.

The stableIds match the existing PG rows (bare-10 alphanumeric, e.g. `JKhtN999IF`). That's deliberate: those rows are already FK-referenced by `scorecard_grades.entity_id`, and the entities-sync displacement logic at `apps/wiki-server/src/routes/tablebase/entities.ts:1089-1098` would otherwise rename the existing rows to `<title>-displaced-<sidpart>` and break the FMTI grade joins on `/scorecards`. Verified each YAML stableId equals `generateId("organization:<slug>")` (sha256 → base64url → strip `-`/`_`) so the upsert hits `onConflictDoUpdate(target: stableId)` cleanly. Sync's `clearStubIfEnriched` will auto-strip `metadata.stub` once descriptions land.

A YAML comment in the diff calls out why these 7 don't carry the canonical `sid_` prefix newer entries use. Followed the QUA-750/QUA-752 SaferAI/Seoul precedents for entry shape.

## Verification

- Prod baseline: all 7 `/organizations/<slug>` return 404 today (`curl https://www.longtermwiki.com/organizations/ai21-labs`, etc.).
- `pnpm crux w validate gate --scope=content --fix` passes.
- `pnpm setup:quick` rebuilds `database.json`; all 7 entries present in `typedEntities` with correct `type=organization`, expected `orgType`, and the existing PG stableIds.
- Local Next.js dev server (`DEV_PORT=3014`): all 7 `/organizations/<slug>` return 200 with proper titles.
- Hostile review (Phase 3b): 0 CRITICAL/HIGH/MEDIUM, 3 LOW description-polish nits — Adept and Writer descriptions revised in a follow-up commit.

## Test plan

- [x] gate passes locally
- [x] all 7 pages render 200 in local dev server
- [x] each YAML stableId verified to match `generateId("organization:<slug>")`
- [ ] CI green
- [ ] After merge + deploy: confirm `/organizations/ai21-labs` (etc.) returns 200 in prod
- [ ] After deploy: spot-check `/scorecards` row links for the 7 orgs

Fixes QUA-869.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the organization directory with seven new entries: ai21-labs, Midjourney, Writer, Adept, BigCode, Aleph Alpha, and Stability AI. Each organization is now fully integrated with complete profiles including descriptions, website links, and comprehensive metadata to enhance discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->