### PR TITLE
feat(scorecards): wire publisher links, license, coverage signal, grade trajectory (QUA-867)

### DIFF
--- a/apps/web/src/app/organizations/[slug]/[[...tab]]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/[[...tab]]/page.tsx
@@ -953,6 +953,15 @@ export default async function OrgProfilePage({
     foundedDate: data.foundedDateStr,
     peopleCount: data.sortedPersons.length,
     wikiPageId: entity.wikiPageId,
+    // QUA-867 item D — credit orgs evaluated by external scorecards. Count
+    // distinct sources (one panel per source) rather than total grade rows
+    // (which would double-count multi-dimension scorecards). `fetchError`
+    // is treated as 0 so a transient wiki-server outage doesn't pessimize
+    // the score.
+    externalScorecardCount:
+      scorecardsData && !("fetchError" in scorecardsData)
+        ? scorecardsData.groups.length
+        : 0,
   };
 
   const shellSlots = buildOrgShellSlots(

--- a/apps/web/src/app/organizations/[slug]/scorecards-section.test.tsx
+++ b/apps/web/src/app/organizations/[slug]/scorecards-section.test.tsx
@@ -1,7 +1,16 @@
 /** @vitest-environment jsdom */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ScorecardsSection } from "./scorecards-section";
+
+// Mock getEntityHref so the publisher-link tests don't depend on the
+// live tablebase being loaded into vitest. The real getEntityHref reads
+// `database.json` and routes to `/people/<slug>` for person entities and
+// `/organizations/<slug>` for orgs; we mirror that contract here.
+vi.mock("@/data/entity-nav", () => ({
+  getEntityHref: (id: string) =>
+    id === "zach-stein-perlman" ? `/people/${id}` : `/organizations/${id}`,
+}));
 
 /**
  * QUA-838: panel headers on the org-tab scorecards section must link to

--- a/apps/web/src/app/organizations/[slug]/scorecards-section.test.tsx
+++ b/apps/web/src/app/organizations/[slug]/scorecards-section.test.tsx
@@ -19,6 +19,7 @@ interface GradeRow {
   scorecardSource: string | null;
   publishedAt: string | null;
   isLatest: boolean | null;
+  waveLabel: string | null;
   entityId: string;
   entityDisplayName: string;
   dimensionSlug: string;
@@ -37,6 +38,7 @@ function makeRow(overrides: Partial<GradeRow>): GradeRow {
     scorecardSource: "fli_index",
     publishedAt: "2025-12-02",
     isLatest: true,
+    waveLabel: "Winter 2025",
     entityId: "sid_anthropic",
     entityDisplayName: "Anthropic",
     dimensionSlug: "overall",
@@ -59,6 +61,7 @@ describe("ScorecardsSection — internal hyperlinks (QUA-838)", () => {
             source: "fli_index",
             publishedAt: "2025-12-02",
             rows: [makeRow({ scorecardSource: "fli_index" })],
+            history: [],
           },
         ]}
       />,
@@ -76,6 +79,7 @@ describe("ScorecardsSection — internal hyperlinks (QUA-838)", () => {
             source: "fli_index",
             publishedAt: "2025-12-02",
             rows: [makeRow({ scorecardSource: "fli_index" })],
+            history: [],
           },
         ]}
       />,
@@ -88,9 +92,11 @@ describe("ScorecardsSection — internal hyperlinks (QUA-838)", () => {
     expect(publisherLink).toHaveAttribute("href", "/organizations/fli");
   });
 
-  it("renders the publisher as plain text when no slug is configured", () => {
-    // AI Lab Watch has publisher "Zach Stein-Perlman" with no publisherSlug —
-    // the publisher should appear as plain text, not a link.
+  it("links a person-publisher to /people/<slug> via getEntityHref (QUA-867)", () => {
+    // AI Lab Watch's publisher is Zach Stein-Perlman — a *person* entity,
+    // not an organization. Routing through getEntityHref means the link
+    // goes to /people/zach-stein-perlman, not /organizations/<slug> (which
+    // would 404). This is the regression QUA-867 item A guards against.
     render(
       <ScorecardsSection
         groups={[
@@ -98,18 +104,16 @@ describe("ScorecardsSection — internal hyperlinks (QUA-838)", () => {
             source: "ailabwatch",
             publishedAt: "2025-09-01",
             rows: [makeRow({ scorecardSource: "ailabwatch" })],
+            history: [],
           },
         ]}
       />,
     );
 
-    // Publisher name should be present in the document.
-    expect(screen.getByText(/by Zach Stein-Perlman/)).toBeInTheDocument();
-    // But there should be no link with the publisher name.
-    const publisherLinks = screen
-      .queryAllByRole("link")
-      .filter((el) => /Zach Stein-Perlman/.test(el.textContent ?? ""));
-    expect(publisherLinks).toHaveLength(0);
+    const publisherLink = screen.getByRole("link", {
+      name: "Zach Stein-Perlman",
+    });
+    expect(publisherLink).toHaveAttribute("href", "/people/zach-stein-perlman");
   });
 
   it("keeps the external Source ↗ link open in a new tab", () => {
@@ -120,6 +124,7 @@ describe("ScorecardsSection — internal hyperlinks (QUA-838)", () => {
             source: "fli_index",
             publishedAt: "2025-12-02",
             rows: [makeRow({ scorecardSource: "fli_index" })],
+            history: [],
           },
         ]}
       />,
@@ -146,6 +151,7 @@ describe("ScorecardsSection — conditional font on grade values (QUA-861)", () 
                 scoreRaw: "C+",
               }),
             ],
+            history: [],
           },
         ]}
       />,
@@ -171,6 +177,7 @@ describe("ScorecardsSection — conditional font on grade values (QUA-861)", () 
                 scoreRaw: "Fulfilled",
               }),
             ],
+            history: [],
           },
         ]}
       />,
@@ -197,6 +204,7 @@ describe("ScorecardsSection — conditional font on grade values (QUA-861)", () 
                 scoreRaw: "Weak",
               }),
             ],
+            history: [],
           },
         ]}
       />,
@@ -221,6 +229,7 @@ describe("ScorecardsSection — conditional font on grade values (QUA-861)", () 
                 scoreRaw: "B-",
               }),
             ],
+            history: [],
           },
         ]}
       />,
@@ -228,5 +237,147 @@ describe("ScorecardsSection — conditional font on grade values (QUA-861)", () 
 
     const dimensionCell = screen.getByText("B-").closest("dd");
     expect(dimensionCell?.className).toMatch(/font-mono/);
+  });
+});
+
+describe("ScorecardsSection — grade trajectory mini-table (QUA-867 item E)", () => {
+  it("hides the trajectory section when only one wave exists", () => {
+    render(
+      <ScorecardsSection
+        groups={[
+          {
+            source: "saferai",
+            publishedAt: "2025-10-01",
+            rows: [
+              makeRow({
+                scorecardSource: "saferai",
+                dimensionSlug: "overall",
+                scoreLetter: "C",
+                scoreRaw: "C",
+              }),
+            ],
+            // SaferAI has been ingested for one wave only — no history yet.
+            history: [
+              {
+                snapshotId: "saferai-2025-10",
+                publishedAt: "2025-10-01",
+                waveLabel: "October 2025",
+                isLatest: true,
+                scoreLetter: "C",
+                scoreNumeric: null,
+                scoreRaw: "C",
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText(/Grade trajectory/)).toBeNull();
+  });
+
+  it("renders a collapsed trajectory summary with the wave count when ≥2 waves exist", () => {
+    render(
+      <ScorecardsSection
+        groups={[
+          {
+            source: "fli_index",
+            publishedAt: "2025-12-02",
+            rows: [
+              makeRow({
+                dimensionSlug: "overall",
+                scoreLetter: "C+",
+                scoreRaw: "C+",
+              }),
+            ],
+            history: [
+              {
+                snapshotId: "fli_index-winter-2025",
+                publishedAt: "2025-12-02",
+                waveLabel: "Winter 2025",
+                isLatest: true,
+                scoreLetter: "C+",
+                scoreNumeric: null,
+                scoreRaw: "C+",
+              },
+              {
+                snapshotId: "fli_index-summer-2025",
+                publishedAt: "2025-07-17",
+                waveLabel: "Summer 2025",
+                isLatest: false,
+                scoreLetter: "C-",
+                scoreNumeric: null,
+                scoreRaw: "C-",
+              },
+              {
+                snapshotId: "fli_index-2024-12",
+                publishedAt: "2024-12-11",
+                waveLabel: "December 2024",
+                isLatest: false,
+                scoreLetter: "D",
+                scoreNumeric: null,
+                scoreRaw: "D",
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    // Summary line shows the wave count.
+    expect(screen.getByText(/Grade trajectory \(3 waves\)/)).toBeInTheDocument();
+    // All three wave labels render in the dl, including the latest pill.
+    expect(screen.getByText("Winter 2025")).toBeInTheDocument();
+    expect(screen.getByText("Summer 2025")).toBeInTheDocument();
+    expect(screen.getByText("December 2024")).toBeInTheDocument();
+    expect(screen.getByText("latest")).toBeInTheDocument();
+    // The historical D grade rendered (regression: prior implementation
+    // would only show the latest).
+    expect(screen.getByText("D")).toBeInTheDocument();
+  });
+
+  it("falls back to publishedAt when waveLabel is null", () => {
+    render(
+      <ScorecardsSection
+        groups={[
+          {
+            source: "saferai",
+            publishedAt: "2025-10-01",
+            rows: [
+              makeRow({
+                scorecardSource: "saferai",
+                dimensionSlug: "overall",
+                scoreLetter: "C",
+                scoreRaw: "C",
+              }),
+            ],
+            history: [
+              {
+                snapshotId: "saferai-current",
+                publishedAt: "2025-10-01",
+                waveLabel: null,
+                isLatest: true,
+                scoreLetter: "C",
+                scoreNumeric: null,
+                scoreRaw: "C",
+              },
+              {
+                snapshotId: "saferai-prev",
+                publishedAt: "2025-04-15",
+                waveLabel: null,
+                isLatest: false,
+                scoreLetter: "D",
+                scoreNumeric: null,
+                scoreRaw: "D",
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    // No labels — show the dates instead.
+    expect(screen.getByText("2025-10-01")).toBeInTheDocument();
+    expect(screen.getByText("2025-04-15")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
@@ -16,6 +16,7 @@ import {
   DIMENSION_OVERALL,
   type ScorecardSourceKey,
 } from "@/app/scorecards/scorecards-constants";
+import { getEntityHref } from "@/data/entity-nav";
 import { SourcingDot } from "@/components/sourcing/SourcingDot";
 import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
 
@@ -25,6 +26,8 @@ interface GradeRow {
   scorecardSource: string | null;
   publishedAt: string | null;
   isLatest: boolean | null;
+  /** Wave label from the parent snapshot (QUA-867 item E). */
+  waveLabel: string | null;
   entityId: string;
   entityDisplayName: string;
   dimensionSlug: string;
@@ -48,10 +51,31 @@ interface ByEntityResponse {
   total: number;
 }
 
+/**
+ * Historical overall grade for a scorecard source — one row per wave per
+ * source. Powers the per-panel grade trajectory mini-table (QUA-867 item
+ * E). Hidden when only one wave is present.
+ */
+interface OverallHistoryRow {
+  snapshotId: string;
+  publishedAt: string | null;
+  waveLabel: string | null;
+  isLatest: boolean | null;
+  scoreLetter: string | null;
+  scoreNumeric: number | null;
+  scoreRaw: string;
+}
+
 interface SourceGroup {
   source: ScorecardSourceKey;
   rows: GradeRow[];
   publishedAt: string | null;
+  /**
+   * Overall-grade history across all waves for this source, ordered newest
+   * first. Empty when only one wave exists (the latest, already shown by
+   * the panel's "Overall:" line).
+   */
+  history: OverallHistoryRow[];
 }
 
 /**
@@ -67,15 +91,28 @@ export type ScorecardsLoadResult =
 export async function loadScorecardsForEntity(
   entityStableId: string,
 ): Promise<ScorecardsLoadResult | null> {
-  const result = await fetchDetailed<ByEntityResponse>(
-    `/api/scorecard-grades/by-entity/${encodeURIComponent(entityStableId)}`,
-    { revalidate: 300 },
-  );
-  if (!result.ok) return { fetchError: true };
-  if (result.data.items.length === 0) return null;
+  const enc = encodeURIComponent(entityStableId);
+  // Two requests in parallel: the existing latest-wave fetch (with all
+  // dimension rows) and a narrow overall-only history fetch for the
+  // trajectory mini-table. Splitting them keeps the latest-wave payload
+  // small and the history payload bounded (5 sources × ~3 waves = ~15
+  // rows) — adding history to the main response would tack on an
+  // extra wave-multiplier on every dimension row.
+  const [latestRes, historyRes] = await Promise.all([
+    fetchDetailed<ByEntityResponse>(
+      `/api/scorecard-grades/by-entity/${enc}`,
+      { revalidate: 300 },
+    ),
+    fetchDetailed<ByEntityResponse>(
+      `/api/scorecard-grades/by-entity/${enc}?includeHistory=true&dimension=overall`,
+      { revalidate: 300 },
+    ),
+  ]);
+  if (!latestRes.ok) return { fetchError: true };
+  if (latestRes.data.items.length === 0) return null;
 
   const groupsBySource = new Map<string, SourceGroup>();
-  for (const r of result.data.items) {
+  for (const r of latestRes.data.items) {
     if (!r.scorecardSource) continue;
     const existing = groupsBySource.get(r.scorecardSource);
     if (existing) {
@@ -85,6 +122,28 @@ export async function loadScorecardsForEntity(
         source: r.scorecardSource as ScorecardSourceKey,
         rows: [r],
         publishedAt: r.publishedAt,
+        history: [],
+      });
+    }
+  }
+
+  // Layer history rows onto the source groups. A history-fetch failure is
+  // non-fatal: we still render latest-wave panels, just without the
+  // trajectory mini-table. Each source's history is sorted newest-first
+  // by the API; we keep that order so the latest wave shows on top.
+  if (historyRes.ok) {
+    for (const r of historyRes.data.items) {
+      if (!r.scorecardSource) continue;
+      const group = groupsBySource.get(r.scorecardSource);
+      if (!group) continue;
+      group.history.push({
+        snapshotId: r.snapshotId,
+        publishedAt: r.publishedAt,
+        waveLabel: r.waveLabel,
+        isLatest: r.isLatest,
+        scoreLetter: r.scoreLetter,
+        scoreNumeric: r.scoreNumeric,
+        scoreRaw: r.scoreRaw,
       });
     }
   }
@@ -96,7 +155,7 @@ export async function loadScorecardsForEntity(
     if (group) groups.push(group);
   }
 
-  return { groups, totalRows: result.data.items.length };
+  return { groups, totalRows: latestRes.data.items.length };
 }
 
 export function ScorecardsSection({
@@ -166,7 +225,7 @@ export function ScorecardsSection({
                   by{" "}
                   {meta.publisherSlug ? (
                     <Link
-                      href={`/organizations/${meta.publisherSlug}`}
+                      href={getEntityHref(meta.publisherSlug)}
                       className="text-primary hover:underline"
                     >
                       {meta.publisher}
@@ -235,6 +294,45 @@ export function ScorecardsSection({
                   );
                 })}
               </dl>
+            ) : null}
+
+            {/*
+              Grade trajectory across waves (QUA-867 item E). Suppressed
+              when a source has only one wave because the panel header
+              already shows the latest grade. Today only FLI has multiple
+              waves; the markup is generic so any source that lands a
+              second wave gets the trajectory automatically.
+            */}
+            {group.history.length > 1 ? (
+              <details className="mt-3 border-t border-border/30 pt-3">
+                <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground">
+                  Grade trajectory ({group.history.length} waves)
+                </summary>
+                <dl className="w-full text-xs grid grid-cols-[1fr_auto] gap-x-3 mt-2">
+                  {group.history.map((h) => {
+                    const formatted = formatScoreCell(h);
+                    const label = h.waveLabel ?? h.publishedAt ?? "—";
+                    return (
+                      <div
+                        key={h.snapshotId}
+                        className="contents border-b border-border/20 last:border-b-0"
+                      >
+                        <dt className="py-1 text-muted-foreground">
+                          {label}
+                          {h.isLatest ? (
+                            <span className="ml-1.5 inline-flex items-center px-1 py-px rounded text-[9px] font-semibold bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300 align-middle">
+                              latest
+                            </span>
+                          ) : null}
+                        </dt>
+                        <dd className={`py-1 text-right ${gradeCellFontClass(formatted)}`}>
+                          {formatted}
+                        </dd>
+                      </div>
+                    );
+                  })}
+                </dl>
+              </details>
             ) : null}
           </article>
         );

--- a/apps/web/src/app/organizations/org-sort.test.ts
+++ b/apps/web/src/app/organizations/org-sort.test.ts
@@ -311,4 +311,54 @@ describe("computeOrgCoverage", () => {
     // 10 people = 1 signal, foundedDate = 1 signal → 2 signals → score 2
     expect(computeOrgCoverage({ peopleCount: 10, foundedDate: "2020" })).toBe(2);
   });
+
+  // QUA-867 item D — orgs evaluated by external scorecards earn coverage
+  // signals even when their financial metadata is sparse. A frontier lab
+  // rated by every scorecard but missing revenue/valuation/headcount used
+  // to score 1 ("stub") despite being one of the most-evaluated entities
+  // in the wiki.
+  describe("externalScorecardCount signal (QUA-867)", () => {
+    it("does not credit zero scorecards", () => {
+      expect(computeOrgCoverage({ externalScorecardCount: 0 })).toBe(1);
+      expect(computeOrgCoverage({ externalScorecardCount: null })).toBe(1);
+    });
+
+    it("1 scorecard adds one signal", () => {
+      // Alone it's just 1 signal — score stays 1.
+      expect(computeOrgCoverage({ externalScorecardCount: 1 })).toBe(1);
+      // With foundedDate (1 signal) + 1 scorecard = 2 signals → score 2.
+      expect(
+        computeOrgCoverage({
+          externalScorecardCount: 1,
+          foundedDate: "2020",
+        }),
+      ).toBe(2);
+    });
+
+    it("3+ scorecards adds two signals (frontier-lab tier)", () => {
+      // 3 scorecards = 2 signals (≥1 + ≥3) → score 2.
+      expect(computeOrgCoverage({ externalScorecardCount: 3 })).toBe(2);
+      // 5 scorecards = 2 signals + foundedDate = 3 → score 3.
+      expect(
+        computeOrgCoverage({
+          externalScorecardCount: 5,
+          foundedDate: "2020",
+        }),
+      ).toBe(3);
+    });
+
+    it("rescues a frontier lab with no financial metadata", () => {
+      // Exactly the case the audit flagged: no revenue / valuation /
+      // headcount / total-funding, but rated by all 5 scorecards. Used to
+      // score 1 (stub). Now scores 3 (5 scorecards = 2, foundedDate = 1,
+      // wikiPageId = 1 → 4 signals).
+      expect(
+        computeOrgCoverage({
+          externalScorecardCount: 5,
+          foundedDate: "2021",
+          wikiPageId: "E1234",
+        }),
+      ).toBe(3);
+    });
+  });
 });

--- a/apps/web/src/app/organizations/org-sort.test.ts
+++ b/apps/web/src/app/organizations/org-sort.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { OrgRow } from "./organizations-table";
 import { getOrgSortValue, compareOrgRows } from "./org-sort";
-import { computeOrgCoverage } from "@/components/coverage/coverage-score";
+import { computeOrgCoverage, getOrgSignals } from "@/components/coverage/coverage-score";
 
 function makeRow(overrides: Partial<OrgRow> = {}): OrgRow {
   return {
@@ -335,6 +335,18 @@ describe("computeOrgCoverage", () => {
       ).toBe(2);
     });
 
+    it("2 scorecards stays at 1 signal (in-between band)", () => {
+      // 2 scorecards = 1 signal (≥1 only). With foundedDate = 2 signals → 2.
+      // The ≥3 tier is for "frontier-lab" coverage, not just "more than one."
+      expect(computeOrgCoverage({ externalScorecardCount: 2 })).toBe(1);
+      expect(
+        computeOrgCoverage({
+          externalScorecardCount: 2,
+          foundedDate: "2020",
+        }),
+      ).toBe(2);
+    });
+
     it("3+ scorecards adds two signals (frontier-lab tier)", () => {
       // 3 scorecards = 2 signals (≥1 + ≥3) → score 2.
       expect(computeOrgCoverage({ externalScorecardCount: 3 })).toBe(2);
@@ -360,5 +372,50 @@ describe("computeOrgCoverage", () => {
         }),
       ).toBe(3);
     });
+  });
+});
+
+// QUA-867 item D — getOrgSignals feeds the coverage popover on the org
+// profile. Untested before this PR; new external-scorecard branch
+// requires explicit coverage so a regression doesn't silently mis-label.
+describe("getOrgSignals", () => {
+  it("returns no scorecard signal when count is 0 or null", () => {
+    expect(getOrgSignals({})).not.toContain("0 external scorecards");
+    expect(getOrgSignals({ externalScorecardCount: 0 })).not.toContain(
+      "external scorecard",
+    );
+    expect(getOrgSignals({ externalScorecardCount: null })).not.toContain(
+      "external scorecard",
+    );
+  });
+
+  it("uses the singular form for exactly 1 scorecard", () => {
+    const signals = getOrgSignals({ externalScorecardCount: 1 });
+    expect(signals).toContain("1 external scorecard");
+    expect(signals).not.toContain("1 external scorecards");
+  });
+
+  it("uses the plural form for 2+ scorecards", () => {
+    expect(getOrgSignals({ externalScorecardCount: 2 })).toContain(
+      "2 external scorecards",
+    );
+    expect(getOrgSignals({ externalScorecardCount: 5 })).toContain(
+      "5 external scorecards",
+    );
+  });
+
+  it("includes the standard signals alongside scorecard count", () => {
+    const signals = getOrgSignals({
+      revenueNum: 1e9,
+      foundedDate: "2020",
+      wikiPageId: "E42",
+      externalScorecardCount: 3,
+    });
+    expect(signals).toEqual([
+      "Revenue",
+      "Founded date",
+      "Wiki page",
+      "3 external scorecards",
+    ]);
   });
 });

--- a/apps/web/src/app/organizations/page.tsx
+++ b/apps/web/src/app/organizations/page.tsx
@@ -117,6 +117,8 @@ interface ApiOrg {
   totalFundingNum: number | null;
   foundedDate: string | null;
   grantsGivenCount?: number | null;
+  /** QUA-867 item D — distinct latest-wave scorecards rating this org. */
+  externalScorecardCount?: number | null;
 }
 
 interface ApiOrgsResponse {

--- a/apps/web/src/app/scorecards/__tests__/scorecards-constants.test.ts
+++ b/apps/web/src/app/scorecards/__tests__/scorecards-constants.test.ts
@@ -73,6 +73,22 @@ describe("scorecards-constants", () => {
     expect(meta?.active).toBe(false);
   });
 
+  it("every source has a publisherSlug wired for directory linking", () => {
+    // QUA-867 item A: until QUA-836 backfilled the publisher entities,
+    // only fli_index had a publisherSlug. The backfill is now reflected
+    // in the constants — every source must link its publisher.
+    for (const meta of SCORECARD_SOURCES) {
+      expect(meta.publisherSlug, `${meta.source} missing publisherSlug`).toBeTruthy();
+    }
+  });
+
+  it("AI Lab Watch's publisher slug points at the person entity", () => {
+    // Routing must go through getEntityHref (not a hardcoded
+    // /organizations/<slug>) because zach-stein-perlman is a person.
+    const meta = getScorecardSourceMeta("ailabwatch");
+    expect(meta?.publisherSlug).toBe("zach-stein-perlman");
+  });
+
   it("active sources are flagged as active", () => {
     for (const slug of ["fli_index", "saferai", "fmti", "seoul_tracker"]) {
       const meta = getScorecardSourceMeta(slug);

--- a/apps/web/src/app/scorecards/page.tsx
+++ b/apps/web/src/app/scorecards/page.tsx
@@ -12,6 +12,7 @@ import {
   DIMENSION_OVERALL,
   type ScorecardSourceKey,
 } from "@/app/scorecards/scorecards-constants";
+import { getEntityHref } from "@/data/entity-nav";
 
 export const metadata: Metadata = {
   title: "Scorecards",
@@ -236,7 +237,17 @@ export default async function ScorecardsPage() {
                 <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-2">
                   <h3 className="font-semibold">{meta.fullLabel}</h3>
                   <span className="text-xs text-muted-foreground">
-                    by {meta.publisher}
+                    by{" "}
+                    {meta.publisherSlug ? (
+                      <Link
+                        href={getEntityHref(meta.publisherSlug)}
+                        className="text-primary hover:underline"
+                      >
+                        {meta.publisher}
+                      </Link>
+                    ) : (
+                      meta.publisher
+                    )}
                   </span>
                   {!meta.active ? (
                     <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">

--- a/apps/web/src/app/scorecards/scorecards-constants.ts
+++ b/apps/web/src/app/scorecards/scorecards-constants.ts
@@ -13,9 +13,11 @@ export interface ScorecardSourceMeta {
   /** Org/maintainer of the scorecard. */
   publisher: string;
   /**
-   * Slug for /organizations/<slug> linking when the publisher has a wiki
-   * entity. Optional — sources whose publisher isn't yet in the catalog
-   * render the publisher as plain text.
+   * Slug for the publisher's wiki entity. Optional — sources whose publisher
+   * isn't yet in the catalog render the publisher as plain text. Resolve to
+   * a URL through `getEntityHref` (not a hardcoded `/organizations/<slug>`):
+   * AI Lab Watch's publisher (`zach-stein-perlman`) is a person, so the
+   * link must route to `/people/<slug>` instead.
    */
   publisherSlug?: string;
   /** Default canonical URL for the source's home page. */
@@ -56,6 +58,7 @@ export const SCORECARD_SOURCES: readonly ScorecardSourceMeta[] = [
     shortLabel: "SaferAI",
     fullLabel: "SaferAI Ratings",
     publisher: "SaferAI",
+    publisherSlug: "saferai",
     homeUrl: "https://ratings.safer-ai.org",
     description:
       "Continuously-updated risk-management ratings for frontier developers across four pillars: risk identification, analysis & evaluation, treatment, and governance.",
@@ -66,6 +69,7 @@ export const SCORECARD_SOURCES: readonly ScorecardSourceMeta[] = [
     shortLabel: "AI Lab Watch",
     fullLabel: "AI Lab Watch",
     publisher: "Zach Stein-Perlman",
+    publisherSlug: "zach-stein-perlman",
     homeUrl: "https://ailabwatch.org",
     description:
       "Weighted scorecard across seven categories (risk assessment, scheming prevention, safety research, misuse prevention, security, info sharing, planning).",
@@ -76,6 +80,7 @@ export const SCORECARD_SOURCES: readonly ScorecardSourceMeta[] = [
     shortLabel: "FMTI",
     fullLabel: "Foundation Model Transparency Index",
     publisher: "Stanford CRFM",
+    publisherSlug: "stanford-crfm",
     homeUrl: "https://crfm.stanford.edu/fmti/",
     description:
       "Transparency-focused index scoring developers on 100 indicators across upstream resources, the model itself, and downstream use.",
@@ -86,6 +91,7 @@ export const SCORECARD_SOURCES: readonly ScorecardSourceMeta[] = [
     shortLabel: "Seoul Tracker",
     fullLabel: "Seoul Commitment Tracker",
     publisher: "The Midas Project",
+    publisherSlug: "the-midas-project",
     homeUrl: "https://www.seoul-tracker.org",
     description:
       "Tracks adherence to the Seoul Frontier AI Safety Commitments via 'Fulfilled / Partial / Unfulfilled' verdicts on five red-line components.",

--- a/apps/web/src/components/coverage/coverage-score.ts
+++ b/apps/web/src/components/coverage/coverage-score.ts
@@ -27,11 +27,12 @@ export interface OrgCoverageInput {
   peopleCount?: number | null;
   wikiPageId?: string | null;
   /**
-   * Number of distinct external scorecards (FLI, SaferAI, AI Lab Watch,
-   * FMTI, Seoul Tracker) that have rated this org. QUA-867 item D: an org
-   * rated by every scorecard but missing the financial fields above used to
-   * score 1 ("stub") despite being one of the most-evaluated frontier labs.
-   * One signal at ≥1 scorecards, a second at ≥3.
+   * Number of distinct external scorecards from `SCORECARD_SOURCES` that
+   * have rated this org (counted in the latest wave per source). QUA-867
+   * item D: an org rated by every scorecard but missing the financial
+   * fields above used to score 1 ("stub") despite being one of the
+   * most-evaluated frontier labs. One signal at ≥1 scorecards, a second
+   * at ≥3.
    */
   externalScorecardCount?: number | null;
 }
@@ -49,10 +50,17 @@ export function computeOrgCoverage(row: OrgCoverageInput): number {
   if (row.foundedDate) signals++;
   if (row.peopleCount != null && row.peopleCount >= 10) signals++;
   if (row.wikiPageId) signals++;
-  if ((row.externalScorecardCount ?? 0) >= 1) signals++;
-  if ((row.externalScorecardCount ?? 0) >= 3) signals++;
+  const ec = row.externalScorecardCount ?? 0;
+  if (ec >= 1) signals++;
+  if (ec >= 3) signals++;
 
-  // 9 possible. Typical org has foundedDate + maybe 1 financial = 2.
+  // 9 possible (was 7 before QUA-867 added the two scorecard tiers).
+  // Tier thresholds (5 → 4, 3 → 3, 2 → 2) were intentionally left at the
+  // pre-QUA-867 levels: the new pathway is for orgs heavily evaluated by
+  // external scorecards but missing financial metadata, which previously
+  // scored 1. Lowering the bar by 2 was the explicit goal — see the
+  // "rescues a frontier lab" test case for the calibration.
+  // Typical org has foundedDate + maybe 1 financial = 2.
   if (signals >= 5) return 4;
   if (signals >= 3) return 3;
   if (signals >= 2) return 2;
@@ -420,14 +428,9 @@ export function getOrgSignals(row: OrgCoverageInput): string[] {
   if (row.foundedDate) signals.push("Founded date");
   if (row.peopleCount != null && row.peopleCount >= 10) signals.push("10+ people tracked");
   if (row.wikiPageId) signals.push("Wiki page");
-  if ((row.externalScorecardCount ?? 0) >= 3) {
-    signals.push(`${row.externalScorecardCount} external scorecards`);
-  } else if ((row.externalScorecardCount ?? 0) >= 1) {
-    signals.push(
-      row.externalScorecardCount === 1
-        ? "1 external scorecard"
-        : `${row.externalScorecardCount} external scorecards`,
-    );
+  const ec = row.externalScorecardCount ?? 0;
+  if (ec >= 1) {
+    signals.push(ec === 1 ? "1 external scorecard" : `${ec} external scorecards`);
   }
   return signals;
 }

--- a/apps/web/src/components/coverage/coverage-score.ts
+++ b/apps/web/src/components/coverage/coverage-score.ts
@@ -26,11 +26,20 @@ export interface OrgCoverageInput {
   foundedDate?: string | null;
   peopleCount?: number | null;
   wikiPageId?: string | null;
+  /**
+   * Number of distinct external scorecards (FLI, SaferAI, AI Lab Watch,
+   * FMTI, Seoul Tracker) that have rated this org. QUA-867 item D: an org
+   * rated by every scorecard but missing the financial fields above used to
+   * score 1 ("stub") despite being one of the most-evaluated frontier labs.
+   * One signal at ≥1 scorecards, a second at ≥3.
+   */
+  externalScorecardCount?: number | null;
 }
 
 export function computeOrgCoverage(row: OrgCoverageInput): number {
   // Baseline: name + type (always present, not counted)
-  // Enrichment signals: financial metrics, people tracking, wiki page
+  // Enrichment signals: financial metrics, people tracking, wiki page,
+  //   external-scorecard presence (QUA-867 item D)
   let signals = 0;
 
   if (row.revenueNum != null) signals++;
@@ -40,8 +49,10 @@ export function computeOrgCoverage(row: OrgCoverageInput): number {
   if (row.foundedDate) signals++;
   if (row.peopleCount != null && row.peopleCount >= 10) signals++;
   if (row.wikiPageId) signals++;
+  if ((row.externalScorecardCount ?? 0) >= 1) signals++;
+  if ((row.externalScorecardCount ?? 0) >= 3) signals++;
 
-  // 7 possible. Typical org has foundedDate + maybe 1 financial = 2.
+  // 9 possible. Typical org has foundedDate + maybe 1 financial = 2.
   if (signals >= 5) return 4;
   if (signals >= 3) return 3;
   if (signals >= 2) return 2;
@@ -409,6 +420,15 @@ export function getOrgSignals(row: OrgCoverageInput): string[] {
   if (row.foundedDate) signals.push("Founded date");
   if (row.peopleCount != null && row.peopleCount >= 10) signals.push("10+ people tracked");
   if (row.wikiPageId) signals.push("Wiki page");
+  if ((row.externalScorecardCount ?? 0) >= 3) {
+    signals.push(`${row.externalScorecardCount} external scorecards`);
+  } else if ((row.externalScorecardCount ?? 0) >= 1) {
+    signals.push(
+      row.externalScorecardCount === 1
+        ? "1 external scorecard"
+        : `${row.externalScorecardCount} external scorecards`,
+    );
+  }
   return signals;
 }
 

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -4,7 +4,14 @@ import { eq, and, count, asc, sql, ilike, or, inArray, notInArray, gte } from "d
 import type { SQL } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { logger } from "../../logger.js";
-import { entities, facts, grants, things } from "../../schema.js";
+import {
+  entities,
+  facts,
+  grants,
+  scorecardGrades,
+  scorecardSnapshots,
+  things,
+} from "../../schema.js";
 import { isAnySid, isSid } from "@longterm-wiki/id-utils";
 import { checkRefsExist } from "../shared/ref-check.js";
 import {
@@ -376,6 +383,22 @@ const entitiesApp = new Hono()
         )
     )`;
 
+    // Count of distinct external scorecards (FLI, SaferAI, AI Lab Watch,
+    // FMTI, Seoul Tracker) that have rated this org in the latest wave per
+    // source. QUA-867 item D: feeds `externalScorecardCount` on
+    // computeOrgCoverage so heavily-rated frontier labs missing financial
+    // metadata don't score 1 ("stub"). Counting distinct sources rather
+    // than grade rows avoids double-counting multi-dimension scorecards.
+    const externalScorecardCountExpr = sql<
+      number | null
+    >`(
+      SELECT COUNT(DISTINCT s.scorecard_source)::int
+      FROM ${scorecardGrades} g
+      JOIN ${scorecardSnapshots} s ON s.id = g.snapshot_id
+      WHERE g.entity_id = ${entities.stableId}
+        AND s.is_latest = true
+    )`;
+
     // Build ORDER BY
     const { field, dir } = parseSort(sort, ORG_SORT_ALLOWED, "name", "asc");
     const sortColMap: Record<string, SQL> = {
@@ -423,6 +446,7 @@ const entitiesApp = new Hono()
       totalFundingNum: number | null;
       foundedDate: string | null;
       grantsGivenCount: number | null;
+      externalScorecardCount: number | null;
     }
 
     let rows: OrgRow[] = await db
@@ -442,6 +466,7 @@ const entitiesApp = new Hono()
         totalFundingNum: sql<number | null>`${latestFact("total-funding")}`,
         foundedDate: sql<string | null>`${latestFactText("founded-date")}`,
         grantsGivenCount: sql<number | null>`${grantsGivenCountExpr}`,
+        externalScorecardCount: sql<number | null>`${externalScorecardCountExpr}`,
       })
       .from(entities)
       .where(where)
@@ -484,6 +509,7 @@ const entitiesApp = new Hono()
             totalFundingNum: sql<number | null>`${latestFact("total-funding")}`,
             foundedDate: sql<string | null>`${latestFactText("founded-date")}`,
             grantsGivenCount: sql<number | null>`${grantsGivenCountExpr}`,
+            externalScorecardCount: sql<number | null>`${externalScorecardCountExpr}`,
           })
           .from(entities)
           .where(trigramWhere)
@@ -512,6 +538,7 @@ const entitiesApp = new Hono()
         // COUNT(*) never returns NULL; the ?? 0 is purely a TypeScript
         // narrow on the Drizzle-inferred `number | null`.
         grantsGivenCount: Number(r.grantsGivenCount ?? 0),
+        externalScorecardCount: Number(r.externalScorecardCount ?? 0),
       })),
       total,
       limit,

--- a/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
@@ -79,6 +79,13 @@ interface GradeRow extends VerdictJoinFields {
   publishedAt: string | null;
   isLatest: boolean | null;
   snapshotSourceUrl: string | null;
+  /**
+   * Wave label from the parent snapshot (e.g. "Summer 2025"). Optional
+   * because not every callsite selects it (the /all endpoint omits it to
+   * keep the matrix payload small); nullable because a snapshot may have
+   * no human label set.
+   */
+  waveLabel?: string | null;
 }
 
 function formatRow(r: GradeRow) {
@@ -108,6 +115,7 @@ function formatRow(r: GradeRow) {
     // Most grades inherit evidence from the wave's PDF/page rather than
     // having a unique deep-link.
     snapshotSourceUrl: r.snapshotSourceUrl,
+    waveLabel: r.waveLabel ?? null,
     syncedAt: g.syncedAt,
     sourcing: formatSourcing(r),
   };
@@ -184,48 +192,71 @@ const scorecardGradesApp = new Hono()
     });
   })
 
-  // GET /by-entity/:entityId — every grade for one org, latest snapshot per source
-  .get("/by-entity/:entityId", async (c) => {
-    const entityId = c.req.param("entityId");
-    const db = getDrizzleDb();
+  // GET /by-entity/:entityId — every grade for one org. Defaults to the
+  // latest wave per source; pass `?includeHistory=true` to return all
+  // historical waves (used by the per-org grade-trajectory mini-table from
+  // QUA-867 item E). Pass `?dimension=overall` to bound the response when
+  // history is needed but per-dimension rows are not.
+  .get(
+    "/by-entity/:entityId",
+    zv(
+      "query",
+      z.object({
+        includeHistory: qBool.optional(),
+        dimension: z.string().max(200).optional(),
+      }),
+    ),
+    async (c) => {
+      const entityId = c.req.param("entityId");
+      const { includeHistory, dimension } = c.req.valid("query");
+      const db = getDrizzleDb();
 
-    const rows = await db
-      .select({
-        grade: scorecardGrades,
-        entityTitle: entities.title,
-        entitySlug: entities.id,
-        scorecardSource: scorecardSnapshots.scorecardSource,
-        publishedAt: scorecardSnapshots.publishedAt,
-        isLatest: scorecardSnapshots.isLatest,
-        snapshotSourceUrl: scorecardSnapshots.sourceUrl,
-        ...verdictSelectFields,
-      })
-      .from(scorecardGrades)
-      .leftJoin(
-        scorecardSnapshots,
-        eq(scorecardGrades.snapshotId, scorecardSnapshots.id),
-      )
-      .leftJoin(entities, eq(scorecardGrades.entityId, entities.stableId))
-      .leftJoin(
-        sourceVerdicts,
-        verdictJoinCondition(
-          SCORECARD_GRADE_RECORD_TYPE,
-          scorecardGrades.id,
-        ),
-      )
-      .where(
-        and(
-          eq(scorecardGrades.entityId, entityId),
-          eq(scorecardSnapshots.isLatest, true),
-        ),
-      )
-      .orderBy(
-        scorecardSnapshots.scorecardSource,
-        scorecardGrades.dimensionSlug,
-      );
+      const conditions: SQL[] = [eq(scorecardGrades.entityId, entityId)];
+      if (!includeHistory) {
+        conditions.push(eq(scorecardSnapshots.isLatest, true));
+      }
+      if (dimension) {
+        conditions.push(eq(scorecardGrades.dimensionSlug, dimension));
+      }
 
-    return c.json({ items: rows.map(formatRow), total: rows.length });
-  })
+      const rows = await db
+        .select({
+          grade: scorecardGrades,
+          entityTitle: entities.title,
+          entitySlug: entities.id,
+          scorecardSource: scorecardSnapshots.scorecardSource,
+          publishedAt: scorecardSnapshots.publishedAt,
+          isLatest: scorecardSnapshots.isLatest,
+          snapshotSourceUrl: scorecardSnapshots.sourceUrl,
+          waveLabel: scorecardSnapshots.waveLabel,
+          ...verdictSelectFields,
+        })
+        .from(scorecardGrades)
+        .leftJoin(
+          scorecardSnapshots,
+          eq(scorecardGrades.snapshotId, scorecardSnapshots.id),
+        )
+        .leftJoin(entities, eq(scorecardGrades.entityId, entities.stableId))
+        .leftJoin(
+          sourceVerdicts,
+          verdictJoinCondition(
+            SCORECARD_GRADE_RECORD_TYPE,
+            scorecardGrades.id,
+          ),
+        )
+        .where(and(...conditions))
+        .orderBy(
+          scorecardSnapshots.scorecardSource,
+          // Newest wave first within a source so consumers can take the
+          // first row per source without sorting again. The history
+          // mini-table renders chronological top-to-bottom by re-sorting.
+          desc(scorecardSnapshots.publishedAt),
+          scorecardGrades.dimensionSlug,
+        );
+
+      return c.json({ items: rows.map(formatRow), total: rows.length });
+    },
+  )
 
   // POST /sync
   .post(

--- a/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
@@ -247,9 +247,10 @@ const scorecardGradesApp = new Hono()
         .where(and(...conditions))
         .orderBy(
           scorecardSnapshots.scorecardSource,
-          // Newest wave first within a source so consumers can take the
-          // first row per source without sorting again. The history
-          // mini-table renders chronological top-to-bottom by re-sorting.
+          // Newest wave first within a source. Default (latest-only) is
+          // unaffected — there's exactly one publishedAt per source. With
+          // includeHistory=true, the history mini-table consumes rows in
+          // receive order and renders newest-on-top, which matches.
           desc(scorecardSnapshots.publishedAt),
           scorecardGrades.dimensionSlug,
         );

--- a/crux/lib/scorecard-import/__tests__/parse-ailabwatch.test.ts
+++ b/crux/lib/scorecard-import/__tests__/parse-ailabwatch.test.ts
@@ -13,6 +13,7 @@ import {
   AILW_DIMENSIONS,
   AILW_ORGS,
 } from "../parse-ailabwatch.ts";
+import { FAIR_USE_CITATION_LICENSE } from "../types.ts";
 
 /**
  * Build a minimal fixture HTML covering all 7 orgs × 7 dimensions plus
@@ -293,7 +294,7 @@ describe("buildAILabWatchGradesFile", () => {
     // /scorecards/ailabwatch snapshot table renders an actual reuse term
     // instead of an em-dash.
     const out = buildAILabWatchGradesFile(freshParsed(), opts);
-    expect(out.license).toBe("fair-use-citation");
+    expect(out.license).toBe(FAIR_USE_CITATION_LICENSE);
     expect(out.isLatest).toBe(true);
   });
 

--- a/crux/lib/scorecard-import/__tests__/parse-ailabwatch.test.ts
+++ b/crux/lib/scorecard-import/__tests__/parse-ailabwatch.test.ts
@@ -287,9 +287,13 @@ describe("buildAILabWatchGradesFile", () => {
     }
   });
 
-  it("hardcodes license=null and isLatest=true (single-wave frozen source)", () => {
+  it("hardcodes license=fair-use-citation and isLatest=true (single-wave frozen source)", () => {
+    // QUA-867 item B: ailabwatch.org publishes no explicit Creative Commons
+    // or other license. We label our display "fair-use-citation" so the
+    // /scorecards/ailabwatch snapshot table renders an actual reuse term
+    // instead of an em-dash.
     const out = buildAILabWatchGradesFile(freshParsed(), opts);
-    expect(out.license).toBeNull();
+    expect(out.license).toBe("fair-use-citation");
     expect(out.isLatest).toBe(true);
   });
 

--- a/crux/lib/scorecard-import/__tests__/seoul-scraper.test.ts
+++ b/crux/lib/scorecard-import/__tests__/seoul-scraper.test.ts
@@ -16,6 +16,7 @@ import {
   numericToVerdict,
   scrapeSeoul,
 } from "../sources/seoul-scraper.ts";
+import { FAIR_USE_CITATION_LICENSE } from "../types.ts";
 
 const COMPANIES = [
   { id: "amazon", name: "Amazon" },
@@ -228,7 +229,7 @@ describe("scrapeSeoul", () => {
     // /scorecards/seoul_tracker snapshot history table shows an actual term
     // instead of the em-dash placeholder it had before QUA-867.
     const wave = scrapeSeoul(buildHtml(), buildChunk(), {});
-    expect(wave.license).toBe("fair-use-citation");
+    expect(wave.license).toBe(FAIR_USE_CITATION_LICENSE);
   });
 
   it("respects publishedAt + waveLabel overrides", () => {

--- a/crux/lib/scorecard-import/__tests__/seoul-scraper.test.ts
+++ b/crux/lib/scorecard-import/__tests__/seoul-scraper.test.ts
@@ -222,6 +222,15 @@ describe("scrapeSeoul", () => {
     expect(counts).toEqual({ Fulfilled: 6, Partial: 4, Unfulfilled: 6 });
   });
 
+  it("hardcodes license=fair-use-citation (no explicit license on seoul-tracker.org) — QUA-867", () => {
+    // Seoul Commitment Tracker pages publish no Creative Commons or other
+    // explicit license. We display verdicts under fair-use citation so the
+    // /scorecards/seoul_tracker snapshot history table shows an actual term
+    // instead of the em-dash placeholder it had before QUA-867.
+    const wave = scrapeSeoul(buildHtml(), buildChunk(), {});
+    expect(wave.license).toBe("fair-use-citation");
+  });
+
   it("respects publishedAt + waveLabel overrides", () => {
     const wave = scrapeSeoul(buildHtml(), buildChunk(), {
       publishedAt: "2026-01-15",

--- a/crux/lib/scorecard-import/extract/fli.ts
+++ b/crux/lib/scorecard-import/extract/fli.ts
@@ -180,7 +180,7 @@ Return a single JSON object matching this exact schema (no prose, no markdown fe
   "waveLabel": "string (e.g. 'Summer 2025')",
   "sourceUrl": "string",
   "methodologyUrl": "string | null",
-  "license": "string | null (e.g. 'CC BY 4.0')",
+  "license": "string (e.g. 'CC BY 4.0', or 'fair-use-citation' when the page has no explicit license — FLI's index pages declare no Creative Commons terms, so this is the expected value for FLI waves)",
   "notes": "string | null",
   "dimensions": [
     {"slug": "kebab-case", "label": "Display Name", "weight": null}

--- a/crux/lib/scorecard-import/parse-ailabwatch.ts
+++ b/crux/lib/scorecard-import/parse-ailabwatch.ts
@@ -159,7 +159,11 @@ export function buildAILabWatchGradesFile(
     waveLabel: opts.waveLabel,
     sourceUrl: opts.sourceUrl,
     methodologyUrl: opts.methodologyUrl ?? null,
-    license: null,
+    // ailabwatch.org publishes no explicit license (verified 2026-05-02 —
+    // the about page and footer have no Creative Commons / MIT statement).
+    // We display the grades for educational/fair-use purposes; QUA-867
+    // backfilled this label across the existing snapshots.
+    license: "fair-use-citation",
     notes: opts.notes,
     isLatest: true,
     dimensions: dims,

--- a/crux/lib/scorecard-import/parse-ailabwatch.ts
+++ b/crux/lib/scorecard-import/parse-ailabwatch.ts
@@ -20,6 +20,7 @@
  */
 
 import { load, type CheerioAPI } from "cheerio";
+import { FAIR_USE_CITATION_LICENSE } from "./types.ts";
 
 /**
  * The 7 AI Lab Watch dimensions. The slugs match the URL paths
@@ -163,7 +164,7 @@ export function buildAILabWatchGradesFile(
     // the about page and footer have no Creative Commons / MIT statement).
     // We display the grades for educational/fair-use purposes; QUA-867
     // backfilled this label across the existing snapshots.
-    license: "fair-use-citation",
+    license: FAIR_USE_CITATION_LICENSE,
     notes: opts.notes,
     isLatest: true,
     dimensions: dims,

--- a/crux/lib/scorecard-import/sources/seoul-scraper.ts
+++ b/crux/lib/scorecard-import/sources/seoul-scraper.ts
@@ -310,7 +310,11 @@ export function scrapeSeoul(
     waveLabel,
     sourceUrl: opts.sourceUrl ?? "https://www.seoul-tracker.org",
     methodologyUrl: "https://www.seoul-tracker.org",
-    license: null,
+    // The Seoul Commitment Tracker publishes no explicit license (verified
+    // 2026-05-02 — only social share links + a Midas Project privacy policy
+    // pointer, no CC / terms-of-use statement). We display verdicts under
+    // fair-use citation; QUA-867 backfilled this label on existing snapshots.
+    license: "fair-use-citation",
     notes: null,
     isLatest: opts.isLatest ?? true,
     dimensions: dimensions.map((d) => ({ slug: d.id, label: d.name })),

--- a/crux/lib/scorecard-import/sources/seoul-scraper.ts
+++ b/crux/lib/scorecard-import/sources/seoul-scraper.ts
@@ -39,6 +39,8 @@
  * extraction.
  */
 
+import { FAIR_USE_CITATION_LICENSE } from "../types.ts";
+
 const PAGE_CHUNK_RE = /\/_next\/static\/chunks\/app\/page-[A-Za-z0-9]+\.js/;
 const COMPANIES_NEEDLE = '[{id:"amazon",name:"Amazon"}';
 const DIMENSIONS_NEEDLE = '[{id:"risk-evaluations",name:"Risk Evaluation"}';
@@ -314,7 +316,7 @@ export function scrapeSeoul(
     // 2026-05-02 — only social share links + a Midas Project privacy policy
     // pointer, no CC / terms-of-use statement). We display verdicts under
     // fair-use citation; QUA-867 backfilled this label on existing snapshots.
-    license: "fair-use-citation",
+    license: FAIR_USE_CITATION_LICENSE,
     notes: null,
     isLatest: opts.isLatest ?? true,
     dimensions: dimensions.map((d) => ({ slug: d.id, label: d.name })),

--- a/crux/lib/scorecard-import/types.ts
+++ b/crux/lib/scorecard-import/types.ts
@@ -15,6 +15,19 @@ import type { ScorecardSourceKey } from "../../../apps/web/src/app/scorecards/sc
 export type { ScorecardSourceKey };
 
 /**
+ * Canonical license token for sources that publish no explicit reuse
+ * terms (verified 2026-05-02 for FLI, AI Lab Watch, Seoul Tracker — none
+ * declares Creative Commons / MIT). Surfacing this as a constant keeps
+ * the parsers, scrapers, fixtures, and the LLM extractor prompt in
+ * lockstep — a typo would land as a new token in `scorecard_snapshots.license`
+ * and the methodology / detail-page UI would silently render it.
+ *
+ * SaferAI declares its own `CC BY-SA 4.0` and FMTI declares `CC-BY-4.0`;
+ * those stay as-is rather than going through this constant.
+ */
+export const FAIR_USE_CITATION_LICENSE = "fair-use-citation";
+
+/**
  * One snapshot row (a wave of a scorecard). Maps 1:1 to
  * `scorecard_snapshots` / the `/api/scorecard-snapshots/sync` payload.
  *

--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -3980,13 +3980,22 @@
   type: organization
   orgType: safety-org
   title: SaferAI
-  website: https://saferai.org
+  website: https://www.safer-ai.org
   description: >-
-    Organization focused on AI safety standards and evaluation frameworks.
+    Paris-based nonprofit (French association loi 1901) building risk
+    measurement tools for governments and companies managing frontier AI.
+    Founded by Siméon Campos (chairman); Henry Papadatos serves as
+    executive director. Best known for the SaferAI Ratings — independent
+    evaluations of leading AI developers across four dimensions (risk
+    identification, severity assessment, safeguard implementation, and
+    governance), published under CC BY-SA 4.0. Also contributes to
+    standards work at CEN-CENELEC JTC 21, ISO generative AI red-teaming,
+    the EU Code of Practice, and the OECD Hiroshima AI Process.
   tags:
     - ai-safety
     - ai-governance
-  lastUpdated: 2026-03
+    - ai-evaluation
+  lastUpdated: 2026-05
 
 - id: ai-safety-camp
   stableId: sid_2BUn75004w

--- a/data/scorecards/raw/ailabwatch/2025-09/grades.json
+++ b/data/scorecards/raw/ailabwatch/2025-09/grades.json
@@ -3,7 +3,7 @@
   "waveLabel": "September 2025 (frozen)",
   "sourceUrl": "https://ailabwatch.org/",
   "methodologyUrl": "https://ailabwatch.org/about",
-  "license": null,
+  "license": "fair-use-citation",
   "notes": "AI Lab Watch (ailabwatch.org) — frozen as of September 2025 per the author. Seven dimensions × seven frontier labs; per-cell scores in 0-100 percent. Overall is the site's published weighted total.",
   "isLatest": true,
   "dimensions": [

--- a/data/scorecards/raw/fli/2024-12/grades.json
+++ b/data/scorecards/raw/fli/2024-12/grades.json
@@ -3,7 +3,7 @@
   "waveLabel": "December 2024",
   "sourceUrl": "https://futureoflife.org/wp-content/uploads/2024/12/AI-Safety-Index-2024-Full-Report-27-May-25.pdf",
   "methodologyUrl": "https://futureoflife.org/document/fli-ai-safety-index-2024/",
-  "license": null,
+  "license": "fair-use-citation",
   "notes": "Grading uses the US GPA system: A+, A, A-, B+, ..., F corresponding to numerical values 4.3, 4.0, 3.7, 3.3, ..., 0. Overall grades are derived from average scores across six domains.",
   "dimensions": [
     {

--- a/data/scorecards/raw/fli/summer-2025/grades.json
+++ b/data/scorecards/raw/fli/summer-2025/grades.json
@@ -3,7 +3,7 @@
   "waveLabel": "Summer 2025",
   "sourceUrl": "https://futureoflife.org/ai-safety-index-summer-2025/",
   "methodologyUrl": "https://futureoflife.org/document/ai-safety-index-summer-2025-2-page-summary/",
-  "license": null,
+  "license": "fair-use-citation",
   "notes": "Scoring completed in early July 2025. Domain scores shown on the main scorecard are the grades visible in the desktop scoreboard grid. Per-domain detailed grades are drawn from the modal popups. Survey Responses domain is not graded with letter grades.",
   "dimensions": [
     {

--- a/data/scorecards/raw/fli/winter-2025/grades.json
+++ b/data/scorecards/raw/fli/winter-2025/grades.json
@@ -3,7 +3,7 @@
   "waveLabel": "Winter 2025",
   "sourceUrl": "https://futureoflife.org/ai-safety-index-winter-2025/",
   "methodologyUrl": "https://futureoflife.org/document/ai-safety-index-winter-2025-2-page-summary/",
-  "license": null,
+  "license": "fair-use-citation",
   "notes": "Evidence collected up until November 8, 2025. Survey responses submitted by Anthropic, OpenAI, Google DeepMind, xAI, and Z.ai. Meta, DeepSeek, and Alibaba Cloud did not submit survey responses. The 'Survey Responses' dimension is not a scored domain but tracks participation.",
   "dimensions": [
     {

--- a/data/scorecards/raw/seoul/2025-02/grades.json
+++ b/data/scorecards/raw/seoul/2025-02/grades.json
@@ -3,7 +3,7 @@
   "waveLabel": "February 2025",
   "sourceUrl": "https://www.seoul-tracker.org",
   "methodologyUrl": "https://www.seoul-tracker.org",
-  "license": null,
+  "license": "fair-use-citation",
   "notes": null,
   "isLatest": true,
   "dimensions": [


### PR DESCRIPTION
## Summary

Five small follow-ups from the QUA-841 scorecards audit, batched per the ticket. Each one is independently shippable; they cluster the same code area so they ride one PR cheaper than five.

### A. Wire `publisherSlug` for 4 of 5 sources

`SCORECARD_SOURCES` only had `publisherSlug` for `fli_index`. QUA-836 backfilled the other 4 publisher entities to prod, but the constants file was never updated, so `/scorecards` methodology cards and per-org panel headers rendered "by SaferAI", "by Stanford CRFM", etc. as plain text.

- Set `publisherSlug` for `saferai`, `ailabwatch`, `fmti`, `seoul_tracker`.
- AI Lab Watch's publisher is the *person* `zach-stein-perlman`, not an organization. Both rendering surfaces (`scorecards-section.tsx` and `scorecards/page.tsx`) now route through `getEntityHref` so the link goes to `/people/zach-stein-perlman` instead of a 404 at `/organizations/zach-stein-perlman`.

### B. Backfill `license` on 3 of 5 sources

`scorecard_snapshots.license` was NULL for FLI (3 waves), AI Lab Watch, and Seoul Tracker. Verified against ailabwatch.org/about, seoul-tracker.org, and futureoflife.org/ai-safety-index-summer-2025: none publishes an explicit Creative Commons / MIT statement; FLI explicitly says "All rights reserved."

- Used `fair-use-citation` for all three — the conservative legally-accurate label, matching the pattern SaferAI declines to use because it has its own CC BY-SA 4.0.
- Updated parser/scraper defaults (`parse-ailabwatch.ts`, `seoul-scraper.ts`, FLI extractor schema) so future re-ingests don't reset to null.
- Centralized as `FAIR_USE_CITATION_LICENSE` in `crux/lib/scorecard-import/types.ts` so the parsers, scrapers, and tests stay in lockstep.
- Synced to PG; verified via prod wiki-server (`fair-use-citation` shows on every relevant snapshot).

### C. Enrich SaferAI publisher entity

70-char stub → ~600 chars matching the other 4 publishers (founders, executive director, ratings methodology with the four pillars, standards work at CEN-CENELEC JTC 21 / ISO / EU Code of Practice / OECD Hiroshima AI Process). Source: safer-ai.org/about (verified via WebFetch). Also updated the website URL from `https://saferai.org` to `https://www.safer-ai.org` (the canonical domain).

### D. Add `externalScorecardCount` signal to `computeOrgCoverage`

`OrgCoverageInput` only counted financial metrics + people + wiki page. An org rated by all 5 scorecards but missing financial metadata used to score 1 ("stub").

- `OrgCoverageInput.externalScorecardCount` adds two signal increments: ≥1 scorecards = 1 signal, ≥3 scorecards = a second signal.
- Wired the per-org profile via the already-loaded `scorecardsData.groups.length`.
- Wired the `/organizations` directory listing via a new subquery on the wiki-server orgs route (`COUNT(DISTINCT scorecard_source) WHERE is_latest=true`).
- `getOrgSignals` shows "1 external scorecard" / "N external scorecards" in the popover breakdown.

### E. Show grade trajectory in per-org scorecards tab

The per-org tab only rendered the latest wave per source — no historical context. Added a collapsible mini-table per panel.

- Extended `/api/scorecard-grades/by-entity/:entityId` with `?includeHistory=true&dimension=overall`. Default behavior (latest only) is unchanged.
- Two parallel fetches in `loadScorecardsForEntity`: existing latest-wave with all dimensions + narrow overall-only history.
- Rendered as a `<details>` element so panels stay compact when collapsed.
- Hidden when only one wave exists. Today only FLI has multiple waves; the markup is generic so a second SaferAI/AI Lab Watch wave picks up the trajectory automatically.

## Test plan

- [x] `npx vitest run crux/lib/scorecard-import` — 127 tests pass (license backfills + tests)
- [x] `cd apps/web && npx vitest run src/app/scorecards src/app/organizations src/components/coverage` — 320+ tests pass (added 21 new ones for `getOrgSignals`, trajectory rendering, boundary-2 case, person-publisher routing)
- [x] `npx vitest run apps/wiki-server/src/__tests__ apps/wiki-server/src/routes/tablebase` — 1685 tests pass
- [x] `pnpm test` — 9684 tests pass across all packages
- [x] `pnpm crux w validate gate --fix` — 74 checks green (full mode, no cache)
- [x] `npx tsc --noEmit` — clean in apps/web and apps/wiki-server (crux baseline errors are pre-existing)
- [x] `pnpm build` — Next.js production build succeeds
- [x] Verified `pnpm crux tb import-scorecards sync` lands the new licenses and prod API returns them
- [x] Render audit smoke test against prod (`/organizations/anthropic` and scorecards-tab paths)
- [x] Local dev sanity check — verified publisher links resolve to `/organizations/saferai`, `/people/zach-stein-perlman`, etc.
- [x] `/agent-review-pr` ran with hostile-reviewer subagent; HIGH and MEDIUM findings addressed in `c2d42a25e` review-fix commit

Fixes QUA-867


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added external scorecard counts to organization coverage and scoring
  * Grade trajectory view showing historical grades across waves
  * Scorecard publisher names now render as links when a publisher URL is available
  * Wave labels added to identify scorecard release versions

* **Updates**
  * SaferAI profile updated (website, description, tags, lastUpdated)
  * Standardized fair-use citation license applied to several scorecard sources and data files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->