### PR TITLE
QUA-869 follow-up: e2e regression coverage + metadata polish

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -135,6 +135,16 @@ const SIMPLE_PAGES = [
   "/frontier-safety-frameworks/methodology",  // QUA-709 methodology
   "/scorecards",  // QUA-688 scorecards directory
   "/scorecards/fli_index",  // QUA-837 per-scorecard detail route
+  // QUA-869 — FMTI stub orgs promoted to YAML so /scorecards row links resolve.
+  // Loading these confirms the YAML entries persist; if YAML is removed
+  // and the entity reverts to a PG-only stub, the directory page returns 404.
+  "/organizations/ai21-labs",
+  "/organizations/midjourney",
+  "/organizations/writer",
+  "/organizations/adept",
+  "/organizations/bigcode",
+  "/organizations/aleph-alpha",
+  "/organizations/stability-ai",
   "/divisions",  // QUA-897 sourcing-summary header
   // NOTE: /things/[id] was migrated to EntityProfileShell in QUA-489 but is
   // not in this list — its records live only in PG, so the page 404s in the

--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -9636,17 +9636,24 @@
 # resolves. stableIds match the existing PG rows (created by `fmti-ingest
 # --ensure-stubs` in QUA-748) so the scorecard_grades FKs stay valid; that's
 # why they don't carry the canonical sid_ prefix the newer entries use.
+# Migrating these to canonical `sid_`-prefixed format (and fixing the FMTI
+# ingester to emit prefixed IDs by default) is tracked in QUA-1060.
 - id: ai21-labs
   stableId: JKhtN999IF
   type: organization
   orgType: frontier-lab
   title: AI21 Labs
+  aliases:
+    - AI21
   website: https://www.ai21.com
   description: >-
     Israeli AI lab founded in 2017 by Yoav Shoham, Ori Goshen, and Amnon
     Shashua. Develops the Jurassic and Jamba families of large language
     models for enterprise NLP, with a focus on retrieval-augmented and
     structured-reasoning applications.
+  tags:
+    - llm-developer
+    - foundation-models
   lastUpdated: 2026-05
 
 - id: midjourney
@@ -9660,6 +9667,9 @@
     the Midjourney image-generation service, originally distributed
     through Discord. Self-funded and known for stylised image outputs
     used widely in concept art and marketing.
+  tags:
+    - generative-ai
+    - image-generation
   lastUpdated: 2026-05
 
 - id: writer
@@ -9678,12 +9688,17 @@
     models. Develops the Palmyra family of domain-specific LLMs and a
     B2B platform for AI-assisted writing, knowledge work, and agent
     workflows.
+  tags:
+    - llm-developer
+    - foundation-models
+    - enterprise-ai
   lastUpdated: 2026-05
 
 - id: adept
   stableId: vnxlRm3c1P
   type: organization
   orgType: startup
+  orgStatus: defunct
   title: Adept
   aliases:
     - Adept AI
@@ -9696,12 +9711,15 @@
     for the ACT-1 and Fuyu model families. In 2024 most of its
     leadership and a non-exclusive technology licence were acquired by
     Amazon, leaving a residual research team.
+  tags:
+    - ai-agents
+    - foundation-models
   lastUpdated: 2026-05
 
 - id: bigcode
   stableId: yAMKxvX5Y4
   type: organization
-  orgType: academic
+  orgType: other
   title: BigCode
   aliases:
     - BigCode Project
@@ -9712,6 +9730,10 @@
     models for code. Released the StarCoder and StarCoder2 model
     families along with The Stack training corpus, with explicit
     attention to data provenance and opt-out tooling.
+  tags:
+    - open-source
+    - code-llm
+    - foundation-models
   lastUpdated: 2026-05
 
 - id: aleph-alpha
@@ -9726,6 +9748,10 @@
     of large language models and positions itself around European data
     sovereignty, sovereign-AI deployments, and government and industrial
     customers.
+  tags:
+    - llm-developer
+    - foundation-models
+    - europe
   lastUpdated: 2026-05
 
 - id: stability-ai
@@ -9742,5 +9768,10 @@
     collaboration with the CompVis group at LMU Munich and Runway), and
     for subsequent open-weight image, video, and audio generative model
     families.
+  tags:
+    - open-source
+    - generative-ai
+    - image-generation
+    - foundation-models
   lastUpdated: 2026-05
 


### PR DESCRIPTION
## Summary

QUA-869 follow-up. The core fix (promote 7 FMTI stub orgs to YAML so /organizations/<slug> resolves) shipped in #4830. This adds the load-bearing regression test that didn't make it into that PR, plus a couple of light metadata refinements:

- **e2e regression coverage**: add the 7 new `/organizations/<slug>` paths to `SIMPLE_PAGES` in `e2e/render-audit.spec.ts`. Without this, if any of the YAML entries get reverted or refactored away, the scorecards row link would silently start 404'ing again.
- **YAML inline comment**: reference QUA-1060 (the "FMTI ingester writes bare stableIds" follow-up) so the intentional convention deviation is grep-able from the YAML.
- **adept**: `orgStatus: defunct` (matches the description's account of the Amazon acqui-hire; mirrors the convention used by `google-brain` etc.).
- **bigcode**: `orgType: other` (was `academic`; HF + ServiceNow research collab is corporate-led, not university-affiliated).
- **tags + AI21 alias** on the 7 entries to help the directory's filter/cluster surfaces.

## Test plan

- [x] `pnpm build-data:content` clean — `database.json` reflects `orgStatus`, `orgType`, `tags`, `aliases` for all 7 orgs.
- [x] `pnpm crux w validate gate --scope=content --fix` — 5/5 checks pass.
- [x] Local Playwright: 7/7 render-audit assertions pass against the 7 new pages (`PLAYWRIGHT_BASE_URL=http://localhost:3022 npx playwright test e2e/render-audit.spec.ts -g "ai21-labs|midjourney|writer|adept|bigcode|aleph-alpha|stability-ai"`).
- [ ] Post-deploy: `curl -s -o /dev/null -w "%{http_code}" https://www.longtermwiki.com/organizations/ai21-labs` returns 200 (currently 404 — main hasn't redeployed yet at PR-open time).

## Why bigcode is `other`, not `academic`

Existing `academic` entries (`chai`, `arc`, `epoch-ai` etc.) are university-led labs with PI/grad-student structure. BigCode is a multi-corporate research collaboration between Hugging Face and ServiceNow Research — the artifacts (StarCoder, The Stack) are corporate-published, not academic-press. `other` is the closest fit in the existing enum.

Closes QUA-869 (the part that didn't ship in #4830).

Related: QUA-1060 (FMTI ingester sid_-prefix migration).
