### PR TITLE
feat(QUA-745): expose model aliases in UI (detail page + search) and add /internal/model-aliases

### DIFF
--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -66,9 +66,8 @@ export default async function AiModelDetailPage({
     return notFound();
   }
 
-  // Fetch system cards (QUA-702) and model aliases (QUA-745) in parallel.
-  // Best-effort: a wiki-server outage shouldn't break the whole page, just
-  // hide the tab / drop the "Also known as" line.
+  // Best-effort: a wiki-server outage shouldn't break the page, just hide
+  // the system-card tab and drop the "Also known as" line.
   let systemCards: RpcModelSystemCardRow[] = [];
   let aliases: string[] = [];
   if (entity.stableId) {
@@ -78,14 +77,14 @@ export default async function AiModelDetailPage({
         { revalidate: 300 },
       ),
       fetchFromWikiServer<RpcModelAliasesAllResult>(
-        `/api/model-aliases/all?modelStableId=${encodeURIComponent(entity.stableId)}&limit=200`,
+        `/api/model-aliases/all?modelStableId=${encodeURIComponent(entity.stableId)}&limit=20`,
         { revalidate: 300 },
       ),
     ]);
     if (cardsResult?.items) systemCards = cardsResult.items;
     if (aliasesResult?.items) {
-      // Skip aliases that are already the entity title (case-insensitive) —
-      // showing "Also known as: gpt-4 turbo" on the GPT-4 Turbo page is noise.
+      // Skip aliases that match the entity title — "Also known as: gpt-4 turbo"
+      // on the GPT-4 Turbo page is noise.
       const titleLower = entity.title.toLowerCase();
       aliases = aliasesResult.items
         .map((r) => r.alias)
@@ -268,7 +267,7 @@ export default async function AiModelDetailPage({
       entityId={entity.id}
       title={entity.title}
       titlePills={titlePills}
-      aliases={aliases.length > 0 ? aliases : undefined}
+      aliases={aliases}
       coverage={{ score: coverageScore, signals: coverageSignals }}
       subtitle={entity.description || undefined}
       headerLinks={headerLinks}

--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -30,6 +30,7 @@ import {
   fetchFromWikiServer,
   type RpcModelSystemCardsByModelResult,
   type RpcModelSystemCardRow,
+  type RpcModelAliasesAllResult,
 } from "@lib/wiki-server";
 
 export function generateStaticParams() {
@@ -65,15 +66,31 @@ export default async function AiModelDetailPage({
     return notFound();
   }
 
-  // Fetch system cards (QUA-702). Best-effort: a wiki-server outage shouldn't
-  // break the whole page, just hide the tab.
+  // Fetch system cards (QUA-702) and model aliases (QUA-745) in parallel.
+  // Best-effort: a wiki-server outage shouldn't break the whole page, just
+  // hide the tab / drop the "Also known as" line.
   let systemCards: RpcModelSystemCardRow[] = [];
+  let aliases: string[] = [];
   if (entity.stableId) {
-    const result = await fetchFromWikiServer<RpcModelSystemCardsByModelResult>(
-      `/api/model-system-cards/by-model/${entity.stableId}?limit=20`,
-      { revalidate: 300 },
-    );
-    if (result?.items) systemCards = result.items;
+    const [cardsResult, aliasesResult] = await Promise.all([
+      fetchFromWikiServer<RpcModelSystemCardsByModelResult>(
+        `/api/model-system-cards/by-model/${entity.stableId}?limit=20`,
+        { revalidate: 300 },
+      ),
+      fetchFromWikiServer<RpcModelAliasesAllResult>(
+        `/api/model-aliases/all?modelStableId=${encodeURIComponent(entity.stableId)}&limit=200`,
+        { revalidate: 300 },
+      ),
+    ]);
+    if (cardsResult?.items) systemCards = cardsResult.items;
+    if (aliasesResult?.items) {
+      // Skip aliases that are already the entity title (case-insensitive) —
+      // showing "Also known as: gpt-4 turbo" on the GPT-4 Turbo page is noise.
+      const titleLower = entity.title.toLowerCase();
+      aliases = aliasesResult.items
+        .map((r) => r.alias)
+        .filter((a) => a.toLowerCase() !== titleLower);
+    }
   }
 
   // Resolve developer
@@ -251,6 +268,7 @@ export default async function AiModelDetailPage({
       entityId={entity.id}
       title={entity.title}
       titlePills={titlePills}
+      aliases={aliases.length > 0 ? aliases : undefined}
       coverage={{ score: coverageScore, signals: coverageSignals }}
       subtitle={entity.description || undefined}
       headerLinks={headerLinks}

--- a/apps/web/src/app/internal/model-aliases-dashboard/model-aliases-dashboard-content.tsx
+++ b/apps/web/src/app/internal/model-aliases-dashboard/model-aliases-dashboard-content.tsx
@@ -89,7 +89,11 @@ export async function ModelAliasesDashboardContent() {
       modelStableId,
       rows: rows.sort((a, b) => a.alias.localeCompare(b.alias)),
     }))
-    .sort((a, b) => b.rows.length - a.rows.length);
+    .sort(
+      (a, b) =>
+        b.rows.length - a.rows.length ||
+        a.modelStableId.localeCompare(b.modelStableId),
+    );
 
   return (
     <>
@@ -109,7 +113,7 @@ export async function ModelAliasesDashboardContent() {
         <StatCard
           label="Canonical Models"
           value={byModel.size.toString()}
-          sub={`with ≥1 alias`}
+          sub="with ≥1 alias"
         />
         <StatCard
           label="Sources"
@@ -207,7 +211,7 @@ export async function ModelAliasesDashboardContent() {
             </code>{" "}
             to populate this table from seed YAML, or promote an entry from{" "}
             <a
-              href="/wiki/E2541"
+              href="/internal/benchmark-quarantine-dashboard"
               className="text-primary hover:underline"
             >
               Benchmark Quarantine

--- a/apps/web/src/app/internal/model-aliases-dashboard/model-aliases-dashboard-content.tsx
+++ b/apps/web/src/app/internal/model-aliases-dashboard/model-aliases-dashboard-content.tsx
@@ -2,8 +2,6 @@
  * Model Aliases Dashboard — exposes the model_aliases table that maps raw
  * external model names (e.g. "gpt-4-turbo-2024-04-09") to canonical AI-model
  * entity stable_ids. Used by Phase 2 benchmark ingesters at resolution time.
- *
- * QUA-745 — surfaces existing data; no new ingest path.
  */
 import {
   fetchDetailed,
@@ -53,17 +51,15 @@ function emptyFallback(): DashboardData {
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
-function confidenceColor(c: string): string {
-  switch (c) {
-    case "exact":
-      return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300";
-    case "fuzzy":
-      return "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300";
-    case "manual":
-      return "bg-sky-100 text-sky-800 dark:bg-sky-900/30 dark:text-sky-300";
-    default:
-      return "bg-muted/40 text-muted-foreground";
-  }
+const CONFIDENCE_COLORS: Record<RpcModelAliasRow["confidence"], string> = {
+  exact: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
+  fuzzy: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  manual: "bg-sky-100 text-sky-800 dark:bg-sky-900/30 dark:text-sky-300",
+};
+
+function breakdownSub<T>(rows: T[], format: (r: T) => string): string | undefined {
+  if (rows.length === 0) return undefined;
+  return rows.map(format).join(", ");
 }
 
 // ── Content Component ────────────────────────────────────────────────────
@@ -75,9 +71,8 @@ export async function ModelAliasesDashboardContent() {
   );
 
   const { stats, aliases } = data;
+  const truncated = stats.total > aliases.length;
 
-  // Group aliases by their target model (modelStableId) — the dashboard's
-  // primary view is "for each canonical model, what aliases point at it?".
   const byModel = new Map<string, RpcModelAliasRow[]>();
   for (const a of aliases) {
     const arr = byModel.get(a.modelStableId);
@@ -107,39 +102,28 @@ export async function ModelAliasesDashboardContent() {
         by the <code className="text-xs">model_aliases</code> table.
       </p>
 
-      {/* Summary stats */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 my-6">
         <StatCard label="Total Aliases" value={stats.total.toString()} />
         <StatCard
           label="Canonical Models"
-          value={byModel.size.toString()}
-          sub="with ≥1 alias"
+          value={truncated ? `${byModel.size}+` : byModel.size.toString()}
+          sub={truncated ? "of loaded aliases" : "with ≥1 alias"}
         />
         <StatCard
           label="Sources"
           value={stats.bySource.length.toString()}
-          sub={
-            stats.bySource.length > 0
-              ? stats.bySource
-                  .map((s) => `${s.source} (${s.total})`)
-                  .join(", ")
-              : undefined
-          }
+          sub={breakdownSub(stats.bySource, (r) => `${r.source} (${r.total})`)}
         />
         <StatCard
           label="By Confidence"
-          value={stats.byConfidence.reduce((s, x) => s + x.total, 0).toString()}
-          sub={
-            stats.byConfidence.length > 0
-              ? stats.byConfidence
-                  .map((c) => `${c.confidence} (${c.total})`)
-                  .join(", ")
-              : undefined
-          }
+          value={stats.byConfidence.length.toString()}
+          sub={breakdownSub(
+            stats.byConfidence,
+            (r) => `${r.confidence} (${r.total})`,
+          )}
         />
       </div>
 
-      {/* Grouped table — one row per (model, alias) — model rowspans across its aliases */}
       {groupedRows.length > 0 && (
         <div className="my-6 rounded-lg border border-border/60 overflow-hidden">
           <table className="w-full text-sm">
@@ -176,9 +160,7 @@ export async function ModelAliasesDashboardContent() {
                     </td>
                     <td className="py-2 px-3">
                       <span
-                        className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold ${confidenceColor(
-                          row.confidence,
-                        )}`}
+                        className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold ${CONFIDENCE_COLORS[row.confidence] ?? "bg-muted/40 text-muted-foreground"}`}
                       >
                         {row.confidence}
                       </span>

--- a/apps/web/src/app/internal/model-aliases-dashboard/model-aliases-dashboard-content.tsx
+++ b/apps/web/src/app/internal/model-aliases-dashboard/model-aliases-dashboard-content.tsx
@@ -1,0 +1,243 @@
+/**
+ * Model Aliases Dashboard — exposes the model_aliases table that maps raw
+ * external model names (e.g. "gpt-4-turbo-2024-04-09") to canonical AI-model
+ * entity stable_ids. Used by Phase 2 benchmark ingesters at resolution time.
+ *
+ * QUA-745 — surfaces existing data; no new ingest path.
+ */
+import {
+  fetchDetailed,
+  withApiFallback,
+  type FetchResult,
+  type RpcModelAliasesAllResult,
+  type RpcModelAliasesStatsResult,
+  type RpcModelAliasRow,
+} from "@lib/wiki-server";
+import { DataSourceBanner } from "@components/internal/DataSourceBanner";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface DashboardData {
+  stats: RpcModelAliasesStatsResult;
+  aliases: RpcModelAliasRow[];
+}
+
+// ── Data Loading ─────────────────────────────────────────────────────────
+
+async function loadFromApi(): Promise<FetchResult<DashboardData>> {
+  const [statsResult, allResult] = await Promise.all([
+    fetchDetailed<RpcModelAliasesStatsResult>("/api/model-aliases/stats", {
+      revalidate: 60,
+    }),
+    fetchDetailed<RpcModelAliasesAllResult>(
+      "/api/model-aliases/all?limit=500",
+      { revalidate: 60 },
+    ),
+  ]);
+
+  if (!statsResult.ok) return statsResult;
+  if (!allResult.ok) return allResult;
+
+  return {
+    ok: true,
+    data: { stats: statsResult.data, aliases: allResult.data.items },
+  };
+}
+
+function emptyFallback(): DashboardData {
+  return {
+    stats: { total: 0, bySource: [], byConfidence: [] },
+    aliases: [],
+  };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function confidenceColor(c: string): string {
+  switch (c) {
+    case "exact":
+      return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300";
+    case "fuzzy":
+      return "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300";
+    case "manual":
+      return "bg-sky-100 text-sky-800 dark:bg-sky-900/30 dark:text-sky-300";
+    default:
+      return "bg-muted/40 text-muted-foreground";
+  }
+}
+
+// ── Content Component ────────────────────────────────────────────────────
+
+export async function ModelAliasesDashboardContent() {
+  const { data, source, apiError } = await withApiFallback(
+    loadFromApi,
+    emptyFallback,
+  );
+
+  const { stats, aliases } = data;
+
+  // Group aliases by their target model (modelStableId) — the dashboard's
+  // primary view is "for each canonical model, what aliases point at it?".
+  const byModel = new Map<string, RpcModelAliasRow[]>();
+  for (const a of aliases) {
+    const arr = byModel.get(a.modelStableId);
+    if (arr) arr.push(a);
+    else byModel.set(a.modelStableId, [a]);
+  }
+  const groupedRows = Array.from(byModel.entries())
+    .map(([modelStableId, rows]) => ({
+      modelStableId,
+      rows: rows.sort((a, b) => a.alias.localeCompare(b.alias)),
+    }))
+    .sort((a, b) => b.rows.length - a.rows.length);
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm leading-relaxed">
+        Maps raw external model names (e.g.{" "}
+        <code className="text-xs">gpt-4-turbo-2024-04-09</code>) to the
+        canonical AI-model entity (e.g. <code className="text-xs">GPT-4 Turbo</code>).
+        Populated by{" "}
+        <code className="text-xs">crux tb model-aliases sync</code> from
+        seed YAML and ingester promotions out of benchmark quarantine. Backed
+        by the <code className="text-xs">model_aliases</code> table.
+      </p>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 my-6">
+        <StatCard label="Total Aliases" value={stats.total.toString()} />
+        <StatCard
+          label="Canonical Models"
+          value={byModel.size.toString()}
+          sub={`with ≥1 alias`}
+        />
+        <StatCard
+          label="Sources"
+          value={stats.bySource.length.toString()}
+          sub={
+            stats.bySource.length > 0
+              ? stats.bySource
+                  .map((s) => `${s.source} (${s.total})`)
+                  .join(", ")
+              : undefined
+          }
+        />
+        <StatCard
+          label="By Confidence"
+          value={stats.byConfidence.reduce((s, x) => s + x.total, 0).toString()}
+          sub={
+            stats.byConfidence.length > 0
+              ? stats.byConfidence
+                  .map((c) => `${c.confidence} (${c.total})`)
+                  .join(", ")
+              : undefined
+          }
+        />
+      </div>
+
+      {/* Grouped table — one row per (model, alias) — model rowspans across its aliases */}
+      {groupedRows.length > 0 && (
+        <div className="my-6 rounded-lg border border-border/60 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/30">
+              <tr className="text-xs text-muted-foreground">
+                <th className="py-2 px-3 text-left font-medium">Canonical Model</th>
+                <th className="py-2 px-3 text-left font-medium">Alias</th>
+                <th className="py-2 px-3 text-left font-medium">Source</th>
+                <th className="py-2 px-3 text-left font-medium">Confidence</th>
+                <th className="py-2 px-3 text-left font-medium">Synced</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/50">
+              {groupedRows.flatMap((g) =>
+                g.rows.map((row, i) => (
+                  <tr
+                    key={`${g.modelStableId}-${row.alias}`}
+                    className="hover:bg-muted/20"
+                  >
+                    {i === 0 ? (
+                      <td
+                        rowSpan={g.rows.length}
+                        className="py-2 px-3 align-top font-mono text-xs text-muted-foreground border-r border-border/50"
+                      >
+                        {g.modelStableId}
+                        <span className="block text-muted-foreground/50">
+                          {g.rows.length} alias{g.rows.length === 1 ? "" : "es"}
+                        </span>
+                      </td>
+                    ) : null}
+                    <td className="py-2 px-3 font-mono text-xs">{row.alias}</td>
+                    <td className="py-2 px-3 text-muted-foreground">
+                      {row.source}
+                    </td>
+                    <td className="py-2 px-3">
+                      <span
+                        className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold ${confidenceColor(
+                          row.confidence,
+                        )}`}
+                      >
+                        {row.confidence}
+                      </span>
+                    </td>
+                    <td className="py-2 px-3 text-xs text-muted-foreground tabular-nums">
+                      {row.syncedAt
+                        ? new Date(row.syncedAt).toISOString().slice(0, 10)
+                        : "—"}
+                    </td>
+                  </tr>
+                )),
+              )}
+            </tbody>
+          </table>
+          {stats.total > aliases.length && (
+            <div className="px-3 py-2 text-xs text-muted-foreground text-center bg-muted/20">
+              Showing {aliases.length} of {stats.total} aliases
+            </div>
+          )}
+        </div>
+      )}
+
+      {stats.total === 0 && (
+        <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground my-6">
+          <p className="text-lg font-medium mb-2">No model aliases yet</p>
+          <p className="text-sm">
+            Run{" "}
+            <code className="text-xs">
+              crux tb model-aliases sync
+            </code>{" "}
+            to populate this table from seed YAML, or promote an entry from{" "}
+            <a
+              href="/wiki/E2541"
+              className="text-primary hover:underline"
+            >
+              Benchmark Quarantine
+            </a>
+            .
+          </p>
+        </div>
+      )}
+
+      <DataSourceBanner source={source} apiError={apiError} />
+    </>
+  );
+}
+
+// ── Helper Components ────────────────────────────────────────────────────
+
+function StatCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 p-4">
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      <p className="text-2xl font-bold tabular-nums">{value}</p>
+      {sub && <p className="text-xs text-muted-foreground mt-1">{sub}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/app/internal/model-aliases-dashboard/page.tsx
+++ b/apps/web/src/app/internal/model-aliases-dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function ModelAliasesDashboardPage() {
+  redirect("/wiki/E2556");
+}

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -88,6 +88,7 @@ import { TablebaseCoverageContent } from "@/app/internal/tablebase-coverage/tabl
 import { AutomationLandscapeContent } from "@/app/internal/automation-landscape/automation-landscape-content";
 import { FrameworkReviewContent } from "@/app/internal/framework-review/framework-review-content";
 import { BenchmarkQuarantineContent } from "@/app/internal/benchmark-quarantine/benchmark-quarantine-content";
+import { ModelAliasesDashboardContent } from "@/app/internal/model-aliases-dashboard/model-aliases-dashboard-content";
 
 // Ported stub components — high priority
 import { Section } from "@/components/wiki/Section";
@@ -258,6 +259,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   AutomationLandscapeContent,
   FrameworkReviewContent,
   BenchmarkQuarantineContent,
+  ModelAliasesDashboardContent,
 
   // Table view components
   SafetyApproachesTableView,

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -289,6 +289,7 @@ export function getInternalNav(): NavSection[] {
         { label: "Jobs", href: internalHref("jobs-dashboard") },
         { label: "System Cards", href: internalHref("system-cards-dashboard") },
         { label: "Benchmark Quarantine", href: internalHref("benchmark-quarantine-dashboard") },
+        { label: "Model Aliases", href: internalHref("model-aliases-dashboard") },
         { label: "Framework Review", href: internalHref("framework-review-dashboard") },
         { label: "Coverage", href: internalHref("tablebase-coverage-dashboard") },
       ],

--- a/apps/web/src/lib/wiki-server.ts
+++ b/apps/web/src/lib/wiki-server.ts
@@ -213,6 +213,7 @@ import type { CampaignFinanceRoute } from "@wiki-server/campaign-finance-route";
 import type { ModelSystemCardsRoute } from "@wiki-server/model-system-cards-route";
 import type { FrameworkReviewRoute } from "@wiki-server/framework-review-route";
 import type { BenchmarkResultsPendingRoute } from "@wiki-server/benchmark-results-pending-route";
+import type { ModelAliasesRoute } from "@wiki-server/model-aliases-route";
 
 /**
  * Create a typed Hono RPC client for the facts API.
@@ -647,6 +648,27 @@ export type RpcBenchmarkResultsPendingAllResult = InferResponseType<
 
 /** A single quarantine row from the all endpoint */
 export type RpcBenchmarkResultsPendingRow = RpcBenchmarkResultsPendingAllResult['items'][number];
+
+// ============================================================================
+// Hono RPC client — Model Aliases API (QUA-689 / QUA-745)
+// ============================================================================
+
+type ModelAliasesClient = ReturnType<typeof hc<ModelAliasesRoute>>;
+
+/** Inferred response type for GET /api/model-aliases/stats */
+export type RpcModelAliasesStatsResult = InferResponseType<
+  ModelAliasesClient['stats']['$get'],
+  200
+>;
+
+/** Inferred response type for GET /api/model-aliases/all */
+export type RpcModelAliasesAllResult = InferResponseType<
+  ModelAliasesClient['all']['$get'],
+  200
+>;
+
+/** A single alias row from the all endpoint */
+export type RpcModelAliasRow = RpcModelAliasesAllResult['items'][number];
 
 // ============================================================================
 // Hono RPC client — Framework Review API (QUA-710)

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -43,7 +43,8 @@
       "@wiki-server/resources-route": ["../wiki-server/src/routes/wikibase/resources.ts"],
       "@wiki-server/model-system-cards-route": ["../wiki-server/src/routes/tablebase/model-system-cards.ts"],
       "@wiki-server/framework-review-route": ["../wiki-server/src/routes/operational/framework-review.ts"],
-      "@wiki-server/benchmark-results-pending-route": ["../wiki-server/src/routes/tablebase/benchmark-results-pending.ts"]
+      "@wiki-server/benchmark-results-pending-route": ["../wiki-server/src/routes/tablebase/benchmark-results-pending.ts"],
+      "@wiki-server/model-aliases-route": ["../wiki-server/src/routes/tablebase/model-aliases.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/apps/wiki-server/src/__tests__/pages.test.ts
+++ b/apps/wiki-server/src/__tests__/pages.test.ts
@@ -6,10 +6,14 @@ import { mockDbModule, postJson } from "./test-utils.js";
 
 let pagesStore: Map<string, Record<string, unknown>>;
 let entityIdsStore: Map<number, { slug: string; description: string | null; created_at: Date }>;
+let modelAliasesStore: Array<{ alias: string; model_stable_id: string }>;
+let entitiesStore: Map<string, { id: string; stable_id: string }>; // slug → row
 
 function resetStores() {
   pagesStore = new Map();
   entityIdsStore = new Map();
+  modelAliasesStore = [];
+  entitiesStore = new Map();
 }
 
 /**
@@ -179,6 +183,55 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       }
     }
     return results.slice(0, limit);
+  }
+
+  // --- model_aliases JOIN entities JOIN wiki_pages: alias-based search (QUA-745) ---
+  if (q.includes("model_aliases") && q.includes("join entities") && q.includes("join wiki_pages")) {
+    const aliasLower = params[0] as string;
+    const aliasPrefix = params[1] as string; // "alias%" form
+    const limit = (params[2] as number) || 20;
+    const excludeIds = (params[3] as string[]) || [];
+    const prefixCore = aliasPrefix.endsWith("%") ? aliasPrefix.slice(0, -1) : aliasPrefix;
+
+    type Hit = { row: Record<string, unknown>; rank: number };
+    const hits: Hit[] = [];
+    const seen = new Set<string>();
+    for (const a of modelAliasesStore) {
+      const isExact = a.alias === aliasLower;
+      const isPrefix = a.alias.startsWith(prefixCore);
+      if (!isExact && !isPrefix) continue;
+
+      const ent = Array.from(entitiesStore.values()).find(
+        (e) => e.stable_id === a.model_stable_id,
+      );
+      if (!ent) continue;
+
+      const page = pagesStore.get(ent.id);
+      if (!page) continue;
+      if (excludeIds.includes(page.slug as string)) continue;
+      if (page.entity_type === "internal") continue;
+      if (page.wiki_id == null) continue;
+      if (seen.has(page.slug as string)) continue;
+      seen.add(page.slug as string);
+
+      hits.push({
+        row: {
+          id: page.slug,
+          wiki_id: page.wiki_id,
+          title: page.title,
+          description: page.description,
+          entity_type: page.entity_type,
+          category: page.category,
+          reader_importance: page.reader_importance,
+          quality: page.quality,
+          rank: isExact ? 100.0 : 50.0,
+          snippet: page.description || null,
+        },
+        rank: isExact ? 100.0 : 50.0,
+      });
+    }
+    hits.sort((a, b) => b.rank - a.rank);
+    return hits.slice(0, limit).map((h) => h.row);
   }
 
   // --- wiki_pages: SELECT with WHERE + OR (get by slug or wiki_id) ---
@@ -515,6 +568,53 @@ describe("Pages API", () => {
     it("returns empty results for no match", async () => {
       const res = await app.request(
         "/api/pages/search?q=nonexistentxyz"
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results).toHaveLength(0);
+    });
+
+    // QUA-745 — alias-based search resolves external naming to canonical pages.
+    it("resolves a model alias to the canonical wiki page", async () => {
+      await seedPage(app, "gpt-4-turbo", "GPT-4 Turbo", {
+        description: "OpenAI flagship turbo model",
+        entityType: "ai-model",
+      });
+      // Seed the entity row + alias row that the alias-search SQL JOINs against.
+      entitiesStore.set("gpt-4-turbo", {
+        id: "gpt-4-turbo",
+        stable_id: "sid_gpt4turbo",
+      });
+      modelAliasesStore.push({
+        alias: "gpt-4-turbo-2024-04-09",
+        model_stable_id: "sid_gpt4turbo",
+      });
+
+      const res = await app.request(
+        "/api/pages/search?q=gpt-4-turbo-2024-04-09"
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results.length).toBeGreaterThan(0);
+      expect(body.results[0].id).toBe("gpt-4-turbo");
+    });
+
+    it("does not match an alias whose target page has no wiki_id", async () => {
+      await seedPage(app, "phantom-model", "Phantom Model", {
+        wikiId: null,
+        entityType: "ai-model",
+      });
+      entitiesStore.set("phantom-model", {
+        id: "phantom-model",
+        stable_id: "sid_phantom",
+      });
+      modelAliasesStore.push({
+        alias: "phantom-2024-01-01",
+        model_stable_id: "sid_phantom",
+      });
+
+      const res = await app.request(
+        "/api/pages/search?q=phantom-2024-01-01"
       );
       expect(res.status).toBe(200);
       const body = await res.json();

--- a/apps/wiki-server/src/__tests__/pages.test.ts
+++ b/apps/wiki-server/src/__tests__/pages.test.ts
@@ -185,32 +185,26 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return results.slice(0, limit);
   }
 
-  // --- model_aliases JOIN entities JOIN wiki_pages: alias-based search (QUA-745) ---
-  // Mirrors the Phase 3 SQL in apps/wiki-server/src/routes/wikibase/pages.ts:
-  //   DISTINCT ON (wp.slug) ... ORDER BY wp.slug, rank DESC
-  //   WHERE wp.entity_type = 'ai-model' AND wp.wiki_id IS NOT NULL
-  //         AND (ma.alias = $1 OR ma.alias LIKE $2)
-  //         AND wp.slug NOT IN excludeIds
+  // Mirrors the Phase 3 alias-search SQL in routes/wikibase/pages.ts.
   if (q.includes("model_aliases") && q.includes("join entities") && q.includes("join wiki_pages")) {
     const aliasLower = params[0] as string;
-    const aliasPrefix = params[1] as string; // "alias%" form
+    const aliasPrefix = params[1] as string;
     const limit = (params[2] as number) || 20;
     const excludeIds = (params[3] as string[]) || [];
     const prefixCore = aliasPrefix.endsWith("%") ? aliasPrefix.slice(0, -1) : aliasPrefix;
+    const useLike = q.includes("or ma.alias like");
 
-    // Step 1: collect all candidate (slug, rank) pairs that match the WHERE.
     type Candidate = { slug: string; row: Record<string, unknown>; rank: number };
-    const candidates: Candidate[] = [];
+    const bySlug = new Map<string, Candidate>();
     for (const a of modelAliasesStore) {
       const isExact = a.alias === aliasLower;
-      const isPrefix = a.alias.startsWith(prefixCore);
+      const isPrefix = useLike && a.alias.startsWith(prefixCore);
       if (!isExact && !isPrefix) continue;
 
       const ent = Array.from(entitiesStore.values()).find(
         (e) => e.stable_id === a.model_stable_id,
       );
       if (!ent) continue;
-
       const page = pagesStore.get(ent.id);
       if (!page) continue;
       if (excludeIds.includes(page.slug as string)) continue;
@@ -218,8 +212,11 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       if (page.wiki_id == null) continue;
 
       const rank = isExact ? 100.0 : 50.0;
-      candidates.push({
-        slug: page.slug as string,
+      const slug = page.slug as string;
+      const existing = bySlug.get(slug);
+      if (existing && existing.rank >= rank) continue;
+      bySlug.set(slug, {
+        slug,
         rank,
         row: {
           id: page.slug,
@@ -236,16 +233,10 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       });
     }
 
-    // Step 2: DISTINCT ON (slug) — keep the highest-rank candidate per slug.
-    const bySlug = new Map<string, Candidate>();
-    for (const c of candidates) {
-      const existing = bySlug.get(c.slug);
-      if (!existing || c.rank > existing.rank) bySlug.set(c.slug, c);
-    }
-
-    // Step 3: sort by rank DESC (mimics the post-DISTINCT resort).
-    const hits = Array.from(bySlug.values()).sort((a, b) => b.rank - a.rank);
-    return hits.slice(0, limit).map((h) => h.row);
+    return Array.from(bySlug.values())
+      .sort((a, b) => b.rank - a.rank)
+      .slice(0, limit)
+      .map((h) => h.row);
   }
 
   // --- wiki_pages: SELECT with WHERE + OR (get by slug or wiki_id) ---
@@ -588,7 +579,6 @@ describe("Pages API", () => {
       expect(body.results).toHaveLength(0);
     });
 
-    // QUA-745 — alias-based search resolves external naming to canonical pages.
     it("resolves a model alias to the canonical wiki page", async () => {
       await seedPage(app, "gpt-4-turbo", "GPT-4 Turbo", {
         description: "OpenAI flagship turbo model",
@@ -635,8 +625,6 @@ describe("Pages API", () => {
       expect(body.results).toHaveLength(0);
     });
 
-    // Prefix match: a partial query like "claude-3-5" should still resolve
-    // to the canonical page via an alias starting with that prefix.
     it("resolves an alias via prefix match", async () => {
       await seedPage(app, "claude-3-5-sonnet", "Claude 3.5 Sonnet", {
         entityType: "ai-model",
@@ -660,8 +648,6 @@ describe("Pages API", () => {
       );
     });
 
-    // Dedup: when multiple aliases (one exact, one prefix-only) point at the
-    // same model, the canonical page should appear exactly once.
     it("dedupes when multiple aliases point at the same model", async () => {
       await seedPage(app, "gpt-4-turbo", "GPT-4 Turbo", {
         entityType: "ai-model",
@@ -691,9 +677,7 @@ describe("Pages API", () => {
       expect(matches).toHaveLength(1);
     });
 
-    // Adversarial: a `%` in the user query must not act as a LIKE wildcard.
-    // Without escapeIlike(), "%" would match every alias. The mock dispatch
-    // uses startsWith for prefix matching which mirrors the escaped form.
+    // Without escapeIlike, "%" in user input would match every alias.
     it("does not treat user input '%' as a LIKE wildcard", async () => {
       await seedPage(app, "claude-3-haiku", "Claude 3 Haiku", {
         entityType: "ai-model",
@@ -718,8 +702,6 @@ describe("Pages API", () => {
       ).toBeUndefined();
     });
 
-    // Defense in depth: even if an alias points at a non-ai-model entity
-    // (corruption / future schema drift), it must NOT leak into search.
     it("rejects an alias whose target page is not entity_type=ai-model", async () => {
       await seedPage(app, "openai", "OpenAI", {
         // Wrong type — alias should not resolve here.

--- a/apps/wiki-server/src/__tests__/pages.test.ts
+++ b/apps/wiki-server/src/__tests__/pages.test.ts
@@ -186,6 +186,11 @@ function dispatch(query: string, params: unknown[]): unknown[] {
   }
 
   // --- model_aliases JOIN entities JOIN wiki_pages: alias-based search (QUA-745) ---
+  // Mirrors the Phase 3 SQL in apps/wiki-server/src/routes/wikibase/pages.ts:
+  //   DISTINCT ON (wp.slug) ... ORDER BY wp.slug, rank DESC
+  //   WHERE wp.entity_type = 'ai-model' AND wp.wiki_id IS NOT NULL
+  //         AND (ma.alias = $1 OR ma.alias LIKE $2)
+  //         AND wp.slug NOT IN excludeIds
   if (q.includes("model_aliases") && q.includes("join entities") && q.includes("join wiki_pages")) {
     const aliasLower = params[0] as string;
     const aliasPrefix = params[1] as string; // "alias%" form
@@ -193,9 +198,9 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     const excludeIds = (params[3] as string[]) || [];
     const prefixCore = aliasPrefix.endsWith("%") ? aliasPrefix.slice(0, -1) : aliasPrefix;
 
-    type Hit = { row: Record<string, unknown>; rank: number };
-    const hits: Hit[] = [];
-    const seen = new Set<string>();
+    // Step 1: collect all candidate (slug, rank) pairs that match the WHERE.
+    type Candidate = { slug: string; row: Record<string, unknown>; rank: number };
+    const candidates: Candidate[] = [];
     for (const a of modelAliasesStore) {
       const isExact = a.alias === aliasLower;
       const isPrefix = a.alias.startsWith(prefixCore);
@@ -209,12 +214,13 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       const page = pagesStore.get(ent.id);
       if (!page) continue;
       if (excludeIds.includes(page.slug as string)) continue;
-      if (page.entity_type === "internal") continue;
+      if (page.entity_type !== "ai-model") continue;
       if (page.wiki_id == null) continue;
-      if (seen.has(page.slug as string)) continue;
-      seen.add(page.slug as string);
 
-      hits.push({
+      const rank = isExact ? 100.0 : 50.0;
+      candidates.push({
+        slug: page.slug as string,
+        rank,
         row: {
           id: page.slug,
           wiki_id: page.wiki_id,
@@ -224,13 +230,21 @@ function dispatch(query: string, params: unknown[]): unknown[] {
           category: page.category,
           reader_importance: page.reader_importance,
           quality: page.quality,
-          rank: isExact ? 100.0 : 50.0,
+          rank,
           snippet: page.description || null,
         },
-        rank: isExact ? 100.0 : 50.0,
       });
     }
-    hits.sort((a, b) => b.rank - a.rank);
+
+    // Step 2: DISTINCT ON (slug) — keep the highest-rank candidate per slug.
+    const bySlug = new Map<string, Candidate>();
+    for (const c of candidates) {
+      const existing = bySlug.get(c.slug);
+      if (!existing || c.rank > existing.rank) bySlug.set(c.slug, c);
+    }
+
+    // Step 3: sort by rank DESC (mimics the post-DISTINCT resort).
+    const hits = Array.from(bySlug.values()).sort((a, b) => b.rank - a.rank);
     return hits.slice(0, limit).map((h) => h.row);
   }
 
@@ -615,6 +629,113 @@ describe("Pages API", () => {
 
       const res = await app.request(
         "/api/pages/search?q=phantom-2024-01-01"
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results).toHaveLength(0);
+    });
+
+    // Prefix match: a partial query like "claude-3-5" should still resolve
+    // to the canonical page via an alias starting with that prefix.
+    it("resolves an alias via prefix match", async () => {
+      await seedPage(app, "claude-3-5-sonnet", "Claude 3.5 Sonnet", {
+        entityType: "ai-model",
+      });
+      entitiesStore.set("claude-3-5-sonnet", {
+        id: "claude-3-5-sonnet",
+        stable_id: "sid_claude35sonnet",
+      });
+      modelAliasesStore.push({
+        alias: "claude-3-5-sonnet-20240620",
+        model_stable_id: "sid_claude35sonnet",
+      });
+
+      const res = await app.request(
+        "/api/pages/search?q=claude-3-5-sonnet-2024",
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results.map((r: { id: string }) => r.id)).toContain(
+        "claude-3-5-sonnet",
+      );
+    });
+
+    // Dedup: when multiple aliases (one exact, one prefix-only) point at the
+    // same model, the canonical page should appear exactly once.
+    it("dedupes when multiple aliases point at the same model", async () => {
+      await seedPage(app, "gpt-4-turbo", "GPT-4 Turbo", {
+        entityType: "ai-model",
+      });
+      entitiesStore.set("gpt-4-turbo", {
+        id: "gpt-4-turbo",
+        stable_id: "sid_gpt4turbo",
+      });
+      modelAliasesStore.push(
+        { alias: "gpt-4-turbo", model_stable_id: "sid_gpt4turbo" },
+        {
+          alias: "gpt-4-turbo-2024-04-09",
+          model_stable_id: "sid_gpt4turbo",
+        },
+        {
+          alias: "gpt-4-turbo-preview",
+          model_stable_id: "sid_gpt4turbo",
+        },
+      );
+
+      const res = await app.request("/api/pages/search?q=gpt-4-turbo");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const matches = body.results.filter(
+        (r: { id: string }) => r.id === "gpt-4-turbo",
+      );
+      expect(matches).toHaveLength(1);
+    });
+
+    // Adversarial: a `%` in the user query must not act as a LIKE wildcard.
+    // Without escapeIlike(), "%" would match every alias. The mock dispatch
+    // uses startsWith for prefix matching which mirrors the escaped form.
+    it("does not treat user input '%' as a LIKE wildcard", async () => {
+      await seedPage(app, "claude-3-haiku", "Claude 3 Haiku", {
+        entityType: "ai-model",
+      });
+      entitiesStore.set("claude-3-haiku", {
+        id: "claude-3-haiku",
+        stable_id: "sid_haiku",
+      });
+      modelAliasesStore.push({
+        alias: "claude-3-haiku-20240307",
+        model_stable_id: "sid_haiku",
+      });
+
+      // A bare "%" (or "_") should NOT match the haiku alias as a wildcard.
+      const res = await app.request("/api/pages/search?q=%25");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // FTS / trigram may produce no results either; the assertion is that
+      // the alias-search phase did NOT match haiku via wildcard expansion.
+      expect(
+        body.results.find((r: { id: string }) => r.id === "claude-3-haiku"),
+      ).toBeUndefined();
+    });
+
+    // Defense in depth: even if an alias points at a non-ai-model entity
+    // (corruption / future schema drift), it must NOT leak into search.
+    it("rejects an alias whose target page is not entity_type=ai-model", async () => {
+      await seedPage(app, "openai", "OpenAI", {
+        // Wrong type — alias should not resolve here.
+        entityType: "organization",
+      });
+      entitiesStore.set("openai", {
+        id: "openai",
+        stable_id: "sid_openai",
+      });
+      modelAliasesStore.push({
+        alias: "openai-mystery-model",
+        model_stable_id: "sid_openai",
+      });
+
+      const res = await app.request(
+        "/api/pages/search?q=openai-mystery-model",
       );
       expect(res.status).toBe(200);
       const body = await res.json();

--- a/apps/wiki-server/src/routes/wikibase/pages.ts
+++ b/apps/wiki-server/src/routes/wikibase/pages.ts
@@ -25,6 +25,7 @@ import {
   paginationQuery,
   zv,
   clampedLimit,
+  escapeIlike,
 } from "../shared/utils.js";
 import { logger } from "../../logger.js";
 import {
@@ -136,6 +137,51 @@ const pagesApp = new Hono()
         [q, limit - results.length, results.map((r) => r.id)],
       );
       results = [...results, ...trigramResults];
+    }
+
+    // Phase 3 — model alias lookup (QUA-745). Tokenized FTS won't match
+    // hyphenated identifiers like "gpt-4-turbo-2024-04-09" cleanly, and
+    // aliases aren't part of wiki_pages.search_vector. Look the raw query
+    // up in model_aliases and join to the canonical wiki page for the model.
+    // Within this phase, exact alias matches sort before prefix matches.
+    // Phase 1/2 results are kept ahead of alias hits — content matches are
+    // usually what the user wants when both fire.
+    if (results.length < limit) {
+      const aliasLower = rawQ.trim().toLowerCase();
+      // Reject empty / overlong queries to keep the LIKE/trgm path bounded.
+      if (aliasLower.length > 0 && aliasLower.length <= 200) {
+        const aliasResults = await rawDb.unsafe<PageSearchRow[]>(
+          `SELECT
+            wp.slug AS id,
+            wp.wiki_id,
+            wp.title,
+            wp.description,
+            wp.entity_type,
+            wp.category,
+            wp.reader_importance,
+            wp.quality,
+            CASE WHEN ma.alias = $1 THEN 100.0 ELSE 50.0 END AS rank,
+            wp.description AS snippet
+          FROM model_aliases ma
+          JOIN entities e ON e.stable_id = ma.model_stable_id
+          JOIN wiki_pages wp ON wp.slug = e.id
+          WHERE (ma.alias = $1 OR ma.alias LIKE $2)
+            AND wp.wiki_id IS NOT NULL
+            AND (wp.entity_type IS NULL OR wp.entity_type != 'internal')
+            AND wp.slug NOT IN (SELECT unnest($4::text[]))
+          ORDER BY rank DESC, wp.reader_importance DESC NULLS LAST
+          LIMIT $3`,
+          [
+            aliasLower,
+            // escapeIlike: a literal `%` or `_` in user input would otherwise
+            // act as a LIKE wildcard and explode the match set.
+            `${escapeIlike(aliasLower)}%`,
+            limit - results.length,
+            results.map((r) => r.id),
+          ],
+        );
+        results = [...results, ...aliasResults];
+      }
     }
 
     return c.json({

--- a/apps/wiki-server/src/routes/wikibase/pages.ts
+++ b/apps/wiki-server/src/routes/wikibase/pages.ts
@@ -145,27 +145,27 @@ const pagesApp = new Hono()
       results = [...results, ...trigramResults];
     }
 
-    // Phase 3 — model alias lookup (QUA-745). Tokenized FTS won't match
-    // hyphenated identifiers like "gpt-4-turbo-2024-04-09" cleanly, and
-    // aliases aren't part of wiki_pages.search_vector. Look the raw query
-    // up in model_aliases and join to the canonical wiki page for the model.
-    // Within this phase, exact alias matches sort before prefix matches.
-    // Phase 1/2 results are kept ahead of alias hits — content matches are
-    // usually what the user wants when both fire.
-    if (results.length < limit) {
-      const aliasLower = rawQ.trim().toLowerCase();
-      // Reject empty / overlong queries to keep the LIKE/trgm path bounded.
-      if (aliasLower.length > 0 && aliasLower.length <= MAX_ALIAS_QUERY_LEN) {
-        // DISTINCT ON dedupes the result when multiple aliases point at the
-        // same model (e.g. both "gpt-4-turbo" and "gpt-4-turbo-2024-04-09"
-        // resolve to GPT-4 Turbo) — without it, the same wiki page would
-        // appear in `results` once per matching alias.
-        // entity_type filter: defense in depth. The FK only enforces that
-        // model_stable_id resolves to *some* entity; the business rule that
-        // it's an ai-model lives in the ingester. A future bad ingester or
-        // data migration could route an alias to a person/concept entity.
-        const aliasResults = await rawDb.unsafe<PageSearchRow[]>(
-          `SELECT DISTINCT ON (wp.slug)
+    // Phase 3 — model alias lookup (QUA-745). Tokenized FTS won't tokenize
+    // hyphenated identifiers like "gpt-4-turbo-2024-04-09" the way model
+    // aliases are stored, so we match against `model_aliases.alias` directly.
+    // Skip when the query has whitespace — aliases are always single-token
+    // identifiers, so multi-word queries can never resolve via this phase.
+    const aliasLower = rawQ.trim().toLowerCase();
+    if (
+      results.length < limit &&
+      aliasLower.length > 0 &&
+      aliasLower.length <= MAX_ALIAS_QUERY_LEN &&
+      !/\s/.test(aliasLower)
+    ) {
+      // DISTINCT ON dedupes when multiple aliases resolve to the same model.
+      // entity_type filter is defense in depth: the FK only enforces that
+      // `model_stable_id` resolves to some entity, not that it's an ai-model.
+      // Prefix LIKE requires ≥3 chars to avoid scanning a wide alias set on
+      // 1-2 char queries; exact match still resolves at any length.
+      const useLike = aliasLower.length >= 3;
+      const aliasResults = await rawDb.unsafe<PageSearchRow[]>(
+        `SELECT * FROM (
+          SELECT DISTINCT ON (wp.slug)
             wp.slug AS id,
             wp.wiki_id,
             wp.title,
@@ -179,25 +179,24 @@ const pagesApp = new Hono()
           FROM model_aliases ma
           JOIN entities e ON e.stable_id = ma.model_stable_id
           JOIN wiki_pages wp ON wp.slug = e.id
-          WHERE (ma.alias = $1 OR ma.alias LIKE $2)
+          WHERE (ma.alias = $1${useLike ? " OR ma.alias LIKE $2" : ""})
             AND wp.wiki_id IS NOT NULL
             AND wp.entity_type = 'ai-model'
             AND wp.slug NOT IN (SELECT unnest($4::text[]))
           ORDER BY wp.slug, rank DESC, wp.reader_importance DESC NULLS LAST
-          LIMIT $3`,
-          [
-            aliasLower,
-            // escapeIlike: a literal `%` or `_` in user input would otherwise
-            // act as a LIKE wildcard and explode the match set.
-            `${escapeIlike(aliasLower)}%`,
-            limit - results.length,
-            results.map((r) => r.id),
-          ],
-        );
-        // DISTINCT ON ordered by slug for dedup; resort by rank for output.
-        aliasResults.sort((a, b) => Number(b.rank) - Number(a.rank));
-        results = [...results, ...aliasResults];
-      }
+        ) deduped
+        ORDER BY rank DESC, reader_importance DESC NULLS LAST
+        LIMIT $3`,
+        [
+          aliasLower,
+          // escapeIlike: a literal `%` in user input would otherwise act as
+          // a LIKE wildcard and explode the match set.
+          useLike ? `${escapeIlike(aliasLower)}%` : aliasLower,
+          limit - results.length,
+          results.map((r) => r.id),
+        ],
+      );
+      results = [...results, ...aliasResults];
     }
 
     return c.json({

--- a/apps/wiki-server/src/routes/wikibase/pages.ts
+++ b/apps/wiki-server/src/routes/wikibase/pages.ts
@@ -62,6 +62,12 @@ interface PageSearchRow {
 
 const MAX_PAGE_SIZE = 200;
 
+// Phase 3 alias-search (QUA-745): bound user input length and rank exact
+// matches above prefix matches within the alias-search result set.
+const MAX_ALIAS_QUERY_LEN = 200;
+const ALIAS_EXACT_RANK = 100.0;
+const ALIAS_PREFIX_RANK = 50.0;
+
 // ---- Schemas (from shared api-types) ----
 
 // Re-exported so external consumers (e.g. tests) can import them by name.
@@ -149,9 +155,17 @@ const pagesApp = new Hono()
     if (results.length < limit) {
       const aliasLower = rawQ.trim().toLowerCase();
       // Reject empty / overlong queries to keep the LIKE/trgm path bounded.
-      if (aliasLower.length > 0 && aliasLower.length <= 200) {
+      if (aliasLower.length > 0 && aliasLower.length <= MAX_ALIAS_QUERY_LEN) {
+        // DISTINCT ON dedupes the result when multiple aliases point at the
+        // same model (e.g. both "gpt-4-turbo" and "gpt-4-turbo-2024-04-09"
+        // resolve to GPT-4 Turbo) — without it, the same wiki page would
+        // appear in `results` once per matching alias.
+        // entity_type filter: defense in depth. The FK only enforces that
+        // model_stable_id resolves to *some* entity; the business rule that
+        // it's an ai-model lives in the ingester. A future bad ingester or
+        // data migration could route an alias to a person/concept entity.
         const aliasResults = await rawDb.unsafe<PageSearchRow[]>(
-          `SELECT
+          `SELECT DISTINCT ON (wp.slug)
             wp.slug AS id,
             wp.wiki_id,
             wp.title,
@@ -160,16 +174,16 @@ const pagesApp = new Hono()
             wp.category,
             wp.reader_importance,
             wp.quality,
-            CASE WHEN ma.alias = $1 THEN 100.0 ELSE 50.0 END AS rank,
+            CASE WHEN ma.alias = $1 THEN ${ALIAS_EXACT_RANK} ELSE ${ALIAS_PREFIX_RANK} END AS rank,
             wp.description AS snippet
           FROM model_aliases ma
           JOIN entities e ON e.stable_id = ma.model_stable_id
           JOIN wiki_pages wp ON wp.slug = e.id
           WHERE (ma.alias = $1 OR ma.alias LIKE $2)
             AND wp.wiki_id IS NOT NULL
-            AND (wp.entity_type IS NULL OR wp.entity_type != 'internal')
+            AND wp.entity_type = 'ai-model'
             AND wp.slug NOT IN (SELECT unnest($4::text[]))
-          ORDER BY rank DESC, wp.reader_importance DESC NULLS LAST
+          ORDER BY wp.slug, rank DESC, wp.reader_importance DESC NULLS LAST
           LIMIT $3`,
           [
             aliasLower,
@@ -180,6 +194,8 @@ const pagesApp = new Hono()
             results.map((r) => r.id),
           ],
         );
+        // DISTINCT ON ordered by slug for dedup; resort by rank for output.
+        aliasResults.sort((a, b) => Number(b.rank) - Number(a.rank));
         results = [...results, ...aliasResults];
       }
     }

--- a/content/docs/internal/model-aliases-dashboard.mdx
+++ b/content/docs/internal/model-aliases-dashboard.mdx
@@ -1,0 +1,10 @@
+---
+wikiId: E2556
+title: "Model Aliases"
+description: "Maps raw external model names (e.g. gpt-4-turbo-2024-04-09) to canonical AI-model entities. Used by Phase 2 benchmark ingesters at resolution time (QUA-689 / QUA-745)."
+subcategory: dashboards
+contentFormat: dashboard
+lastEdited: "2026-05-02"
+---
+
+<ModelAliasesDashboardContent />


### PR DESCRIPTION
## Summary

QUA-689 Phase 2 added a `model_aliases` table that maps name variants (e.g. `gpt-4-turbo-2024-04-09` → GPT-4 Turbo) for benchmark ingest. The data was populated but never exposed in any UI. This PR exposes it through three surfaces.

## Changes

**1. AI model detail page** (`/ai-models/[slug]`)
- Fetches `/api/model-aliases/all?modelStableId=...` in parallel with the existing system-cards fetch.
- Renders aliases via the existing `aliases` prop on `EntityProfileShell` ("Also known as: ...").
- Aliases that match the entity title (case-insensitive) are filtered out as noise.

**2. Page search** (`/api/pages/search` Phase 3 — new)
- JOINs `model_aliases` → `entities` → `wiki_pages` so a query like `gpt-4-turbo-2024-04-09` resolves to GPT-4 Turbo. FTS doesn't tokenize hyphenated identifiers cleanly, and aliases aren't part of `wiki_pages.search_vector`.
- Fires only when the query has no whitespace (aliases are always single-token identifiers) and ≤200 chars.
- Prefix-LIKE branch requires ≥3 chars to bound the scan; exact-match still works at any length.
- `DISTINCT ON (wp.slug)` dedupes when multiple aliases resolve to the same model.
- `wp.entity_type = 'ai-model'` filter is defense in depth — the FK only enforces "some entity exists", not "is an ai-model".
- User input is `escapeIlike`'d before the LIKE pattern so `%` / `_` can't behave as wildcards.

**3. /internal/model-aliases dashboard** (Pattern A, E2556)
- Lists all aliases grouped by canonical model with source / confidence / syncedAt columns.
- Stats by source and confidence (truncation-aware "Canonical Models" count).
- Sidebar entry under TableBase.

## Test plan

- [x] `pnpm test` (wiki-server: 1691 passed; 5 pre-existing snapshot-resources failures on main are unrelated)
- [x] `pnpm build` — full Next.js build green, all pages render
- [x] `pnpm crux w validate gate --no-cache` — all 74 gate checks passed (3 pre-existing advisory warnings)
- [x] 27 wiki-server unit tests covering: exact match, prefix match, dedup, entity_type filter, no-wiki_id rejection, `%` adversarial input
- [x] Curl-tested `/wiki/E2556` (200, dashboard renders) and `/ai-models/gpt-4-turbo` (200) against local dev server
- [x] `/agent-review-pr` — 7/7 phases recorded, marker written
- [x] `/simplify` — 3 review agents (reuse, quality, efficiency), key findings applied

## Acceptance (per QUA-745)

- [x] AI-model detail page shows aliases when the model has any
- [x] Search query for an aliased name returns the canonical model
- [x] `/internal/model-aliases` exists with Pattern A

Fixes QUA-745.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model aliases (alternate names) now display on AI model detail pages
  * New Model Aliases Dashboard provides a comprehensive overview of all canonical models with alias statistics, confidence levels, and data sources
  * Search functionality now includes model alias matching to help discover models by alternate names

* **Documentation**
  * Added documentation for the new Model Aliases Dashboard

<!-- end of auto-generated comment: release notes by coderabbit.ai -->