### PR TITLE
feat(qua-942): PDF resources first-class adapter pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,7 @@ These live in `docs/agent-rules/`. They are **NOT** auto-loaded — to keep cach
 | TableBase sync routes (`apps/wiki-server/src/routes/tablebase/`) | `docs/agent-rules/tablebase-sync-factory.md` |
 | TableBase / FactBase / WikiBase naming, which layer owns what | `docs/agent-rules/three-bases-architecture.md` |
 | Source-check verdicts, coverage scoring, `/api/sourcing/*`, dot indicators | `docs/agent-rules/source-check-system.md` |
+| Archiving a PDF as a Resource, page-addressable evidence (`evidence_locator`) | `docs/agent-rules/source-check-system.md` § 9 |
 | `numericId` vs `stableId` vs `tableId` — allocation, validation | `docs/agent-rules/id-system.md` |
 | Adding/changing a `crux/validate/` validator or the gate | `docs/agent-rules/validation-gate-system.md` |
 | Entity profile pages (`/organizations/[slug]`, `/people/[slug]`, etc.) | `docs/agent-rules/entity-profile-pages.md` |

--- a/apps/wiki-server/drizzle/0224_qua_942_evidence_locator.sql
+++ b/apps/wiki-server/drizzle/0224_qua_942_evidence_locator.sql
@@ -1,0 +1,25 @@
+-- QUA-942: page-addressable evidence for source-check.
+--
+-- Adds optional `evidence_locator` JSONB column to `source_check_evidence`,
+-- so a single source can carry multiple per-location verdicts (e.g. one row
+-- per PDF page, table cell, or HTML anchor) instead of being limited to the
+-- whole-source verdict that the row already represents.
+--
+-- Shape (validated in app code, not by CHECK — JSONB stays flexible for new
+-- locator kinds without per-kind migrations):
+--
+--   { "kind": "pdf-page", "page": 14 }
+--   { "kind": "pdf-page", "page": 14, "table": "2.3" }
+--   { "kind": "csv-cell", "row": 23, "column": "risk-assessment" }
+--   { "kind": "html-anchor", "selector": "#table-2" }
+--
+-- NULL = whole-source evidence (existing behavior, no migration impact on
+-- existing rows). Index is partial so we don't pay storage for the NULL rows
+-- that dominate today's evidence corpus.
+
+ALTER TABLE "source_check_evidence"
+  ADD COLUMN IF NOT EXISTS "evidence_locator" jsonb;
+
+CREATE INDEX IF NOT EXISTS "idx_sce_evidence_locator"
+  ON "source_check_evidence" USING gin ("evidence_locator")
+  WHERE "evidence_locator" IS NOT NULL;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1562,6 +1562,13 @@
       "when": 1788000100000,
       "tag": "0223_qua_1012_pipeline_runs_cost_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 224,
+      "version": "7",
+      "when": 1788000200000,
+      "tag": "0224_qua_942_evidence_locator",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/migration-0224-qua-942-evidence-locator.test.ts
+++ b/apps/wiki-server/src/__tests__/migration-0224-qua-942-evidence-locator.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Static-shape tests for migration 0224 (QUA-942) — evidence_locator JSONB.
+ *
+ * The migration adds a single nullable JSONB column with a partial GIN index.
+ * Goals checked here:
+ *   - Column added to the right table, with the right type, nullable
+ *   - Index exists, partial (NOT NULL filter), GIN — so we don't pay storage
+ *     for the millions of NULL rows in the table today
+ *   - Migration is idempotent (IF NOT EXISTS) so replay is safe
+ *   - Journal entry exists with the right tag (catches "forgot to update
+ *     journal" — known foot-gun in this repo)
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MIGRATION_FILE = path.resolve(
+  __dirname,
+  "../../drizzle/0224_qua_942_evidence_locator.sql",
+);
+const JOURNAL_FILE = path.resolve(
+  __dirname,
+  "../../drizzle/meta/_journal.json",
+);
+
+describe("migration 0224 — QUA-942 evidence_locator", () => {
+  const sql = readFileSync(MIGRATION_FILE, "utf-8");
+
+  it("adds evidence_locator JSONB column to source_check_evidence", () => {
+    expect(sql).toMatch(
+      /ALTER TABLE\s+"?source_check_evidence"?\s+ADD COLUMN\s+IF NOT EXISTS\s+"?evidence_locator"?\s+jsonb/i,
+    );
+    // Must be nullable — we never want to backfill a JSONB locator on rows
+    // that were written before page-addressable evidence was a thing.
+    // Check only the ALTER TABLE statement (CREATE INDEX has IS NOT NULL in
+    // its WHERE clause, which is fine).
+    const alterMatch = sql.match(/ALTER TABLE[^;]*evidence_locator[^;]*;/i);
+    expect(alterMatch, "ALTER TABLE for evidence_locator should be present").toBeTruthy();
+    expect(alterMatch![0]).not.toMatch(/NOT NULL/i);
+  });
+
+  it("creates a partial GIN index for non-null locators", () => {
+    expect(sql).toMatch(
+      /CREATE INDEX\s+IF NOT EXISTS\s+"?idx_sce_evidence_locator"?[\s\S]*?USING gin/i,
+    );
+    expect(sql).toMatch(/WHERE\s+"?evidence_locator"?\s+IS NOT NULL/i);
+  });
+
+  it("uses IF NOT EXISTS for idempotency on replay", () => {
+    expect(sql).toMatch(/ADD COLUMN\s+IF NOT EXISTS/i);
+    expect(sql).toMatch(/CREATE INDEX\s+IF NOT EXISTS/i);
+  });
+
+  it("is registered in the drizzle journal", () => {
+    const journal = JSON.parse(readFileSync(JOURNAL_FILE, "utf-8")) as {
+      entries: Array<{ idx: number; tag: string }>;
+    };
+    const entry = journal.entries.find((e) => e.idx === 224);
+    expect(entry).toBeDefined();
+    expect(entry?.tag).toBe("0224_qua_942_evidence_locator");
+  });
+});

--- a/apps/wiki-server/src/__tests__/qua-942-evidence-locator-schema.test.ts
+++ b/apps/wiki-server/src/__tests__/qua-942-evidence-locator-schema.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Zod-shape tests for QUA-942 EvidenceLocatorSchema.
+ *
+ * The schema is the source of truth for what shapes can be persisted in
+ * source_check_evidence.evidence_locator. The DB column is JSONB (no shape
+ * enforcement) precisely because we want to add new locator kinds without
+ * a migration — but that means the Zod gate has to be tight.
+ */
+
+import { describe, it, expect } from "vitest";
+import { EvidenceLocatorSchema } from "../routes/sourcing/sourcing.js";
+
+describe("EvidenceLocatorSchema (QUA-942)", () => {
+  describe("pdf-page locator", () => {
+    it("accepts a basic 1-based page number", () => {
+      const parsed = EvidenceLocatorSchema.parse({ kind: "pdf-page", page: 14 });
+      expect(parsed).toEqual({ kind: "pdf-page", page: 14 });
+    });
+
+    it("accepts page + table reference", () => {
+      const parsed = EvidenceLocatorSchema.parse({
+        kind: "pdf-page",
+        page: 14,
+        table: "2.3",
+      });
+      expect(parsed.kind).toBe("pdf-page");
+      if (parsed.kind === "pdf-page") {
+        expect(parsed.table).toBe("2.3");
+      }
+    });
+
+    it("accepts page + table + row", () => {
+      const parsed = EvidenceLocatorSchema.parse({
+        kind: "pdf-page",
+        page: 14,
+        table: "2.3",
+        row: 12,
+      });
+      expect(parsed.kind).toBe("pdf-page");
+    });
+
+    it("rejects page=0 (must be 1-based)", () => {
+      expect(() => EvidenceLocatorSchema.parse({ kind: "pdf-page", page: 0 })).toThrow();
+    });
+
+    it("rejects negative pages", () => {
+      expect(() =>
+        EvidenceLocatorSchema.parse({ kind: "pdf-page", page: -3 }),
+      ).toThrow();
+    });
+
+    it("rejects non-integer pages", () => {
+      expect(() =>
+        EvidenceLocatorSchema.parse({ kind: "pdf-page", page: 1.5 }),
+      ).toThrow();
+    });
+
+    it("rejects absurdly large pages (likely typo / overflow guard)", () => {
+      expect(() =>
+        EvidenceLocatorSchema.parse({ kind: "pdf-page", page: 200_000 }),
+      ).toThrow();
+    });
+
+    it("rejects missing page", () => {
+      expect(() => EvidenceLocatorSchema.parse({ kind: "pdf-page" })).toThrow();
+    });
+  });
+
+  describe("csv-cell locator", () => {
+    it("accepts row + column", () => {
+      const parsed = EvidenceLocatorSchema.parse({
+        kind: "csv-cell",
+        row: 23,
+        column: "risk-assessment",
+      });
+      expect(parsed).toEqual({ kind: "csv-cell", row: 23, column: "risk-assessment" });
+    });
+
+    it("rejects empty column name", () => {
+      expect(() =>
+        EvidenceLocatorSchema.parse({ kind: "csv-cell", row: 1, column: "" }),
+      ).toThrow();
+    });
+
+    it("rejects row=0", () => {
+      expect(() =>
+        EvidenceLocatorSchema.parse({ kind: "csv-cell", row: 0, column: "x" }),
+      ).toThrow();
+    });
+  });
+
+  describe("html-anchor locator", () => {
+    it("accepts a CSS selector", () => {
+      const parsed = EvidenceLocatorSchema.parse({
+        kind: "html-anchor",
+        selector: "#table-2",
+      });
+      expect(parsed).toEqual({ kind: "html-anchor", selector: "#table-2" });
+    });
+
+    it("rejects empty selector", () => {
+      expect(() =>
+        EvidenceLocatorSchema.parse({ kind: "html-anchor", selector: "" }),
+      ).toThrow();
+    });
+  });
+
+  describe("discrimination", () => {
+    it("rejects unknown kinds (forces a schema update for new locators)", () => {
+      expect(() =>
+        EvidenceLocatorSchema.parse({ kind: "transcript-time", seconds: 30 }),
+      ).toThrow();
+    });
+
+    it("rejects missing kind", () => {
+      expect(() =>
+        EvidenceLocatorSchema.parse({ page: 14 } as unknown as { kind: string }),
+      ).toThrow();
+    });
+
+    it("rejects pdf-page fields under csv-cell kind (cross-kind contamination)", () => {
+      // A common mistake when copy-pasting between locator kinds. The
+      // discriminated union should reject this even though the field names
+      // are recognized in pdf-page — csv-cell requires its own row+column.
+      expect(() =>
+        EvidenceLocatorSchema.parse({ kind: "csv-cell", page: 14 }),
+      ).toThrow();
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/qua-942-evidence-locator-schema.test.ts
+++ b/apps/wiki-server/src/__tests__/qua-942-evidence-locator-schema.test.ts
@@ -126,5 +126,64 @@ describe("EvidenceLocatorSchema (QUA-942)", () => {
         EvidenceLocatorSchema.parse({ kind: "csv-cell", page: 14 }),
       ).toThrow();
     });
+
+    it("strips extra keys from valid locators (Zod default)", () => {
+      // The DB column is JSONB so the ONLY thing protecting downstream
+      // consumers from arbitrary extra-key pollution is Zod's default-strip
+      // behavior. If a future config switches schemas to .passthrough(),
+      // this test breaks loudly so we notice.
+      const parsed = EvidenceLocatorSchema.parse({
+        kind: "pdf-page",
+        page: 14,
+        injectedKey: "should not survive",
+        anotherInjection: { nested: true },
+      });
+      expect(parsed).toEqual({ kind: "pdf-page", page: 14 });
+      expect((parsed as Record<string, unknown>).injectedKey).toBeUndefined();
+      expect((parsed as Record<string, unknown>).anotherInjection).toBeUndefined();
+    });
+  });
+
+  describe("field length caps", () => {
+    it("rejects pdf-page table > 50 chars", () => {
+      expect(() =>
+        EvidenceLocatorSchema.parse({
+          kind: "pdf-page",
+          page: 1,
+          table: "x".repeat(51),
+        }),
+      ).toThrow();
+    });
+    it("accepts pdf-page row as string or number", () => {
+      const a = EvidenceLocatorSchema.parse({
+        kind: "pdf-page",
+        page: 1,
+        row: "header-row",
+      });
+      const b = EvidenceLocatorSchema.parse({
+        kind: "pdf-page",
+        page: 1,
+        row: 12,
+      });
+      expect(a.kind).toBe("pdf-page");
+      expect(b.kind).toBe("pdf-page");
+    });
+    it("rejects csv-cell column > 200 chars", () => {
+      expect(() =>
+        EvidenceLocatorSchema.parse({
+          kind: "csv-cell",
+          row: 1,
+          column: "x".repeat(201),
+        }),
+      ).toThrow();
+    });
+    it("rejects html-anchor selector > 500 chars", () => {
+      expect(() =>
+        EvidenceLocatorSchema.parse({
+          kind: "html-anchor",
+          selector: "#" + "x".repeat(500),
+        }),
+      ).toThrow();
+    });
   });
 });

--- a/apps/wiki-server/src/__tests__/qua-942-evidence-locator-schema.test.ts
+++ b/apps/wiki-server/src/__tests__/qua-942-evidence-locator-schema.test.ts
@@ -87,6 +87,12 @@ describe("EvidenceLocatorSchema (QUA-942)", () => {
         EvidenceLocatorSchema.parse({ kind: "csv-cell", row: 0, column: "x" }),
       ).toThrow();
     });
+
+    it("rejects missing row", () => {
+      expect(() =>
+        EvidenceLocatorSchema.parse({ kind: "csv-cell", column: "x" }),
+      ).toThrow();
+    });
   });
 
   describe("html-anchor locator", () => {

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1906,3 +1906,41 @@ export const IdFormatAuditSchema = z.object({
 export type IdFormatAudit = z.infer<typeof IdFormatAuditSchema>;
 export type IdFormatBucketName = (typeof ID_FORMAT_BUCKET_NAMES)[number];
 export type IdFormatSourceTableName = (typeof ID_FORMAT_SOURCE_TABLES)[number];
+
+// -- QUA-942: page-addressable evidence locator --------------------------------
+
+/**
+ * Locator for sourcing evidence stored in `source_check_evidence.evidence_locator`
+ * (table name preserved from earlier schema; the conceptual layer is "sourcing").
+ * NULL/absent = whole-source verdict (existing behavior); a locator narrows the
+ * verdict to a specific page/cell/anchor inside the source. The DB column is
+ * JSONB so new locator kinds add a Zod branch here, not a migration. See the
+ * sourcing-system docs § 9 for the semantics (QUA-942).
+ */
+const PdfPageLocator = z.object({
+  kind: z.literal("pdf-page"),
+  /** 1-based physical page number. */
+  page: z.number().int().min(1).max(100_000),
+  /** Optional table reference within the page (e.g. "2.3"). */
+  table: z.string().max(50).optional(),
+  /** Optional row reference within a table on the page. */
+  row: z.union([z.string().max(50), z.number().int()]).optional(),
+});
+const CsvCellLocator = z.object({
+  kind: z.literal("csv-cell"),
+  /** 1-based row index within the CSV body (header excluded). */
+  row: z.number().int().min(1).max(10_000_000),
+  column: z.string().min(1).max(200),
+});
+const HtmlAnchorLocator = z.object({
+  kind: z.literal("html-anchor"),
+  /** CSS-style selector pinning a fragment of the source HTML. */
+  selector: z.string().min(1).max(500),
+});
+
+export const EvidenceLocatorSchema = z.discriminatedUnion("kind", [
+  PdfPageLocator,
+  CsvCellLocator,
+  HtmlAnchorLocator,
+]);
+export type EvidenceLocator = z.infer<typeof EvidenceLocatorSchema>;

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1924,7 +1924,7 @@ const PdfPageLocator = z.object({
   /** Optional table reference within the page (e.g. "2.3"). */
   table: z.string().max(50).optional(),
   /** Optional row reference within a table on the page. */
-  row: z.union([z.string().max(50), z.number().int()]).optional(),
+  row: z.union([z.string().max(50), z.number().int().min(1)]).optional(),
 });
 const CsvCellLocator = z.object({
   kind: z.literal("csv-cell"),

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -862,6 +862,8 @@ export interface ResourceRow {
   credibilityOverride: number | null;
   fetchedAt: string | null;
   contentHash: string | null;
+  /** Canonical sid_-prefixed identifier returned by `formatResource`. */
+  stableId: string | null;
   /** HTTP reachability of the URL. Distinct from enrichmentStatus (LLM pipeline stage). */
   fetchStatus: "ok" | "dead" | "soft_404" | "not_found" | "timeout" | "unreachable" | "paywall" | "error" | null;
   lastFetchedAt: string | null;

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -45,7 +45,12 @@ import {
 import {
   SOURCING_EXEMPT_TYPES,
   isSourcingExempt,
+  EvidenceLocatorSchema,
 } from "../../api-types.js";
+
+// QUA-942: re-export for tests + clients that want to construct locators
+// without depending on the route module's deeper imports.
+export { EvidenceLocatorSchema, type EvidenceLocator } from "../../api-types.js";
 import { getNonVerifiablePropertyIds } from "../../property-metadata.js";
 import { coerceDisplayName } from "../shared/display-name-coerce.js";
 import {
@@ -224,42 +229,6 @@ const LIVE_RECORDS_CTE = sql`
 `;
 
 // ---- Query schemas ----
-
-/**
- * QUA-942: validated locator shapes for page-addressable evidence.
- * NULL = whole-source evidence (existing behavior); a locator narrows
- * the verdict to a specific page, cell, or anchor inside the source.
- *
- * Discriminated union keeps the JSONB flexible for future locator kinds
- * (e.g. transcript timestamps) without breaking writers that don't yet
- * know about them — pdf-page is shipped first; new kinds add a branch.
- */
-const PdfPageLocator = z.object({
-  kind: z.literal("pdf-page"),
-  /** 1-based physical page number. */
-  page: z.number().int().min(1).max(100_000),
-  /** Optional table reference within the page (e.g. "2.3"). */
-  table: z.string().max(50).optional(),
-  /** Optional row reference within a table on the page. */
-  row: z.union([z.string().max(50), z.number().int()]).optional(),
-});
-const CsvCellLocator = z.object({
-  kind: z.literal("csv-cell"),
-  /** 1-based row index within the CSV body (header excluded). */
-  row: z.number().int().min(1).max(10_000_000),
-  column: z.string().min(1).max(200),
-});
-const HtmlAnchorLocator = z.object({
-  kind: z.literal("html-anchor"),
-  /** CSS-style selector pinning a fragment of the source HTML. */
-  selector: z.string().min(1).max(500),
-});
-export const EvidenceLocatorSchema = z.discriminatedUnion("kind", [
-  PdfPageLocator,
-  CsvCellLocator,
-  HtmlAnchorLocator,
-]);
-export type EvidenceLocator = z.infer<typeof EvidenceLocatorSchema>;
 
 const EvidenceBody = z.object({
   recordType: z.string().min(1).max(50),

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -225,6 +225,42 @@ const LIVE_RECORDS_CTE = sql`
 
 // ---- Query schemas ----
 
+/**
+ * QUA-942: validated locator shapes for page-addressable evidence.
+ * NULL = whole-source evidence (existing behavior); a locator narrows
+ * the verdict to a specific page, cell, or anchor inside the source.
+ *
+ * Discriminated union keeps the JSONB flexible for future locator kinds
+ * (e.g. transcript timestamps) without breaking writers that don't yet
+ * know about them — pdf-page is shipped first; new kinds add a branch.
+ */
+const PdfPageLocator = z.object({
+  kind: z.literal("pdf-page"),
+  /** 1-based physical page number. */
+  page: z.number().int().min(1).max(100_000),
+  /** Optional table reference within the page (e.g. "2.3"). */
+  table: z.string().max(50).optional(),
+  /** Optional row reference within a table on the page. */
+  row: z.union([z.string().max(50), z.number().int()]).optional(),
+});
+const CsvCellLocator = z.object({
+  kind: z.literal("csv-cell"),
+  /** 1-based row index within the CSV body (header excluded). */
+  row: z.number().int().min(1).max(10_000_000),
+  column: z.string().min(1).max(200),
+});
+const HtmlAnchorLocator = z.object({
+  kind: z.literal("html-anchor"),
+  /** CSS-style selector pinning a fragment of the source HTML. */
+  selector: z.string().min(1).max(500),
+});
+export const EvidenceLocatorSchema = z.discriminatedUnion("kind", [
+  PdfPageLocator,
+  CsvCellLocator,
+  HtmlAnchorLocator,
+]);
+export type EvidenceLocator = z.infer<typeof EvidenceLocatorSchema>;
+
 const EvidenceBody = z.object({
   recordType: z.string().min(1).max(50),
   recordId: z.string().min(1).max(MAX_ID_LENGTH),
@@ -243,6 +279,12 @@ const EvidenceBody = z.object({
    * by the QUA-426 relevance gate when present.
    */
   relevanceScore: z.number().min(0).max(1).nullable().optional(),
+  /**
+   * QUA-942: page/cell/anchor-level locator inside the source. NULL or
+   * absent = whole-source verdict (existing behavior). Validated against
+   * the discriminated EvidenceLocatorSchema.
+   */
+  evidenceLocator: EvidenceLocatorSchema.nullable().optional(),
   isPrimarySource: z.boolean().default(false),
   checkerModel: z.string().max(100).nullable().optional(),
   notes: z.string().max(5000).nullable().optional(),
@@ -448,6 +490,7 @@ function mapEvidenceRow(e: {
   verdict: string;
   confidence: number | null;
   relevanceScore: number | null;
+  evidenceLocator: { kind: string; [key: string]: unknown } | null;
   isPrimarySource: boolean;
   checkerModel: string | null;
   notes: string | null;
@@ -467,6 +510,7 @@ function mapEvidenceRow(e: {
     verdict: e.verdict,
     confidence: e.confidence,
     relevanceScore: e.relevanceScore,
+    evidenceLocator: e.evidenceLocator,
     isPrimarySource: e.isPrimarySource,
     checkerModel: e.checkerModel,
     isStale: isStaleModel(e.checkerModel),
@@ -1002,6 +1046,7 @@ const sourcingApp = new Hono()
         verdict: body.verdict,
         confidence: body.confidence ?? null,
         relevanceScore: body.relevanceScore ?? null,
+        evidenceLocator: body.evidenceLocator ?? null,
         isPrimarySource: body.isPrimarySource,
         notes: body.notes ?? null,
         checkedAt: now,
@@ -1041,6 +1086,7 @@ const sourcingApp = new Hono()
             verdict: body.verdict,
             confidence: body.confidence ?? null,
             relevanceScore: body.relevanceScore ?? null,
+            evidenceLocator: body.evidenceLocator ?? null,
             isPrimarySource: body.isPrimarySource,
             checkerModel: checkerModelVal,
             notes: body.notes ?? null,
@@ -1069,6 +1115,7 @@ const sourcingApp = new Hono()
               verdict: body.verdict,
               confidence: body.confidence ?? null,
               relevanceScore: body.relevanceScore ?? null,
+              evidenceLocator: body.evidenceLocator ?? null,
               isPrimarySource: body.isPrimarySource,
               notes: body.notes ?? null,
               checkedAt: now,

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { buildPrefixTsquery } from "../../search-utils.js";
 import { logger } from "../../logger.js";
 import {
+  and,
   eq,
   or,
   count,
@@ -16,6 +17,7 @@ import { getDrizzleDb, getDb } from "../../db.js";
 import {
   resources,
   resourceCitations,
+  resourceContentVersions,
   resourcePapers,
   resourceForumPosts,
   resourcePolicyDocs,
@@ -2116,6 +2118,151 @@ const resourcesApp = new Hono()
       citedBy: citations.map((row) => row.pageId).filter((p): p is string => p != null),
     });
   })
+
+  // ---- POST /:id/content-versions — QUA-942 archive snapshot for a resource ----
+  //
+  // Creates a `resource_content_versions` row tying a fetched/extracted snapshot
+  // to a resource. Dedups on (url, content_hash) so re-archiving the same byte-
+  // identical content is a no-op. Used by the PDF resource adapter
+  // (`crux/lib/resource-archive/pdf.ts`) to archive PDF snapshots without going
+  // through the citation-content path (which is wikiPage-citation-shaped).
+  //
+  // The :id path param accepts either resources.id (legacy hex16) or stableId.
+  .post(
+    "/:id/content-versions",
+    zv(
+      "json",
+      z.object({
+        url: z.string().url().max(2000),
+        // 16-char truncated SHA-256 prefix is the codebase-wide policy
+        // (resource-ingest.ts CONTENT_HASH_PREFIX_LENGTH, citations dual-write).
+        // Allow up to 64 hex (full SHA-256) for forward-compat callers, but
+        // recommended length is 16 — see docs/agent-rules/source-check-system.md § 9.
+        contentHash: z.string().min(8).max(64).regex(/^[0-9a-f]+$/i),
+        fetchedAt: z.string().datetime(),
+        content: z.string().max(2_000_000).nullable().optional(),
+        // Original byte size of the source content. Capped at 100 MiB to
+        // reject obviously-bogus values without coupling to MAX_PDF_BYTES.
+        contentLength: z.number().int().min(0).max(100 * 1024 * 1024).nullable().optional(),
+        httpStatus: z.number().int().min(0).max(999).nullable().optional(),
+        contentType: z.string().max(200).nullable().optional(),
+        fetchMethod: z.string().max(100).nullable().optional(),
+        metadata: z.record(z.unknown()).nullable().optional(),
+      }),
+    ),
+    async (c) => {
+      const id = c.req.param("id");
+      const data = c.req.valid("json");
+      const db = getDrizzleDb();
+
+      // Resolve :id → stableId. Path param can be either the hex16 id or the
+      // sid_-prefixed stableId; downstream RCV.resource_id references stableId.
+      const resourceRow = await db
+        .select({ id: resources.id, stableId: resources.stableId })
+        .from(resources)
+        .where(or(eq(resources.id, id), eq(resources.stableId, id)))
+        .limit(1);
+      if (resourceRow.length === 0) {
+        return notFoundError(c, `Resource not found: ${id}`);
+      }
+      const stableId = resourceRow[0].stableId;
+
+      try {
+        const inserted = await db
+          .insert(resourceContentVersions)
+          .values({
+            resourceId: stableId,
+            url: data.url,
+            contentHash: data.contentHash,
+            fetchedAt: new Date(data.fetchedAt),
+            content: data.content ?? null,
+            contentLength: data.contentLength ?? null,
+            httpStatus: data.httpStatus ?? null,
+            contentType: data.contentType ?? null,
+            fetchMethod: data.fetchMethod ?? null,
+            metadata: data.metadata ?? null,
+          })
+          .onConflictDoNothing({
+            target: [resourceContentVersions.url, resourceContentVersions.contentHash],
+          })
+          .returning({ id: resourceContentVersions.id });
+
+        if (inserted.length > 0) {
+          return c.json(
+            { id: inserted[0].id, resourceId: stableId, deduplicated: false },
+            201,
+          );
+        }
+
+        // Conflict path: a row already exists for this (url, contentHash).
+        // Return its id so callers can still link to it.
+        const existing = await db
+          .select({ id: resourceContentVersions.id })
+          .from(resourceContentVersions)
+          .where(
+            and(
+              eq(resourceContentVersions.url, data.url),
+              eq(resourceContentVersions.contentHash, data.contentHash),
+            ),
+          )
+          .limit(1);
+        return c.json({
+          id: existing[0]?.id ?? null,
+          resourceId: stableId,
+          deduplicated: true,
+        });
+      } catch (err) {
+        return dbError(c, "content version insert", err, { id, url: data.url });
+      }
+    },
+  )
+
+  // ---- GET /:id/content-versions — QUA-942 list snapshots for a resource ----
+  .get(
+    "/:id/content-versions",
+    zv(
+      "query",
+      z.object({
+        limit: clampedLimit(200, 50),
+        offset: z.coerce.number().int().min(0).max(10_000).default(0),
+      }),
+    ),
+    async (c) => {
+      const id = c.req.param("id");
+      const { limit, offset } = c.req.valid("query");
+      const db = getDrizzleDb();
+
+      const resourceRow = await db
+        .select({ stableId: resources.stableId })
+        .from(resources)
+        .where(or(eq(resources.id, id), eq(resources.stableId, id)))
+        .limit(1);
+      if (resourceRow.length === 0) {
+        return notFoundError(c, `Resource not found: ${id}`);
+      }
+      const stableId = resourceRow[0].stableId;
+
+      const rows = await db
+        .select({
+          id: resourceContentVersions.id,
+          url: resourceContentVersions.url,
+          contentHash: resourceContentVersions.contentHash,
+          fetchedAt: resourceContentVersions.fetchedAt,
+          contentLength: resourceContentVersions.contentLength,
+          httpStatus: resourceContentVersions.httpStatus,
+          contentType: resourceContentVersions.contentType,
+          fetchMethod: resourceContentVersions.fetchMethod,
+          metadata: resourceContentVersions.metadata,
+        })
+        .from(resourceContentVersions)
+        .where(eq(resourceContentVersions.resourceId, stableId))
+        .orderBy(desc(resourceContentVersions.fetchedAt))
+        .limit(limit)
+        .offset(offset);
+
+      return c.json({ resourceId: stableId, versions: rows, limit, offset });
+    },
+  )
 
   // ---- POST /dedup — QUA-561 one-shot duplicate merge job ----
   //

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -2134,11 +2134,13 @@ const resourcesApp = new Hono()
       "json",
       z.object({
         url: z.string().url().max(2000),
-        // 16-char truncated SHA-256 prefix is the codebase-wide policy
-        // (resource-ingest.ts CONTENT_HASH_PREFIX_LENGTH, citations dual-write).
-        // Allow up to 64 hex (full SHA-256) for forward-compat callers, but
-        // recommended length is 16 — see docs/agent-rules/source-check-system.md § 9.
-        contentHash: z.string().min(8).max(64).regex(/^[0-9a-f]+$/i),
+        // 16-char truncated SHA-256 prefix — codebase-wide policy. Enforced
+        // strictly here so the (url, content_hash) dedup index actually
+        // dedups across writers; mixed-length hashes for byte-identical
+        // content would silently produce duplicate rows. See
+        // resource-ingest.ts CONTENT_HASH_PREFIX_LENGTH and the citation
+        // dual-write in citations.ts for the canonical sites.
+        contentHash: z.string().length(16).regex(/^[0-9a-f]{16}$/i),
         fetchedAt: z.string().datetime(),
         content: z.string().max(2_000_000).nullable().optional(),
         // Original byte size of the source content. Capped at 100 MiB to

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -2140,7 +2140,11 @@ const resourcesApp = new Hono()
         // content would silently produce duplicate rows. See
         // resource-ingest.ts CONTENT_HASH_PREFIX_LENGTH and the citation
         // dual-write in citations.ts for the canonical sites.
-        contentHash: z.string().length(16).regex(/^[0-9a-f]{16}$/i),
+        contentHash: z
+          .string()
+          .length(16)
+          .regex(/^[0-9a-f]{16}$/i)
+          .transform((value) => value.toLowerCase()),
         fetchedAt: z.string().datetime(),
         content: z.string().max(2_000_000).nullable().optional(),
         // Original byte size of the source content. Capped at 100 MiB to
@@ -2258,7 +2262,7 @@ const resourcesApp = new Hono()
         })
         .from(resourceContentVersions)
         .where(eq(resourceContentVersions.resourceId, stableId))
-        .orderBy(desc(resourceContentVersions.fetchedAt))
+        .orderBy(desc(resourceContentVersions.fetchedAt), desc(resourceContentVersions.id))
         .limit(limit)
         .offset(offset);
 

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1800,6 +1800,16 @@ export const recordSources = pgTable(
      * relevance gate (QUA-426) when present, otherwise defaults to full weight.
      */
     relevanceScore: real("relevance_score"),
+    /**
+     * QUA-942: page-addressable evidence locator. JSONB so new locator kinds
+     * can be added without migrations. NULL = whole-source evidence.
+     * Validated shapes: pdf-page, csv-cell, html-anchor (see EvidenceLocatorSchema
+     * in api-types.ts). Indexed via partial GIN where the column is non-null.
+     */
+    evidenceLocator: jsonb("evidence_locator").$type<{
+      kind: string;
+      [key: string]: unknown;
+    }>(),
     isPrimarySource: boolean("is_primary_source").notNull().default(false),
     checkerModel: text("checker_model"),
     notes: text("notes"),

--- a/crux/commands/import-scorecards.ts
+++ b/crux/commands/import-scorecards.ts
@@ -402,7 +402,7 @@ async function cmdFetch(source: string, wave: string, force: boolean): Promise<C
 const ARCHIVE_PDF_DEFAULT_URLS: Record<string, Record<string, string>> = {
   fli_index: {
     "2024-12":
-      "https://futureoflife.org/wp-content/uploads/2024/12/AI-Safety-Index-2024-Full-Report-27-May-25.pdf",
+      "https://futureoflife.org/wp-content/uploads/2024/12/AI-Safety-Index-2024-Full-Report-11-Dec-24.pdf",
   },
 };
 

--- a/crux/commands/import-scorecards.ts
+++ b/crux/commands/import-scorecards.ts
@@ -23,7 +23,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { join, resolve } from "path";
+import { join, relative, resolve } from "path";
 import { ALL_SOURCES, getAdapter, listSourceKeys } from "../lib/scorecard-import/sources/index.ts";
 import { buildOrgResolver } from "../lib/scorecard-import/org-aliases.ts";
 import { scrapeSaferaiHtml } from "../lib/scorecard-import/sources/saferai-scraper.ts";
@@ -443,10 +443,14 @@ async function cmdArchivePdf(
   console.log(`  file: ${resolvedPath}`);
 
   try {
+    // Store the path relative to the repo root so the resources row points at
+    // a portable location (the file is committed under data/ — see ticket).
+    // path.relative handles symlinks and absolute paths outside cwd correctly.
+    const relativePath = relative(process.cwd(), resolvedPath);
     const result = await archivePdfResource({
       url,
       localFilePath: resolvedPath,
-      localFilename: resolvedPath.replace(`${process.cwd()}/`, ""),
+      localFilename: relativePath.startsWith("..") ? null : relativePath,
       contextNote: `Scorecard wave PDF: ${source}/${wave}`,
       tags: ["scorecard", source, `wave:${wave}`],
       contentLifecycle: "immutable",

--- a/crux/commands/import-scorecards.ts
+++ b/crux/commands/import-scorecards.ts
@@ -38,6 +38,7 @@ import {
   fetchAndCacheRawWave as fetchFliWave,
   extractWaveFromCache as extractFliWave,
 } from "../lib/scorecard-import/extract/fli.ts";
+import { archivePdfResource } from "../lib/resource-archive/pdf.ts";
 
 const SAFERAI_DEFAULT_URL = "https://ratings.safer-ai.org/comparison/";
 const SAFERAI_RAW_DIR = resolve("data/scorecards/raw/saferai");
@@ -394,6 +395,81 @@ async function cmdFetch(source: string, wave: string, force: boolean): Promise<C
   }
 }
 
+/**
+ * Default URLs for committed scorecard wave PDFs. Used when --url is omitted.
+ * Adding a new entry here makes `archive-pdf --source=X --wave=Y` self-contained.
+ */
+const ARCHIVE_PDF_DEFAULT_URLS: Record<string, Record<string, string>> = {
+  fli_index: {
+    "2024-12":
+      "https://futureoflife.org/wp-content/uploads/2024/12/AI-Safety-Index-2024-Full-Report-27-May-25.pdf",
+  },
+};
+
+function defaultArchivePdfUrl(source: string, wave: string): string | null {
+  return ARCHIVE_PDF_DEFAULT_URLS[source]?.[wave] ?? null;
+}
+
+async function cmdArchivePdf(
+  source: string,
+  wave: string,
+  filePath: string,
+  urlOverride: string,
+): Promise<CommandResult> {
+  // Resolve local file: explicit --file wins, else fall back to the canonical
+  // committed copy at data/scorecards/raw/<source>/<wave>/report.pdf.
+  const resolvedPath = filePath
+    ? resolve(filePath)
+    : resolve(`data/scorecards/raw/${source}/${wave}/report.pdf`);
+  if (!existsSync(resolvedPath)) {
+    return {
+      exitCode: 1,
+      output: `[archive-pdf] Local PDF not found: ${resolvedPath}\nPass --file=path/to/report.pdf or commit the wave PDF first.`,
+    };
+  }
+
+  const url = urlOverride || defaultArchivePdfUrl(source, wave);
+  if (!url) {
+    return {
+      exitCode: 1,
+      output:
+        `[archive-pdf] No canonical URL known for ${source}/${wave}.\n` +
+        "Pass --url=https://... so the resource has a stable upstream pointer.",
+    };
+  }
+
+  console.log(`[archive-pdf] ${source}/${wave}`);
+  console.log(`  url: ${url}`);
+  console.log(`  file: ${resolvedPath}`);
+
+  try {
+    const result = await archivePdfResource({
+      url,
+      localFilePath: resolvedPath,
+      localFilename: resolvedPath.replace(`${process.cwd()}/`, ""),
+      contextNote: `Scorecard wave PDF: ${source}/${wave}`,
+      tags: ["scorecard", source, `wave:${wave}`],
+      contentLifecycle: "immutable",
+    });
+    console.log("");
+    console.log(`✓ Archived PDF as resource`);
+    console.log(`  resourceStableId:  ${result.resourceStableId}`);
+    console.log(`  contentHash:       ${result.contentHash}`);
+    console.log(`  pageCount:         ${result.pageCount}`);
+    console.log(`  byteSize:          ${result.byteSize.toLocaleString()} bytes`);
+    console.log(`  textChars:         ${result.contentLength.toLocaleString()}`);
+    console.log(`  fromCache:         ${result.fromCache ? "yes (dedup)" : "no (new snapshot)"}`);
+    if (result.pdfMetadata?.title) {
+      console.log(`  pdfTitle:          ${result.pdfMetadata.title}`);
+    }
+    return { exitCode: 0 };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`✗ archive-pdf ${source}/${wave}: ${message}`);
+    return { exitCode: 1 };
+  }
+}
+
 async function cmdExtract(source: string, wave: string): Promise<CommandResult> {
   assertFetchExtractSourceSupported(source, "extract");
   console.log(`Extracting FLI wave ${wave} (LLM call — may take ~30s)...`);
@@ -449,6 +525,25 @@ async function extractCommand(
   return cmdExtract(source, wave);
 }
 
+async function archivePdfCommand(
+  _args: string[],
+  options: Record<string, unknown>,
+): Promise<CommandResult> {
+  const source = (options.source as string) ?? "";
+  const wave = (options.wave as string) ?? "";
+  if (!source || !wave) {
+    return {
+      exitCode: 1,
+      output:
+        "Usage: pnpm crux tb import-scorecards archive-pdf --source=<key> --wave=<slug> [--file=path/to/report.pdf] [--url=https://...]\n" +
+        "Registers a wave's source PDF as a Resource and writes a content-version snapshot (QUA-942).",
+    };
+  }
+  const filePath = (options.file as string) ?? "";
+  const urlOverride = (options.url as string) ?? "";
+  return cmdArchivePdf(source, wave, filePath, urlOverride);
+}
+
 export const commands = {
   analyze: analyzeCommand,
   sync: syncCommand,
@@ -456,6 +551,7 @@ export const commands = {
   scrape: scrapeCommand,
   fetch: fetchCommand,
   extract: extractCommand,
+  "archive-pdf": archivePdfCommand,
   default: analyzeCommand,
 };
 
@@ -473,6 +569,8 @@ Commands:
                        other sources still use manual extraction)
   fetch                Download a wave's source page/PDF into the cache
   extract              Run the LLM extractor on a cached wave -> grades.json
+  archive-pdf          Register a wave's source PDF as a Resource and write
+                       a content-version snapshot (QUA-942 first consumer)
 
 Options:
   --source=<key>       Filter to a single source (fli_index, saferai,

--- a/crux/lib/__tests__/pdf-extractor.test.ts
+++ b/crux/lib/__tests__/pdf-extractor.test.ts
@@ -9,7 +9,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockGetText = vi.fn();
 const mockGetInfo = vi.fn();
-const mockGetDateNode = vi.fn();
 
 class FakePDFParse {
   // The constructor matters only as long as it doesn't throw — we don't
@@ -32,8 +31,6 @@ import { extractPdfMetadata, extractPdfText } from "../pdf-extractor.ts";
 beforeEach(() => {
   mockGetText.mockReset();
   mockGetInfo.mockReset();
-  mockGetDateNode.mockReset();
-  mockGetDateNode.mockReturnValue({});
 });
 
 const SAMPLE_BUFFER = new TextEncoder().encode("%PDF-1.4 fake content").buffer;
@@ -135,6 +132,29 @@ describe("extractPdfMetadata (QUA-942)", () => {
 
     const out = await extractPdfMetadata(SAMPLE_BUFFER, 5000);
     expect(out!.text).toHaveLength(5000);
+  });
+
+  it("tolerates getDateNode() throwing (returns metadata with null dates)", async () => {
+    // pdf-parse's date parser throws on malformed XMP date strings. The
+    // earlier code path called info.getDateNode() outside any try/catch, so a
+    // single bad date killed the whole extract — even though text + pageCount
+    // had already been recovered. Defensive try/catch lets us degrade gracefully.
+    mockGetText.mockResolvedValue({ text: "body" });
+    mockGetInfo.mockResolvedValue({
+      total: 5,
+      info: { Title: "ok" },
+      getDateNode: () => {
+        throw new Error("malformed XMP date");
+      },
+    });
+
+    const out = await extractPdfMetadata(SAMPLE_BUFFER);
+    expect(out).not.toBeNull();
+    expect(out!.text).toBe("body");
+    expect(out!.pageCount).toBe(5);
+    expect(out!.title).toBe("ok");
+    expect(out!.creationDate).toBeNull();
+    expect(out!.modDate).toBeNull();
   });
 
   it("prefers CreationDate, falls back to XmpCreateDate", async () => {

--- a/crux/lib/__tests__/pdf-extractor.test.ts
+++ b/crux/lib/__tests__/pdf-extractor.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the pdf-extractor utility (text + metadata).
+ *
+ * Goal: contract-test the shape returned to callers (especially the QUA-942
+ * resource adapter), without dragging in real PDF binaries. We mock pdf-parse.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetText = vi.fn();
+const mockGetInfo = vi.fn();
+const mockGetDateNode = vi.fn();
+
+class FakePDFParse {
+  // The constructor matters only as long as it doesn't throw — we don't
+  // exercise its real behavior here.
+  constructor(_opts: unknown) {}
+  getText() {
+    return mockGetText();
+  }
+  getInfo() {
+    return mockGetInfo();
+  }
+}
+
+vi.mock("pdf-parse", () => ({
+  PDFParse: FakePDFParse,
+}));
+
+import { extractPdfMetadata, extractPdfText } from "../pdf-extractor.ts";
+
+beforeEach(() => {
+  mockGetText.mockReset();
+  mockGetInfo.mockReset();
+  mockGetDateNode.mockReset();
+  mockGetDateNode.mockReturnValue({});
+});
+
+const SAMPLE_BUFFER = new TextEncoder().encode("%PDF-1.4 fake content").buffer;
+
+describe("extractPdfText", () => {
+  it("returns extracted text up to maxChars", async () => {
+    mockGetText.mockResolvedValue({ text: "Hello world".repeat(10) });
+    const out = await extractPdfText(SAMPLE_BUFFER, 30);
+    expect(out).toHaveLength(30);
+  });
+
+  it("returns null on extractor failure", async () => {
+    mockGetText.mockRejectedValue(new Error("oops"));
+    const out = await extractPdfText(SAMPLE_BUFFER);
+    expect(out).toBeNull();
+  });
+
+  it("returns null on empty extracted text", async () => {
+    mockGetText.mockResolvedValue({ text: "" });
+    const out = await extractPdfText(SAMPLE_BUFFER);
+    expect(out).toBeNull();
+  });
+});
+
+describe("extractPdfMetadata (QUA-942)", () => {
+  it("returns text + page count + Info-dictionary fields", async () => {
+    mockGetText.mockResolvedValue({ text: "page 1\n\npage 2" });
+    mockGetInfo.mockResolvedValue({
+      total: 60,
+      info: {
+        Title: "Sample Report",
+        Author: "Test Author",
+        Subject: "Subject Line",
+        Creator: "LaTeX",
+        Producer: "pdfTeX",
+      },
+      getDateNode: () => ({
+        CreationDate: new Date("2024-12-11T00:00:00Z"),
+        ModDate: null,
+      }),
+    });
+
+    const out = await extractPdfMetadata(SAMPLE_BUFFER);
+    expect(out).not.toBeNull();
+    expect(out!.pageCount).toBe(60);
+    expect(out!.title).toBe("Sample Report");
+    expect(out!.author).toBe("Test Author");
+    expect(out!.creator).toBe("LaTeX");
+    expect(out!.producer).toBe("pdfTeX");
+    expect(out!.creationDate).toBe("2024-12-11T00:00:00.000Z");
+    expect(out!.text).toBe("page 1\n\npage 2");
+  });
+
+  it("falls back to text-only when getInfo fails", async () => {
+    mockGetText.mockResolvedValue({ text: "body text" });
+    mockGetInfo.mockRejectedValue(new Error("info parse failed"));
+
+    const out = await extractPdfMetadata(SAMPLE_BUFFER);
+    expect(out).not.toBeNull();
+    expect(out!.text).toBe("body text");
+    expect(out!.pageCount).toBe(0);
+    expect(out!.title).toBeNull();
+    expect(out!.author).toBeNull();
+    expect(out!.creationDate).toBeNull();
+  });
+
+  it("returns null when getText fails (no point archiving an empty record)", async () => {
+    mockGetText.mockRejectedValue(new Error("text parse failed"));
+    mockGetInfo.mockResolvedValue({
+      total: 1,
+      info: {},
+      getDateNode: () => ({}),
+    });
+
+    const out = await extractPdfMetadata(SAMPLE_BUFFER);
+    expect(out).toBeNull();
+  });
+
+  it("ignores Info fields that are not strings", async () => {
+    mockGetText.mockResolvedValue({ text: "x" });
+    mockGetInfo.mockResolvedValue({
+      total: 1,
+      info: { Title: 12345 as unknown as string, Author: "" },
+      getDateNode: () => ({}),
+    });
+
+    const out = await extractPdfMetadata(SAMPLE_BUFFER);
+    expect(out!.title).toBeNull();
+    expect(out!.author).toBeNull();
+  });
+
+  it("respects maxChars when truncating extracted text", async () => {
+    mockGetText.mockResolvedValue({ text: "x".repeat(2_000_000) });
+    mockGetInfo.mockResolvedValue({
+      total: 100,
+      info: {},
+      getDateNode: () => ({}),
+    });
+
+    const out = await extractPdfMetadata(SAMPLE_BUFFER, 5000);
+    expect(out!.text).toHaveLength(5000);
+  });
+
+  it("prefers CreationDate, falls back to XmpCreateDate", async () => {
+    mockGetText.mockResolvedValue({ text: "x" });
+    mockGetInfo.mockResolvedValue({
+      total: 1,
+      info: {},
+      getDateNode: () => ({
+        CreationDate: null,
+        XmpCreateDate: new Date("2023-06-15T10:00:00Z"),
+      }),
+    });
+
+    const out = await extractPdfMetadata(SAMPLE_BUFFER);
+    expect(out!.creationDate).toBe("2023-06-15T10:00:00.000Z");
+  });
+});

--- a/crux/lib/pdf-extractor.ts
+++ b/crux/lib/pdf-extractor.ts
@@ -28,14 +28,27 @@ export interface PdfMetadata {
 }
 
 /**
+ * Lazy-load pdf-parse and return a parser bound to the supplied buffer.
+ * Returns null on import or constructor failure (logged once per call).
+ */
+async function loadParser(buffer: ArrayBuffer): Promise<unknown | null> {
+  try {
+    const { PDFParse } = await import('pdf-parse');
+    return new PDFParse({ data: Buffer.from(buffer) });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[pdf-extractor] pdf-parse load failed: ${msg.slice(0, 200)}`);
+    return null;
+  }
+}
+
+/**
  * Extract text from a PDF ArrayBuffer using the pdf-parse library.
  * Returns null on failure (logs a warning).
  *
- * Implemented as a thin wrapper over `extractPdfMetadata` so we don't
- * maintain two parallel pdf-parse load paths. The extra `getInfo()` call
- * is wrapped in its own try/catch and tolerates failure, so the cost on
- * the text-only path is at most one PDF info parse — negligible relative
- * to the text extraction itself.
+ * Text-only path: skips `getInfo()` so the source-fetcher hot path stays at
+ * a single parse pass. Use `extractPdfMetadata` when document metadata
+ * (page count, Info dictionary, dates) is also needed.
  *
  * @param buffer - The raw PDF data as an ArrayBuffer
  * @param maxChars - Maximum characters to return (default: 100_000)
@@ -44,8 +57,16 @@ export async function extractPdfText(
   buffer: ArrayBuffer,
   maxChars = 100_000,
 ): Promise<string | null> {
-  const meta = await extractPdfMetadata(buffer, maxChars);
-  return meta?.text || null;
+  const parser = await loadParser(buffer);
+  if (!parser) return null;
+  try {
+    const result = await (parser as { getText: () => Promise<{ text: string }> }).getText();
+    return result.text.slice(0, maxChars) || null;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[pdf-extractor] pdf-parse failed: ${msg.slice(0, 200)}`);
+    return null;
+  }
 }
 
 function readInfoString(info: unknown, key: string): string | null {
@@ -75,15 +96,8 @@ export async function extractPdfMetadata(
   buffer: ArrayBuffer,
   maxChars = 1_000_000,
 ): Promise<PdfMetadata | null> {
-  let parser: unknown = null;
-  try {
-    const { PDFParse } = await import('pdf-parse');
-    parser = new PDFParse({ data: Buffer.from(buffer) });
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.warn(`[pdf-extractor] pdf-parse load failed: ${msg.slice(0, 200)}`);
-    return null;
-  }
+  const parser = await loadParser(buffer);
+  if (!parser) return null;
 
   // Cast once to a minimal shape we depend on; the full type is in pdf-parse.
   const p = parser as {
@@ -115,7 +129,16 @@ export async function extractPdfMetadata(
     console.warn(`[pdf-extractor] getInfo failed (continuing with text-only): ${msg.slice(0, 200)}`);
   }
 
-  const dates = info?.getDateNode();
+  // pdf-parse can throw inside `getDateNode()` itself when XMP date parsing
+  // hits a malformed date string. Wrap defensively so a partial PDF doesn't
+  // sink the whole extract — we still want text + pageCount + Info-dict text.
+  let dates: Record<string, Date | null | undefined> | null = null;
+  try {
+    dates = info?.getDateNode() ?? null;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[pdf-extractor] getDateNode failed (dropping dates): ${msg.slice(0, 200)}`);
+  }
 
   return {
     text,

--- a/crux/lib/pdf-extractor.ts
+++ b/crux/lib/pdf-extractor.ts
@@ -1,13 +1,41 @@
 /**
  * PDF text extraction utility.
  *
- * Shared between source-fetcher and page-creator source-fetching
- * to avoid duplicating pdf-parse import and error-handling logic.
+ * Shared between source-fetcher, page-creator source-fetching, and the
+ * resource-archive PDF adapter (QUA-942) to avoid duplicating pdf-parse
+ * import and error-handling logic.
  */
+
+export interface PdfMetadata {
+  /** Full extracted text, truncated to `maxChars`. */
+  text: string;
+  /** Total physical page count. */
+  pageCount: number;
+  /** PDF document title from the Info dictionary, when present. */
+  title: string | null;
+  /** Document author(s), when present. */
+  author: string | null;
+  /** Free-form subject/description, when present. */
+  subject: string | null;
+  /** Creator software (e.g. "Adobe InDesign"). Diagnostic only. */
+  creator: string | null;
+  /** Producer software. Diagnostic only. */
+  producer: string | null;
+  /** Creation date as ISO-8601 string, when parseable. */
+  creationDate: string | null;
+  /** Modification date as ISO-8601 string, when parseable. */
+  modDate: string | null;
+}
 
 /**
  * Extract text from a PDF ArrayBuffer using the pdf-parse library.
  * Returns null on failure (logs a warning).
+ *
+ * Implemented as a thin wrapper over `extractPdfMetadata` so we don't
+ * maintain two parallel pdf-parse load paths. The extra `getInfo()` call
+ * is wrapped in its own try/catch and tolerates failure, so the cost on
+ * the text-only path is at most one PDF info parse — negligible relative
+ * to the text extraction itself.
  *
  * @param buffer - The raw PDF data as an ArrayBuffer
  * @param maxChars - Maximum characters to return (default: 100_000)
@@ -16,14 +44,88 @@ export async function extractPdfText(
   buffer: ArrayBuffer,
   maxChars = 100_000,
 ): Promise<string | null> {
+  const meta = await extractPdfMetadata(buffer, maxChars);
+  return meta?.text || null;
+}
+
+function readInfoString(info: unknown, key: string): string | null {
+  if (!info || typeof info !== 'object') return null;
+  const value = (info as Record<string, unknown>)[key];
+  if (typeof value !== 'string' || value.length === 0) return null;
+  return value.slice(0, 1000);
+}
+
+function dateToIso(value: unknown): string | null {
+  if (value instanceof Date && !isNaN(value.valueOf())) return value.toISOString();
+  return null;
+}
+
+/**
+ * Extract text plus document-level metadata from a PDF buffer.
+ *
+ * Returns null when text extraction fails entirely. When metadata extraction
+ * fails but text extraction succeeds, returns text-only with default metadata
+ * (pageCount=0, all string fields null) so callers can still archive the PDF
+ * without losing the text payload.
+ *
+ * @param buffer - The raw PDF data
+ * @param maxChars - Maximum characters of text to return (default: 1_000_000)
+ */
+export async function extractPdfMetadata(
+  buffer: ArrayBuffer,
+  maxChars = 1_000_000,
+): Promise<PdfMetadata | null> {
+  let parser: unknown = null;
   try {
     const { PDFParse } = await import('pdf-parse');
-    const parser = new PDFParse({ data: Buffer.from(buffer) });
-    const result = await parser.getText();
-    return result.text.slice(0, maxChars) || null;
+    parser = new PDFParse({ data: Buffer.from(buffer) });
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    console.warn(`[pdf-extractor] pdf-parse failed: ${msg.slice(0, 200)}`);
+    console.warn(`[pdf-extractor] pdf-parse load failed: ${msg.slice(0, 200)}`);
     return null;
   }
+
+  // Cast once to a minimal shape we depend on; the full type is in pdf-parse.
+  const p = parser as {
+    getText: () => Promise<{ text: string }>;
+    getInfo: () => Promise<{
+      total: number;
+      info?: Record<string, unknown>;
+      getDateNode: () => Record<string, Date | null | undefined>;
+    }>;
+  };
+
+  let text = '';
+  try {
+    const textResult = await p.getText();
+    text = (textResult.text ?? '').slice(0, maxChars);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[pdf-extractor] getText failed: ${msg.slice(0, 200)}`);
+    return null;
+  }
+
+  let info:
+    | { total: number; info?: Record<string, unknown>; getDateNode: () => Record<string, Date | null | undefined> }
+    | null = null;
+  try {
+    info = await p.getInfo();
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[pdf-extractor] getInfo failed (continuing with text-only): ${msg.slice(0, 200)}`);
+  }
+
+  const dates = info?.getDateNode();
+
+  return {
+    text,
+    pageCount: info?.total ?? 0,
+    title: readInfoString(info?.info, 'Title'),
+    author: readInfoString(info?.info, 'Author'),
+    subject: readInfoString(info?.info, 'Subject'),
+    creator: readInfoString(info?.info, 'Creator'),
+    producer: readInfoString(info?.info, 'Producer'),
+    creationDate: dateToIso(dates?.CreationDate ?? dates?.XmpCreateDate ?? null),
+    modDate: dateToIso(dates?.ModDate ?? dates?.XmpModifyDate ?? null),
+  };
 }

--- a/crux/lib/resource-archive/pdf.test.ts
+++ b/crux/lib/resource-archive/pdf.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for the PDF resource adapter (QUA-942).
+ *
+ * Covers the unit shape of `archivePdfResource()` — the wiki-server endpoint
+ * itself has its own integration test in apps/wiki-server. Here we mock the
+ * client and verify:
+ *
+ *  - Reads from a local buffer when given (no network)
+ *  - Computes a SHA-256 hash over the binary
+ *  - Calls upsertResource with sane defaults (purpose, subtype, lifecycle)
+ *  - Posts a content version with PDF metadata in the JSONB blob
+ *  - Reuses an existing resource (no churn on legacyId) when one already exists
+ *  - Surfaces dedup correctly via fromCache
+ *  - Rejects non-HTTPS URLs and oversized payloads
+ *  - Tolerates missing PDF metadata (extractor failure) without losing the
+ *    binary archive
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHash } from "crypto";
+
+// ---------------------------------------------------------------------------
+// Mocks — replace the wiki-server client and pdf-extractor before importing
+// ---------------------------------------------------------------------------
+
+const mockUpsertResource = vi.fn();
+const mockCreateContentVersion = vi.fn();
+const mockLookupByUrl = vi.fn();
+
+vi.mock("../wiki-server/resources.ts", () => ({
+  upsertResource: (...args: unknown[]) => mockUpsertResource(...args),
+  createResourceContentVersion: (...args: unknown[]) => mockCreateContentVersion(...args),
+  lookupResourceByUrl: (...args: unknown[]) => mockLookupByUrl(...args),
+}));
+
+const mockExtractPdfMetadata = vi.fn();
+
+vi.mock("../pdf-extractor.ts", () => ({
+  extractPdfMetadata: (...args: unknown[]) => mockExtractPdfMetadata(...args),
+  // Keep a no-op text extractor so source-fetcher imports don't break.
+  extractPdfText: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../url-utils.ts", () => ({
+  isPrivateHost: (host: string) =>
+    host === "localhost" || host === "127.0.0.1" || host.startsWith("10."),
+}));
+
+import { archivePdfResource } from "./pdf.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function bytes(content: string): Uint8Array {
+  return new TextEncoder().encode(content);
+}
+
+function truncSha256(content: string): string {
+  // 16-char SHA-256 prefix matches CONTENT_HASH_PREFIX_LENGTH in the adapter
+  // and the codebase-wide policy enforced by resource-ingest.ts.
+  return createHash("sha256").update(bytes(content)).digest("hex").slice(0, 16);
+}
+
+const SAMPLE_URL =
+  "https://futureoflife.org/wp-content/uploads/2024/12/AI-Safety-Index-2024-Full-Report-27-May-25.pdf";
+const SAMPLE_BYTES = bytes("%PDF-1.4 fake PDF content for tests");
+const SAMPLE_HASH = truncSha256("%PDF-1.4 fake PDF content for tests");
+
+beforeEach(() => {
+  mockUpsertResource.mockReset();
+  mockCreateContentVersion.mockReset();
+  mockLookupByUrl.mockReset();
+  mockExtractPdfMetadata.mockReset();
+
+  // Sensible defaults — upsert returns the canonical stableId (the adapter
+  // reads it from the response, no second lookup).
+  mockUpsertResource.mockResolvedValue({
+    ok: true,
+    data: { id: "abc1234567890def", url: SAMPLE_URL, stableId: "sid_TestStable1" },
+  });
+  mockCreateContentVersion.mockResolvedValue({
+    ok: true,
+    data: { id: 42, deduplicated: false, resourceId: "sid_TestStable1" },
+  });
+  // Adapter no longer pre-looks-up — keep mock harmless if any future test pings it.
+  mockLookupByUrl.mockResolvedValue({ ok: false });
+  mockExtractPdfMetadata.mockResolvedValue({
+    text: "Page 1 text\n\nPage 2 text",
+    pageCount: 60,
+    title: "AI Safety Index 2024 Full Report",
+    author: "Future of Life Institute",
+    subject: null,
+    creator: "LaTeX",
+    producer: "pdfTeX",
+    creationDate: "2024-12-11T00:00:00.000Z",
+    modDate: null,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("archivePdfResource", () => {
+  it("uses the supplied buffer (no network) and hashes the binary", async () => {
+    const result = await archivePdfResource({
+      url: SAMPLE_URL,
+      buffer: SAMPLE_BYTES,
+    });
+
+    expect(result.contentHash).toBe(SAMPLE_HASH);
+    expect(result.byteSize).toBe(SAMPLE_BYTES.byteLength);
+    expect(result.pageCount).toBe(60);
+    expect(result.resourceStableId).toBe("sid_TestStable1");
+    expect(result.fromCache).toBe(false);
+  });
+
+  it("calls upsertResource with PDF defaults (purpose, subtype, lifecycle)", async () => {
+    await archivePdfResource({ url: SAMPLE_URL, buffer: SAMPLE_BYTES });
+
+    expect(mockUpsertResource).toHaveBeenCalledTimes(1);
+    const call = mockUpsertResource.mock.calls[0][0];
+    expect(call.url).toBe(SAMPLE_URL);
+    expect(call.type).toBe("paper");
+    expect(call.resourcePurpose).toBe("primary_source");
+    expect(call.resourceSubtype).toBe("pdf_report");
+    expect(call.contentLifecycle).toBe("immutable");
+    expect(call.contentHash).toBe(SAMPLE_HASH);
+    expect(call.title).toBe("AI Safety Index 2024 Full Report");
+    expect(call.publishedDate).toBe("2024-12-11");
+    expect(call.typeMetadata?.pdf?.pageCount).toBe(60);
+    expect(call.typeMetadata?.pdf?.byteSize).toBe(SAMPLE_BYTES.byteLength);
+  });
+
+  it("snapshots the binary into resource_content_versions", async () => {
+    await archivePdfResource({
+      url: SAMPLE_URL,
+      buffer: SAMPLE_BYTES,
+      contextNote: "FLI Dec 2024",
+    });
+
+    expect(mockCreateContentVersion).toHaveBeenCalledTimes(1);
+    const [stableId, payload] = mockCreateContentVersion.mock.calls[0];
+    expect(stableId).toBe("sid_TestStable1");
+    expect(payload.url).toBe(SAMPLE_URL);
+    expect(payload.contentHash).toBe(SAMPLE_HASH);
+    expect(payload.contentType).toBe("application/pdf");
+    expect(payload.fetchMethod).toBe("pdf-archive");
+    expect(payload.content).toContain("Page 1 text");
+    expect(payload.metadata?.pageCount).toBe(60);
+    expect(payload.metadata?.extractor).toBe("pdf-parse");
+    expect(payload.metadata?.parserVersion).toMatch(/^pdf-parse@/);
+  });
+
+  it("produces 16-char SHA-256 prefix matching CONTENT_HASH_PREFIX_LENGTH policy", async () => {
+    // Codebase-wide policy: resource_content_versions.content_hash uses the
+    // first 16 hex chars of SHA-256. Aligning across writers is what makes
+    // the (url, content_hash) dedup index actually deduplicate. See
+    // resource-ingest.ts and citations.ts dual-write for the canonical sites.
+    const result = await archivePdfResource({
+      url: SAMPLE_URL,
+      buffer: SAMPLE_BYTES,
+    });
+    expect(result.contentHash).toHaveLength(16);
+    expect(result.contentHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(result.contentHash).toBe(truncSha256("%PDF-1.4 fake PDF content for tests"));
+  });
+
+  it("surfaces dedup when the snapshot endpoint reports no-op", async () => {
+    mockCreateContentVersion.mockResolvedValueOnce({
+      ok: true,
+      data: { id: 1, deduplicated: true, resourceId: "sid_TestStable1" },
+    });
+
+    const result = await archivePdfResource({
+      url: SAMPLE_URL,
+      buffer: SAMPLE_BYTES,
+    });
+    expect(result.fromCache).toBe(true);
+  });
+
+  it("reuses an existing resource via the upsert ON CONFLICT path (no extra lookups)", async () => {
+    // Existing row's stableId is preserved by the server's COALESCE rule.
+    // The adapter no longer pre-/post-looks up — the upsert response carries it.
+    mockUpsertResource.mockResolvedValueOnce({
+      ok: true,
+      data: { id: "abc1234567890def", url: SAMPLE_URL, stableId: "sid_existing" },
+    });
+
+    const result = await archivePdfResource({
+      url: SAMPLE_URL,
+      buffer: SAMPLE_BYTES,
+    });
+
+    expect(result.resourceStableId).toBe("sid_existing");
+    // Upsert is called with id derived from hashId(url) — stable across retries
+    expect(mockUpsertResource.mock.calls[0][0].id).toMatch(/^[0-9a-f]{16}$/);
+    // No GET /lookup round trips — the upsert RETURNING gives us stableId
+    expect(mockLookupByUrl).not.toHaveBeenCalled();
+  });
+
+  it("throws if upsert response is missing stableId (server invariant violation)", async () => {
+    mockUpsertResource.mockResolvedValueOnce({
+      ok: true,
+      data: { id: "abc1234567890def", url: SAMPLE_URL, stableId: null },
+    });
+
+    await expect(
+      archivePdfResource({ url: SAMPLE_URL, buffer: SAMPLE_BYTES }),
+    ).rejects.toThrow(/upsert returned no stableId/);
+  });
+
+  it("rejects non-HTTPS URLs", async () => {
+    await expect(
+      archivePdfResource({ url: "http://insecure.example.com/x.pdf" }),
+    ).rejects.toThrow(/HTTPS/);
+  });
+
+  it("rejects malformed URLs", async () => {
+    await expect(
+      archivePdfResource({ url: "not a url at all" }),
+    ).rejects.toThrow(/Malformed URL/);
+  });
+
+  it("rejects private hosts (SSRF guard)", async () => {
+    await expect(
+      archivePdfResource({ url: "https://localhost/secret.pdf" }),
+    ).rejects.toThrow(/Private host blocked/);
+  });
+
+  it("falls back to text-only when extractPdfMetadata returns null", async () => {
+    mockExtractPdfMetadata.mockResolvedValueOnce(null);
+
+    const result = await archivePdfResource({
+      url: SAMPLE_URL,
+      buffer: SAMPLE_BYTES,
+    });
+
+    expect(result.contentHash).toBe(SAMPLE_HASH);
+    expect(result.pageCount).toBe(0);
+    expect(result.contentLength).toBe(0);
+    expect(result.pdfMetadata).toBeNull();
+    // We still archived the binary even though text extraction failed
+    expect(mockCreateContentVersion).toHaveBeenCalledTimes(1);
+    const payload = mockCreateContentVersion.mock.calls[0][1];
+    expect(payload.contentHash).toBe(SAMPLE_HASH);
+    expect(payload.metadata?.pdfInfo).toBeNull();
+  });
+
+  it("propagates upsert failures (does not silently archive against missing resource)", async () => {
+    mockUpsertResource.mockResolvedValueOnce({
+      ok: false,
+      error: "validation",
+      message: "title too long",
+    });
+
+    await expect(
+      archivePdfResource({ url: SAMPLE_URL, buffer: SAMPLE_BYTES }),
+    ).rejects.toThrow(/failed to upsert resource/);
+  });
+
+  it("propagates content-version write failures", async () => {
+    mockCreateContentVersion.mockResolvedValueOnce({
+      ok: false,
+      error: "server",
+      message: "boom",
+    });
+
+    await expect(
+      archivePdfResource({ url: SAMPLE_URL, buffer: SAMPLE_BYTES }),
+    ).rejects.toThrow(/failed to write content version/);
+  });
+
+  it("uses URL basename as fallback title when both override and PDF Info are absent", async () => {
+    mockExtractPdfMetadata.mockResolvedValueOnce({
+      text: "",
+      pageCount: 1,
+      title: null,
+      author: null,
+      subject: null,
+      creator: null,
+      producer: null,
+      creationDate: null,
+      modDate: null,
+    });
+
+    await archivePdfResource({
+      url: "https://example.com/path/to/My-Report%202024.pdf",
+      buffer: SAMPLE_BYTES,
+    });
+
+    const call = mockUpsertResource.mock.calls[0][0];
+    expect(call.title).toBe("My-Report 2024.pdf");
+  });
+
+  it("rejects oversized buffers without calling the network", async () => {
+    const huge = new Uint8Array(60 * 1024 * 1024); // 60 MiB > 50 MiB cap
+    await expect(
+      archivePdfResource({ url: SAMPLE_URL, buffer: huge }),
+    ).rejects.toThrow(/PDF too large/);
+    expect(mockUpsertResource).not.toHaveBeenCalled();
+  });
+});

--- a/crux/lib/resource-archive/pdf.test.ts
+++ b/crux/lib/resource-archive/pdf.test.ts
@@ -25,12 +25,10 @@ import { createHash } from "crypto";
 
 const mockUpsertResource = vi.fn();
 const mockCreateContentVersion = vi.fn();
-const mockLookupByUrl = vi.fn();
 
 vi.mock("../wiki-server/resources.ts", () => ({
   upsertResource: (...args: unknown[]) => mockUpsertResource(...args),
   createResourceContentVersion: (...args: unknown[]) => mockCreateContentVersion(...args),
-  lookupResourceByUrl: (...args: unknown[]) => mockLookupByUrl(...args),
 }));
 
 const mockExtractPdfMetadata = vi.fn();
@@ -70,7 +68,6 @@ const SAMPLE_HASH = truncSha256("%PDF-1.4 fake PDF content for tests");
 beforeEach(() => {
   mockUpsertResource.mockReset();
   mockCreateContentVersion.mockReset();
-  mockLookupByUrl.mockReset();
   mockExtractPdfMetadata.mockReset();
 
   // Sensible defaults — upsert returns the canonical stableId (the adapter
@@ -83,8 +80,6 @@ beforeEach(() => {
     ok: true,
     data: { id: 42, deduplicated: false, resourceId: "sid_TestStable1" },
   });
-  // Adapter no longer pre-looks-up — keep mock harmless if any future test pings it.
-  mockLookupByUrl.mockResolvedValue({ ok: false });
   mockExtractPdfMetadata.mockResolvedValue({
     text: "Page 1 text\n\nPage 2 text",
     pageCount: 60,
@@ -196,8 +191,6 @@ describe("archivePdfResource", () => {
     expect(result.resourceStableId).toBe("sid_existing");
     // Upsert is called with id derived from hashId(url) — stable across retries
     expect(mockUpsertResource.mock.calls[0][0].id).toMatch(/^[0-9a-f]{16}$/);
-    // No GET /lookup round trips — the upsert RETURNING gives us stableId
-    expect(mockLookupByUrl).not.toHaveBeenCalled();
   });
 
   it("throws if upsert response is missing stableId (server invariant violation)", async () => {

--- a/crux/lib/resource-archive/pdf.test.ts
+++ b/crux/lib/resource-archive/pdf.test.ts
@@ -123,7 +123,7 @@ describe("archivePdfResource", () => {
     expect(call.contentLifecycle).toBe("immutable");
     expect(call.contentHash).toBe(SAMPLE_HASH);
     expect(call.title).toBe("AI Safety Index 2024 Full Report");
-    expect(call.publishedDate).toBe("2024-12-11");
+    expect(call.publishedDate).toBeNull();
     expect(call.typeMetadata?.pdf?.pageCount).toBe(60);
     expect(call.typeMetadata?.pdf?.byteSize).toBe(SAMPLE_BYTES.byteLength);
   });

--- a/crux/lib/resource-archive/pdf.ts
+++ b/crux/lib/resource-archive/pdf.ts
@@ -1,0 +1,337 @@
+/**
+ * PDF Resource Adapter (QUA-942).
+ *
+ * Single-call helper to "ingest a PDF as a Resource, archive its content, and
+ * make page-addressable evidence" — the missing first-class pattern called
+ * out in QUA-942. Mirrors `crux/lib/grant-import/snapshot-capture.ts` but for
+ * unstructured PDFs that don't fit the `resource_tabular_sources` enum.
+ *
+ * What it does, given an HTTPS PDF URL or a pre-fetched buffer:
+ *   1. Loads the binary (HTTPS fetch with SSRF guard, or accepts a local buffer).
+ *   2. Computes a content-integrity hash over the **binary** (not the extracted
+ *      text). This is the hash that survives pdf-parse version upgrades.
+ *   3. Extracts text + document metadata via `extractPdfMetadata` (pdf-parse).
+ *   4. Upserts a `resources` row (`type='paper'`, `resourcePurpose='primary_source'`,
+ *      `resourceSubtype='pdf_report'` by default — callers can override).
+ *   5. Posts a snapshot to `resource_content_versions` with the binary hash,
+ *      extracted text, and PDF metadata in the JSONB `metadata` field.
+ *   6. Returns the resource stableId so callers can attach `source_check_evidence`
+ *      rows with `evidenceLocator: { kind: 'pdf-page', page: N }`.
+ *
+ * The binary itself is **not** stored in PG — `resource_content_versions.content`
+ * is text. Callers that need a permanent binary (e.g. FLI's wave reports) should
+ * commit the file to git under `data/` and pass `localFilename` so the resources
+ * row can point back to the canonical archive.
+ */
+
+import { createHash } from "crypto";
+import { readFile, stat } from "fs/promises";
+import { hashId } from "../hash-utils.ts";
+import { isPrivateHost } from "../url-utils.ts";
+import { extractPdfMetadata, type PdfMetadata } from "../pdf-extractor.ts";
+import {
+  upsertResource,
+  createResourceContentVersion,
+  lookupResourceByUrl,
+} from "../wiki-server/resources.ts";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Cap on PDF download size — 50 MiB is generous for safety reports while
+ * still rejecting accidentally-huge files (full-corpus dumps, etc.). */
+const MAX_PDF_BYTES = 50 * 1024 * 1024;
+
+/** Cap on extracted text persisted to RCV.content. Picked to fit comfortably
+ * inside the 2_000_000-char column limit while leaving room for typical
+ * headers/footers per page. */
+const MAX_PDF_TEXT_CHARS = 1_000_000;
+
+/** Length of the truncated SHA-256 prefix stored in `content_hash`.
+ * Matches the policy used by `resource-ingest.ts` (CONTENT_HASH_PREFIX_LENGTH)
+ * and the citation dual-write in `routes/wikibase/citations.ts`, so the
+ * `(url, content_hash)` dedup index works across writers. 16 hex chars =
+ * 64 bits — enough collision resistance for archive-scale corpora. */
+const CONTENT_HASH_PREFIX_LENGTH = 16;
+
+const FETCH_TIMEOUT_MS = 60_000;
+const FETCH_USER_AGENT =
+  "Mozilla/5.0 (compatible; LongtermWikiPdfArchiver/1.0; +https://www.longtermwiki.com)";
+
+const FETCH_METHOD = "pdf-archive";
+const PARSER_VERSION = "pdf-parse@2.4.5/v1";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ArchivePdfResourceOptions {
+  /** Canonical HTTPS URL the PDF lives at. Required even when `buffer` is
+   *  supplied — used as `resources.url` and the snapshot's `url` field. */
+  url: string;
+  /** Pre-fetched binary, e.g. from a local file. Skips the network fetch. */
+  buffer?: ArrayBuffer | Uint8Array | Buffer;
+  /** Local file path. If `buffer` is not given but the file exists, it's read. */
+  localFilePath?: string;
+  /** Override resource title. Defaults to the PDF's Info.Title or basename. */
+  title?: string | null;
+  /** Optional summary written to `resources.summary`. */
+  summary?: string | null;
+  /** Optional publisher entity stableId. */
+  publisherEntityId?: string | null;
+  /** `resources.resource_purpose`. Defaults to `'primary_source'`. */
+  resourcePurpose?: string;
+  /** `resources.resource_subtype`. Defaults to `'pdf_report'`. */
+  resourceSubtype?: string;
+  /** `resources.content_lifecycle`. PDFs are typically immutable. */
+  contentLifecycle?: "immutable" | "versioned" | "evergreen" | "ephemeral";
+  /** `resources.local_filename` — pointer back to a committed binary copy. */
+  localFilename?: string | null;
+  /** Tags to write on the resources row. */
+  tags?: string[];
+  /** Free-form context note (e.g., "FLI Dec 2024 wave report"). */
+  contextNote?: string | null;
+}
+
+export interface ArchivePdfResourceResult {
+  /** Canonical resource id used as a foreign key on `source_check_evidence`. */
+  resourceStableId: string;
+  /** Truncated SHA-256 of the binary (16 hex chars), matching the
+   *  CONTENT_HASH_PREFIX_LENGTH policy used by `resource-ingest.ts` and the
+   *  citation dual-write so `(url, content_hash)` dedup works across writers. */
+  contentHash: string;
+  /** Extracted text length (chars). */
+  contentLength: number;
+  /** Page count from the PDF Info dictionary. 0 if metadata extraction failed. */
+  pageCount: number;
+  /** Binary size in bytes. */
+  byteSize: number;
+  /** True if a snapshot for (url, contentHash) already existed. */
+  fromCache: boolean;
+  /** PDF Info-dictionary metadata, when available. */
+  pdfMetadata: PdfMetadata | null;
+  /** RCV row id, for cross-linking from evidence reads. */
+  contentVersionId: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toArrayBuffer(input: ArrayBuffer | Uint8Array | Buffer): ArrayBuffer {
+  if (input instanceof ArrayBuffer) return input;
+  // Buffer / Uint8Array — copy into a fresh ArrayBuffer so we own the bytes
+  // and don't keep a SharedArrayBuffer reference alive in tests.
+  return input.buffer.slice(
+    input.byteOffset,
+    input.byteOffset + input.byteLength,
+  ) as ArrayBuffer;
+}
+
+function hashBinary(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex").slice(0, CONTENT_HASH_PREFIX_LENGTH);
+}
+
+function basenameFromUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    const last = u.pathname.split("/").filter(Boolean).pop() ?? "";
+    return decodeURIComponent(last);
+  } catch {
+    return "";
+  }
+}
+
+async function fetchPdf(url: string): Promise<ArrayBuffer> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Malformed URL: ${url}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(`Unsupported protocol: ${parsed.protocol} (HTTPS only)`);
+  }
+  if (isPrivateHost(parsed.hostname.toLowerCase())) {
+    throw new Error(`Private host blocked (SSRF protection): ${parsed.hostname}`);
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent": FETCH_USER_AGENT,
+      Accept: "application/pdf,*/*;q=0.5",
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    redirect: "follow",
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} fetching ${url}`);
+  }
+  const ct = response.headers.get("content-type") ?? "";
+  if (!ct.includes("application/pdf") && !ct.includes("octet-stream")) {
+    throw new Error(`Expected application/pdf, got ${ct} for ${url}`);
+  }
+
+  // Buffer the response so we can enforce the size cap before extraction.
+  const buf = await response.arrayBuffer();
+  if (buf.byteLength > MAX_PDF_BYTES) {
+    throw new Error(
+      `PDF too large: ${buf.byteLength} bytes (limit ${MAX_PDF_BYTES})`,
+    );
+  }
+  return buf;
+}
+
+async function loadBinary(opts: ArchivePdfResourceOptions): Promise<ArrayBuffer> {
+  if (opts.buffer) {
+    const ab = toArrayBuffer(opts.buffer);
+    if (ab.byteLength > MAX_PDF_BYTES) {
+      throw new Error(
+        `PDF too large: ${ab.byteLength} bytes (limit ${MAX_PDF_BYTES})`,
+      );
+    }
+    return ab;
+  }
+  if (opts.localFilePath) {
+    // stat() throws ENOENT if the file is missing — fall through to URL fetch.
+    const fileStat = await stat(opts.localFilePath).catch(() => null);
+    if (fileStat) {
+      if (fileStat.size > MAX_PDF_BYTES) {
+        throw new Error(
+          `Local PDF too large: ${fileStat.size} bytes (limit ${MAX_PDF_BYTES})`,
+        );
+      }
+      return toArrayBuffer(await readFile(opts.localFilePath));
+    }
+  }
+  return fetchPdf(opts.url);
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export async function archivePdfResource(
+  opts: ArchivePdfResourceOptions,
+): Promise<ArchivePdfResourceResult> {
+  if (!opts.url) {
+    throw new Error("archivePdfResource: url is required");
+  }
+
+  const binary = await loadBinary(opts);
+  const bytes = new Uint8Array(binary);
+  const contentHash = hashBinary(bytes);
+
+  // Extract text + metadata. Failure is tolerated: we still archive the binary
+  // hash + size so future re-verification works, but we mark the snapshot as
+  // text-empty so consumers can decide whether to retry extraction later.
+  const meta = await extractPdfMetadata(binary, MAX_PDF_TEXT_CHARS);
+  const text = meta?.text ?? "";
+
+  const baseTitle =
+    opts.title?.trim() ||
+    meta?.title?.trim() ||
+    basenameFromUrl(opts.url) ||
+    null;
+
+  // Upsert the resource row, keying by `id = hashId(url)`. The server will
+  // ON CONFLICT-resolve to the existing row when one exists for this URL, and
+  // its COALESCE policy preserves any previously-set fields the caller didn't
+  // pass. The .returning() clause hands back the canonical stableId
+  // regardless of insert vs update, so we don't need a separate lookup.
+  const legacyId = hashId(opts.url);
+  const upserted = await upsertResource({
+    id: legacyId,
+    url: opts.url,
+    title: baseTitle,
+    type: "paper",
+    summary: opts.summary ?? null,
+    contentHash, // resources.content_hash mirrors the latest snapshot hash
+    fetchedAt: new Date().toISOString(),
+    publisherEntityId: opts.publisherEntityId ?? null,
+    publishedDate: meta?.creationDate
+      ? meta.creationDate.slice(0, 10)
+      : null,
+    authors: meta?.author ? [meta.author] : null,
+    resourcePurpose: opts.resourcePurpose ?? "primary_source",
+    resourceSubtype: opts.resourceSubtype ?? "pdf_report",
+    contentLifecycle: opts.contentLifecycle ?? "immutable",
+    localFilename: opts.localFilename ?? null,
+    tags: opts.tags ?? null,
+    contextNote: opts.contextNote ?? null,
+    typeMetadata: {
+      pdf: {
+        pageCount: meta?.pageCount ?? 0,
+        byteSize: bytes.byteLength,
+        producer: meta?.producer ?? null,
+        creator: meta?.creator ?? null,
+      },
+    },
+  });
+  if (!upserted.ok) {
+    throw new Error(
+      `archivePdfResource: failed to upsert resource — ${upserted.error}: ${upserted.message ?? ""}`,
+    );
+  }
+  const stableId = upserted.data.stableId;
+  if (!stableId) {
+    throw new Error(
+      `archivePdfResource: upsert returned no stableId for ${opts.url}`,
+    );
+  }
+
+  // Snapshot the content. Dedups on (url, contentHash); calling with the same
+  // bytes is a no-op so callers can retry safely.
+  const versionResult = await createResourceContentVersion(stableId, {
+    url: opts.url,
+    contentHash,
+    fetchedAt: new Date().toISOString(),
+    content: text || null,
+    contentLength: bytes.byteLength,
+    httpStatus: 200,
+    contentType: "application/pdf",
+    fetchMethod: FETCH_METHOD,
+    metadata: {
+      pageCount: meta?.pageCount ?? 0,
+      textCharCount: text.length,
+      byteSize: bytes.byteLength,
+      extractor: "pdf-parse",
+      parserVersion: PARSER_VERSION,
+      pdfInfo: meta
+        ? {
+            title: meta.title,
+            author: meta.author,
+            subject: meta.subject,
+            creator: meta.creator,
+            producer: meta.producer,
+            creationDate: meta.creationDate,
+            modDate: meta.modDate,
+          }
+        : null,
+    },
+  });
+  if (!versionResult.ok) {
+    throw new Error(
+      `archivePdfResource: failed to write content version — ${versionResult.error}: ${versionResult.message ?? ""}`,
+    );
+  }
+
+  // The endpoint returns either {id, deduplicated:false} (new row, 201) or
+  // {id, deduplicated:true} (existing row, 200). Both are typed via union.
+  const versionData = versionResult.data as {
+    id: number | null;
+    deduplicated: boolean;
+  };
+
+  return {
+    resourceStableId: stableId,
+    contentHash,
+    contentLength: text.length,
+    pageCount: meta?.pageCount ?? 0,
+    byteSize: bytes.byteLength,
+    fromCache: versionData.deduplicated === true,
+    pdfMetadata: meta,
+    contentVersionId: versionData.id ?? null,
+  };
+}

--- a/crux/lib/resource-archive/pdf.ts
+++ b/crux/lib/resource-archive/pdf.ts
@@ -91,6 +91,11 @@ export interface ArchivePdfResourceOptions {
   tags?: string[];
   /** Free-form context note (e.g., "FLI Dec 2024 wave report"). */
   contextNote?: string | null;
+  /** Optional ISO date (YYYY-MM-DD) for `resources.published_date`.
+   *  PDF Info `CreationDate` is file/export metadata and not a reliable
+   *  publication date, so it is no longer inferred — callers must pass this
+   *  explicitly when known. */
+  publishedDate?: string | null;
 }
 
 export interface ArchivePdfResourceResult {
@@ -142,6 +147,17 @@ function basenameFromUrl(url: string): string {
   }
 }
 
+function assertSafeUrl(target: URL): void {
+  if (target.protocol !== "https:") {
+    throw new Error(`Unsupported protocol: ${target.protocol} (HTTPS only)`);
+  }
+  if (isPrivateHost(target.hostname.toLowerCase())) {
+    throw new Error(`Private host blocked (SSRF protection): ${target.hostname}`);
+  }
+}
+
+const MAX_REDIRECTS = 5;
+
 async function fetchPdf(url: string): Promise<ArrayBuffer> {
   let parsed: URL;
   try {
@@ -149,37 +165,83 @@ async function fetchPdf(url: string): Promise<ArrayBuffer> {
   } catch {
     throw new Error(`Malformed URL: ${url}`);
   }
-  if (parsed.protocol !== "https:") {
-    throw new Error(`Unsupported protocol: ${parsed.protocol} (HTTPS only)`);
+  assertSafeUrl(parsed);
+
+  let currentUrl = parsed;
+  let response: Response | null = null;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const hopResponse = await fetch(currentUrl, {
+      headers: {
+        "User-Agent": FETCH_USER_AGENT,
+        Accept: "application/pdf,*/*;q=0.5",
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      redirect: "manual",
+    });
+    if (hopResponse.status >= 300 && hopResponse.status < 400) {
+      const location = hopResponse.headers.get("location");
+      if (!location) {
+        throw new Error(`Redirect ${hopResponse.status} missing Location header from ${currentUrl}`);
+      }
+      let next: URL;
+      try {
+        next = new URL(location, currentUrl);
+      } catch {
+        throw new Error(`Malformed redirect Location: ${location}`);
+      }
+      assertSafeUrl(next);
+      currentUrl = next;
+      continue;
+    }
+    response = hopResponse;
+    break;
   }
-  if (isPrivateHost(parsed.hostname.toLowerCase())) {
-    throw new Error(`Private host blocked (SSRF protection): ${parsed.hostname}`);
+  if (!response) {
+    throw new Error(`Too many redirects (>${MAX_REDIRECTS}) starting at ${url}`);
   }
 
-  const response = await fetch(url, {
-    headers: {
-      "User-Agent": FETCH_USER_AGENT,
-      Accept: "application/pdf,*/*;q=0.5",
-    },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    redirect: "follow",
-  });
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status} fetching ${url}`);
+    throw new Error(`HTTP ${response.status} fetching ${currentUrl}`);
   }
   const ct = response.headers.get("content-type") ?? "";
   if (!ct.includes("application/pdf") && !ct.includes("octet-stream")) {
-    throw new Error(`Expected application/pdf, got ${ct} for ${url}`);
+    throw new Error(`Expected application/pdf, got ${ct} for ${currentUrl}`);
   }
 
-  // Buffer the response so we can enforce the size cap before extraction.
-  const buf = await response.arrayBuffer();
-  if (buf.byteLength > MAX_PDF_BYTES) {
-    throw new Error(
-      `PDF too large: ${buf.byteLength} bytes (limit ${MAX_PDF_BYTES})`,
-    );
+  // Stream the body so an oversized response trips the cap before exhausting
+  // memory. We can't trust Content-Length to be present or honest.
+  const body = response.body;
+  if (!body) {
+    throw new Error(`Response body missing for ${currentUrl}`);
   }
-  return buf;
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > MAX_PDF_BYTES) {
+        await reader.cancel().catch(() => {}); // catch-ok: stream already aborted; cancel() failure is moot
+        throw new Error(
+          `PDF too large: >${MAX_PDF_BYTES} bytes (limit ${MAX_PDF_BYTES})`,
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged.buffer.slice(merged.byteOffset, merged.byteOffset + merged.byteLength) as ArrayBuffer;
 }
 
 async function loadBinary(opts: ArchivePdfResourceOptions): Promise<ArrayBuffer> {
@@ -193,8 +255,12 @@ async function loadBinary(opts: ArchivePdfResourceOptions): Promise<ArrayBuffer>
     return ab;
   }
   if (opts.localFilePath) {
-    // stat() throws ENOENT if the file is missing — fall through to URL fetch.
-    const fileStat = await stat(opts.localFilePath).catch(() => null);
+    // Only ENOENT falls through to URL fetch — permission/IO errors must surface
+    // so callers see the real failure instead of a silent network re-fetch.
+    const fileStat = await stat(opts.localFilePath).catch((err: NodeJS.ErrnoException) => {
+      if (err && err.code === "ENOENT") return null;
+      throw err;
+    });
     if (fileStat) {
       if (fileStat.size > MAX_PDF_BYTES) {
         throw new Error(
@@ -254,9 +320,7 @@ export async function archivePdfResource(
     contentHash, // resources.content_hash mirrors the latest snapshot hash
     fetchedAt,
     publisherEntityId: opts.publisherEntityId ?? null,
-    publishedDate: meta?.creationDate
-      ? meta.creationDate.slice(0, 10)
-      : null,
+    publishedDate: opts.publishedDate ?? null,
     authors: meta?.author ? [meta.author] : null,
     resourcePurpose: opts.resourcePurpose ?? "primary_source",
     resourceSubtype: opts.resourceSubtype ?? "pdf_report",

--- a/crux/lib/resource-archive/pdf.ts
+++ b/crux/lib/resource-archive/pdf.ts
@@ -32,7 +32,6 @@ import { extractPdfMetadata, type PdfMetadata } from "../pdf-extractor.ts";
 import {
   upsertResource,
   createResourceContentVersion,
-  lookupResourceByUrl,
 } from "../wiki-server/resources.ts";
 
 // ---------------------------------------------------------------------------
@@ -235,6 +234,11 @@ export async function archivePdfResource(
     basenameFromUrl(opts.url) ||
     null;
 
+  // Capture one timestamp so resources.fetched_at and the snapshot's fetchedAt
+  // agree exactly (otherwise they drift by milliseconds, breaking "snapshot
+  // timestamp == resource timestamp" reasoning for consumers).
+  const fetchedAt = new Date().toISOString();
+
   // Upsert the resource row, keying by `id = hashId(url)`. The server will
   // ON CONFLICT-resolve to the existing row when one exists for this URL, and
   // its COALESCE policy preserves any previously-set fields the caller didn't
@@ -248,7 +252,7 @@ export async function archivePdfResource(
     type: "paper",
     summary: opts.summary ?? null,
     contentHash, // resources.content_hash mirrors the latest snapshot hash
-    fetchedAt: new Date().toISOString(),
+    fetchedAt,
     publisherEntityId: opts.publisherEntityId ?? null,
     publishedDate: meta?.creationDate
       ? meta.creationDate.slice(0, 10)
@@ -286,7 +290,7 @@ export async function archivePdfResource(
   const versionResult = await createResourceContentVersion(stableId, {
     url: opts.url,
     contentHash,
-    fetchedAt: new Date().toISOString(),
+    fetchedAt,
     content: text || null,
     contentLength: bytes.byteLength,
     httpStatus: 200,

--- a/crux/lib/wiki-server/resources.ts
+++ b/crux/lib/wiki-server/resources.ts
@@ -210,9 +210,12 @@ export type ListContentVersionsResult = InferResponseType<
 
 export async function listResourceContentVersions(
   resourceId: string,
+  opts: { limit?: number; offset?: number } = {},
 ): Promise<ApiResult<ListContentVersionsResult>> {
-  return apiRequest<ListContentVersionsResult>(
-    'GET',
-    `/api/resources/${encodeURIComponent(resourceId)}/content-versions`,
-  );
+  const params = new URLSearchParams();
+  if (opts.limit != null) params.set('limit', String(opts.limit));
+  if (opts.offset != null) params.set('offset', String(opts.offset));
+  const qs = params.toString();
+  const path = `/api/resources/${encodeURIComponent(resourceId)}/content-versions${qs ? `?${qs}` : ''}`;
+  return apiRequest<ListContentVersionsResult>('GET', path);
 }

--- a/crux/lib/wiki-server/resources.ts
+++ b/crux/lib/wiki-server/resources.ts
@@ -164,3 +164,55 @@ export async function updateAuthorEntityIds(
 ): Promise<ApiResult<UpdateAuthorEntityIdsResult>> {
   return apiRequest<UpdateAuthorEntityIdsResult>('PATCH', '/api/resources/author-entity-ids', { items });
 }
+
+// ---------------------------------------------------------------------------
+// Content versions (QUA-942)
+// ---------------------------------------------------------------------------
+
+export interface CreateContentVersionInput {
+  url: string;
+  contentHash: string;
+  fetchedAt: string;
+  content?: string | null;
+  contentLength?: number | null;
+  httpStatus?: number | null;
+  contentType?: string | null;
+  fetchMethod?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export type CreateContentVersionResult =
+  | InferResponseType<RpcClient[':id']['content-versions']['$post'], 201>
+  | InferResponseType<RpcClient[':id']['content-versions']['$post'], 200>;
+
+/**
+ * Append a snapshot to a resource's content-version history. Dedups on
+ * (url, contentHash) — when the same byte-identical content is archived
+ * again, returns the existing row's id and `deduplicated: true`.
+ */
+export async function createResourceContentVersion(
+  resourceId: string,
+  input: CreateContentVersionInput,
+): Promise<ApiResult<CreateContentVersionResult>> {
+  // Large payloads (PDF text up to 1MB) get the extended timeout from
+  // batchedRequest, matching the existing snapshot endpoint policy.
+  return batchedRequest<CreateContentVersionResult>(
+    'POST',
+    `/api/resources/${encodeURIComponent(resourceId)}/content-versions`,
+    input,
+  );
+}
+
+export type ListContentVersionsResult = InferResponseType<
+  RpcClient[':id']['content-versions']['$get'],
+  200
+>;
+
+export async function listResourceContentVersions(
+  resourceId: string,
+): Promise<ApiResult<ListContentVersionsResult>> {
+  return apiRequest<ListContentVersionsResult>(
+    'GET',
+    `/api/resources/${encodeURIComponent(resourceId)}/content-versions`,
+  );
+}

--- a/docs/agent-rules/source-check-system.md
+++ b/docs/agent-rules/source-check-system.md
@@ -126,3 +126,87 @@ Before proposing new work in this subsystem:
 2. If adding a new entity type's coverage score: add scorer to `coverage-score.ts`, dispatch in `entity-coverage.ts`. Don't copy the pattern to a new file.
 3. If adding a new verdict type: update `source-check-status.ts` mapping AND `verdict-styles.ts` — both must stay in sync
 4. If adding a dashboard: use `/internal/entity-source-checks/` as the Pattern A reference; it has entity ID + redirect already wired
+
+## 9. PDF resources & page-addressable evidence (QUA-942)
+
+PDFs (safety reports, scorecards, methodology docs) get archived through the
+**`archivePdfResource()` adapter** — `crux/lib/resource-archive/pdf.ts`. Don't
+roll your own "fetch + extract + insert resource" pipeline; this adapter is the
+shared seam.
+
+**What it does in one call:**
+
+1. Loads the binary (HTTPS fetch with SSRF guard, or accepts a pre-fetched
+   buffer / local file path).
+2. Computes a full SHA-256 over the **binary** — this is the deterministic
+   integrity hash that survives `pdf-parse` upgrades and rendering changes.
+3. Extracts text + Info-dictionary metadata (`pageCount`, `title`, `author`,
+   `creationDate`) via `extractPdfMetadata` (also exported from `pdf-extractor.ts`).
+4. Upserts a `resources` row (`type='paper'`, `resourcePurpose='primary_source'`,
+   `resourceSubtype='pdf_report'`, `contentLifecycle='immutable'` by default).
+5. Posts a snapshot to `resource_content_versions` via
+   `POST /api/resources/:id/content-versions` with the binary hash, extracted
+   text, and PDF metadata in `metadata` JSONB.
+6. Returns `{ resourceStableId, contentHash, pageCount, fromCache }`.
+
+**Schema choice (Phase 1):** PDFs do **not** get a parallel `resource_documents`
+parent table. They use the existing `resources` row + `resource_content_versions`
+with `content_type='application/pdf'`. PDF-specific metadata lives in
+`resource_content_versions.metadata` JSONB. This keeps the surface area small;
+revisit if a future requirement (e.g. table-of-contents JSON, per-table extracts)
+demands typed columns.
+
+**Storage policy:** the binary itself is **not** stored in PG. The hash + size
+are persisted; the canonical binary lives at `data/scorecards/raw/<source>/<wave>/report.pdf`
+(committed to git) with `resources.local_filename` pointing back to it. If
+upstream rots, the committed copy + matching hash is the ground-truth archive.
+
+**Page-addressable evidence:** `source_check_evidence.evidence_locator` (JSONB,
+added in migration `0224`) carries one of three discriminated locator shapes
+validated by `EvidenceLocatorSchema` in `sourcing.ts`:
+
+```json
+{ "kind": "pdf-page",   "page": 14, "table": "2.3" }
+{ "kind": "csv-cell",   "row": 23, "column": "risk-assessment" }
+{ "kind": "html-anchor", "selector": "#table-2" }
+```
+
+`evidence_locator IS NULL` = whole-source verdict (existing behavior; no
+back-fill on existing rows). The column has a partial GIN index covering only
+non-null rows so we don't pay storage for the millions of NULL legacy rows.
+
+**Calling convention:**
+
+```ts
+import { archivePdfResource } from "../lib/resource-archive/pdf.ts";
+
+const result = await archivePdfResource({
+  url: "https://futureoflife.org/.../AI-Safety-Index-2024-Full-Report.pdf",
+  localFilePath: "data/scorecards/raw/fli/2024-12/report.pdf", // optional
+  publisherEntityId: "sid_FliEntity",
+  contextNote: "FLI Dec 2024 wave report",
+  tags: ["scorecard", "fli_index", "wave:2024-12"],
+});
+
+// Then attach evidence with a page locator:
+await postEvidence({
+  recordType: "scorecard_grade",
+  recordId: gradeId,
+  resourceId: result.resourceStableId,
+  evidenceLocator: { kind: "pdf-page", page: 18 },
+  verdict: "confirmed",
+  // ...
+});
+```
+
+**CLI:** `pnpm crux tb import-scorecards archive-pdf --source=fli_index --wave=2024-12`
+is the proof-of-concept consumer; pattern is generalizable to any wave whose
+PDF lives at `data/scorecards/raw/<source>/<wave>/report.pdf`.
+
+**What's not in scope (file follow-up tickets):**
+- OCR for image-only PDFs.
+- Per-table-cell extraction inside PDFs (e.g., FMTI methodology appendix
+  table 4 row 12). The `pdf-page` locator already supports `table` + `row`
+  hints, but the actual extractor is per-source today.
+- Migrating the system-card harvester (QUA-690) and citation pipeline to use
+  this adapter. The adapter exists; the migration is a separate ticket.


### PR DESCRIPTION
## Summary

QUA-942 ships a first-class adapter pattern for "ingest a PDF as a Resource, archive its content, and make page-addressable evidence" — replacing four scattered ad-hoc PDF paths with one shared seam.

- **`crux/lib/resource-archive/pdf.ts`** — `archivePdfResource()` adapter: HTTPS-only fetch (or local file/buffer) with SSRF guard, 16-char SHA-256 of the binary, pdf-parse text + Info-dict metadata, single-round-trip upsert via the upsert `RETURNING` clause.
- **Migration `0224`** — `evidence_locator JSONB` on `source_check_evidence` + partial GIN index. NULL = whole-source (no back-fill on legacy rows).
- **`EvidenceLocatorSchema`** — discriminated Zod union (`pdf-page` / `csv-cell` / `html-anchor`) wired into `POST /api/sourcing/evidence` and the read mapper. Lives in `api-types.ts` for layered access.
- **`POST /api/resources/:id/content-versions`** + paginated `GET` — dedup on `(url, content_hash)` (16-char hash policy enforced strictly so dedup actually dedups across writers).
- **CLI** — `pnpm crux tb import-scorecards archive-pdf --source=fli_index --wave=2024-12` (proof-of-concept consumer for the FLI Dec 2024 wave, using the committed `data/scorecards/raw/fli/2024-12/report.pdf`).
- **Schema choice (Phase 1)**: PDFs use existing `resources` + `resource_content_versions`, not a parallel `resource_documents` parent table. Per ticket: "Strongly prefer the simplest of these that works."
- **Hash + binary policy**: full SHA-256 of binary (truncated to 16 hex), text in `resource_content_versions.content`, PDF-specific metadata in JSONB `metadata`. Binary itself NOT in PG; canonical copies live committed under `data/scorecards/raw/<source>/<wave>/report.pdf`.
- **Docs**: section 9 in `docs/agent-rules/source-check-system.md`, Tier 2 row in `CLAUDE.md`.

## Out of scope (filed as follow-ups)

- **QUA-1065** — migrate system-card harvester (QUA-690) to use this adapter
- **QUA-1066** — full Drizzle-dispatcher integration tests for the new endpoints + `evidenceLocator` round-trip
- **QUA-945** (already filed) — Phase 2 unblocked for the FLI PDF wave
- OCR / per-cell extraction — speculative until a real consumer needs them; not filed

## Test plan

- [x] 64 targeted unit tests pass — adapter (15), pdf-extractor (10), EvidenceLocatorSchema (21), migration shape (4), sourcing-lint-guard regression (14)
- [x] Full vitest suite green (~9700 tests)
- [x] Type check clean across all 3 projects (`apps/web`, `apps/wiki-server`, `crux`)
- [x] Full validate gate green (71/71 blocking, 2 advisory pre-existing)
- [x] CLI error paths exercised (missing args, missing file, no canonical URL)
- [x] Red-team: SSRF (`@`-tricks, `[::1]`, RFC1918, link-local), `javascript:`/`file:` URLs, JSONB extra-key stripping — all caught
- [x] Hostile review pass (1572-line diff): 4 HIGH findings fixed, 7 MEDIUM fixed, 5 LOW deferred
- [ ] Post-merge: run `pnpm crux tb import-scorecards archive-pdf --source=fli_index --wave=2024-12` against prod to verify the FLI 2024-12 PDF lands as a Resource + content version

Fixes QUA-942


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0224 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
<!-- /deploy-tasks -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDF resource archiving with automatic metadata extraction (title, author, creation date, page count).
  * Introduced page-addressable evidence locators to pinpoint exact locations within resources (PDF pages, spreadsheet cells, HTML anchors).
  * Added resource content versioning with deduplication support for archived materials.

* **Documentation**
  * Updated agent guidelines documenting PDF archiving and evidence locator workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->