### PR TITLE
Block cat-polling on subagent task outputs (QUA-1069)

### DIFF
--- a/.claude/hooks/__tests__/test-block-cat-polling.sh
+++ b/.claude/hooks/__tests__/test-block-cat-polling.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# Smoke test for .claude/hooks/block-cat-polling.sh (QUA-1069).
+#
+# Verifies:
+#   - real W18 worst-case patterns match
+#   - cat / tail / stat verbs are all caught
+#   - counter is per-session (different session_ids don't share a counter)
+#   - threshold is exactly 3 (1 and 2 silent, 3+ blocks)
+#   - the slot path shape (lw/aN) is detected
+#   - Edit/Write tool calls are ignored (Bash-only matcher)
+#   - heredoc bodies and -m "..." commit messages don't false-positive
+#   - missing session_id / unparseable input fail open
+#
+# Run: bash .claude/hooks/__tests__/test-block-cat-polling.sh
+#
+# Exit code: 0 on all-pass, 1 on any failure.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK="$REPO_ROOT/.claude/hooks/block-cat-polling.sh"
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+export CLAUDE_PROJECT_DIR="$TEST_DIR"
+mkdir -p "$TEST_DIR/.claude/hooks"
+cp "$HOOK" "$TEST_DIR/.claude/hooks/block-cat-polling.sh"
+HOOK="$TEST_DIR/.claude/hooks/block-cat-polling.sh"
+
+PASS=0
+FAIL=0
+fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+pass() { PASS=$((PASS+1)); }
+
+invoke() {
+  local cmd="$1"
+  local sid="${2:-test-session-uuid}"
+  local payload
+  payload=$(jq -n --arg cmd "$cmd" --arg sid "$sid" \
+    '{tool_name:"Bash",session_id:$sid,tool_input:{command:$cmd}}')
+  echo "$payload" | bash "$HOOK" 2>/dev/null
+  echo $?
+}
+
+invoke_stderr() {
+  local cmd="$1"
+  local sid="${2:-test-session-uuid}"
+  local payload
+  payload=$(jq -n --arg cmd "$cmd" --arg sid "$sid" \
+    '{tool_name:"Bash",session_id:$sid,tool_input:{command:$cmd}}')
+  echo "$payload" | bash "$HOOK" 2>&1 1>/dev/null
+}
+
+reset_session() {
+  rm -rf "$TEST_DIR/.claude/.poll-counts"
+}
+
+# === Real W18 worst-case patterns (from c7413678 transcript) ===
+echo "--- positive matches (W18 patterns) ---"
+reset_session
+
+# Direct shapes captured from the worst-case session:
+W18_1='cat /private/tmp/claude-501/-Users-ozziegooen-Documents-GitHub-nosync-lw-a9/0227ce3f-ada3-40bb-9779-21a93d355472/tasks/b20pa3o91.output 2>&1 | tail -3; pgrep -lf "lw/a9.*validate-gate" >/dev/null 2>&1 && echo RUN || echo DONE; date'
+W18_2='cat /private/tmp/claude-501/-Users-ozziegooen-Documents-GitHub-nosync-lw-a9/0227ce3f-ada3-40bb-9779-21a93d355472/tasks/b20pa3o91.output 2>&1 | tail; pgrep -lf "lw/a9.*validate-gate" >/dev/null 2>&1 && echo RUN || echo DONE'
+W18_3='cat /private/tmp/claude-501/-Users-ozziegooen-Documents-GitHub-nosync-lw-a9/0227ce3f-ada3-40bb-9779-21a93d355472/tasks/b20pa3o91.output 2>&1; pgrep -lf "lw/a9.*validate-gate" >/dev/null 2>&1 && echo RUN || echo DONE; date'
+
+R=$(invoke "$W18_1" "sid-A"); [ "$R" = "0" ] && pass || fail "1st cat-poll should exit 0 (got $R)"
+R=$(invoke "$W18_2" "sid-A"); [ "$R" = "0" ] && pass || fail "2nd cat-poll should exit 0 (got $R)"
+R=$(invoke "$W18_3" "sid-A"); [ "$R" = "2" ] && pass || fail "3rd cat-poll should exit 2 (got $R)"
+R=$(invoke "$W18_1" "sid-A"); [ "$R" = "2" ] && pass || fail "4th cat-poll should keep blocking (got $R)"
+
+# tail variant
+reset_session
+TAIL_CMD='tail -f /tmp/claude-501/foo/tasks/abc.output'
+R=$(invoke "$TAIL_CMD" "sid-tail"); [ "$R" = "0" ] && pass || fail "tail #1 should exit 0 (got $R)"
+R=$(invoke "$TAIL_CMD" "sid-tail"); [ "$R" = "0" ] && pass || fail "tail #2 should exit 0 (got $R)"
+R=$(invoke "$TAIL_CMD" "sid-tail"); [ "$R" = "2" ] && pass || fail "tail #3 should exit 2 (got $R)"
+
+# stat -f %z variant
+reset_session
+STAT_CMD='stat -f %z /tmp/claude-501/foo/tasks/abc.output'
+R=$(invoke "$STAT_CMD" "sid-stat"); [ "$R" = "0" ] && pass || fail "stat #1 should exit 0 (got $R)"
+R=$(invoke "$STAT_CMD" "sid-stat"); [ "$R" = "0" ] && pass || fail "stat #2 should exit 0 (got $R)"
+R=$(invoke "$STAT_CMD" "sid-stat"); [ "$R" = "2" ] && pass || fail "stat #3 should exit 2 (got $R)"
+
+# Slot path (lw/aN — QUA-471 lore: ensure slug-style paths inside the slot match)
+reset_session
+SLOT_CMD='cat /private/tmp/claude-501/-Users-ozziegooen-Documents-GitHub-nosync-lw-a9/aaaa-bbbb-cccc/tasks/b6t64p6s1.output 2>&1; ps -p 74799 >/dev/null 2>&1 && echo RUN || echo DONE'
+R=$(invoke "$SLOT_CMD" "sid-slot"); [ "$R" = "0" ] && pass || fail "slot #1 should exit 0 (got $R)"
+R=$(invoke "$SLOT_CMD" "sid-slot"); [ "$R" = "0" ] && pass || fail "slot #2 should exit 0 (got $R)"
+R=$(invoke "$SLOT_CMD" "sid-slot"); [ "$R" = "2" ] && pass || fail "slot #3 should exit 2 (got $R)"
+
+STDERR=$(invoke_stderr "$SLOT_CMD" "sid-slot")
+echo "$STDERR" | grep -q "BLOCKED" && pass || fail "stderr should contain BLOCKED"
+echo "$STDERR" | grep -q "Monitor" && pass || fail "stderr should mention Monitor"
+echo "$STDERR" | grep -q "ToolSearch" && pass || fail "stderr should mention ToolSearch"
+echo "$STDERR" | grep -q "wait-on-subagents.md" && pass || fail "stderr should reference rule file"
+
+# === Session isolation ===
+echo "--- session isolation ---"
+reset_session
+R=$(invoke "$W18_1" "session-X"); [ "$R" = "0" ] && pass || fail "session-X #1"
+R=$(invoke "$W18_1" "session-X"); [ "$R" = "0" ] && pass || fail "session-X #2"
+R=$(invoke "$W18_1" "session-Y"); [ "$R" = "0" ] && pass || fail "session-Y #1 (independent counter)"
+R=$(invoke "$W18_1" "session-X"); [ "$R" = "2" ] && pass || fail "session-X #3 (blocks)"
+R=$(invoke "$W18_1" "session-Y"); [ "$R" = "0" ] && pass || fail "session-Y #2 still allowed"
+R=$(invoke "$W18_1" "session-Y"); [ "$R" = "2" ] && pass || fail "session-Y #3 blocks independently"
+
+# === Negative cases (should NEVER block) ===
+echo "--- negative cases ---"
+reset_session
+
+R=$(invoke 'cat /tmp/foo.log' "sid-neg"); [ "$R" = "0" ] && pass || fail "regular cat should not match"
+R=$(invoke 'cat README.md' "sid-neg"); [ "$R" = "0" ] && pass || fail "cat of project file should not match"
+R=$(invoke 'cat /tmp/claude-501/something/else.log' "sid-neg"); [ "$R" = "0" ] && pass || fail "non-tasks /tmp/claude-* should not match"
+R=$(invoke 'cat /tmp/foo/tasks/x.output' "sid-neg"); [ "$R" = "0" ] && pass || fail "tasks/ outside /tmp/claude-* should not match"
+
+# 3 of these should still not block — none match the polling pattern
+R=$(invoke 'cat README.md' "sid-neg"); [ "$R" = "0" ] && pass || fail "non-poll #1"
+R=$(invoke 'cat README.md' "sid-neg"); [ "$R" = "0" ] && pass || fail "non-poll #2"
+R=$(invoke 'cat README.md' "sid-neg"); [ "$R" = "0" ] && pass || fail "non-poll #3"
+
+# Edit/Write should be ignored — Bash matcher only
+EDIT_PAYLOAD=$(jq -n '{tool_name:"Edit",session_id:"sid-edit",tool_input:{file_path:"/tmp/claude-501/foo/tasks/x.output"}}')
+echo "$EDIT_PAYLOAD" | bash "$HOOK" 2>/dev/null
+[ "$?" = "0" ] && pass || fail "Edit tool should be ignored"
+
+# Heredoc body containing the path shape — should not count
+reset_session
+HEREDOC_CMD=$'cat <<\'EOF\' > /tmp/note.md\nDo NOT do `cat /tmp/claude-501/foo/tasks/x.output` — use Monitor.\nEOF'
+R=$(invoke "$HEREDOC_CMD" "sid-here"); [ "$R" = "0" ] && pass || fail "heredoc body #1"
+R=$(invoke "$HEREDOC_CMD" "sid-here"); [ "$R" = "0" ] && pass || fail "heredoc body #2"
+R=$(invoke "$HEREDOC_CMD" "sid-here"); [ "$R" = "0" ] && pass || fail "heredoc body #3"
+
+# git commit -m "..." with the path shape inside the message
+reset_session
+COMMIT_CMD='git commit -m "fix: block cat /tmp/claude-501/x/tasks/y.output polling"'
+R=$(invoke "$COMMIT_CMD" "sid-commit"); [ "$R" = "0" ] && pass || fail "commit -m message #1"
+R=$(invoke "$COMMIT_CMD" "sid-commit"); [ "$R" = "0" ] && pass || fail "commit -m message #2"
+R=$(invoke "$COMMIT_CMD" "sid-commit"); [ "$R" = "0" ] && pass || fail "commit -m message #3"
+
+# === Fail-open cases ===
+echo "--- fail-open ---"
+
+# missing session_id
+reset_session
+NO_SID=$(jq -n '{tool_name:"Bash",tool_input:{command:"cat /tmp/claude-501/foo/tasks/x.output"}}')
+echo "$NO_SID" | bash "$HOOK" 2>/dev/null
+[ "$?" = "0" ] && pass || fail "missing session_id should fail open"
+
+# unparseable input
+echo "this is not json" | bash "$HOOK" 2>/dev/null
+[ "$?" = "0" ] && pass || fail "non-json input should fail open"
+
+# empty input
+echo "" | bash "$HOOK" 2>/dev/null
+[ "$?" = "0" ] && pass || fail "empty input should fail open"
+
+echo
+echo "=================================="
+echo "PASS: $PASS    FAIL: $FAIL"
+echo "=================================="
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/block-cat-polling.sh
+++ b/.claude/hooks/block-cat-polling.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# PreToolUse Bash hook — detects cat-polling on dispatched-subagent task
+# output files (a wait-for-completion anti-pattern) and forces the agent
+# to use Monitor instead. See QUA-1069.
+#
+# At >= THRESHOLD matched commands in a single session, exits 2 with a
+# system-reminder pointing at Monitor with the canonical invocation.
+# Earlier matches are silently counted (a one-shot forensic read of a
+# task file is fine; the pattern fires on busy-wait).
+#
+# Patterns matched (representative shapes from the W18 worst-case
+# transcript):
+#   cat /private/tmp/claude-501/.../tasks/<id>.output
+#   cat /tmp/claude-501/.../tasks/<id>.output
+#   tail [-f] /tmp/claude-.../tasks/<id>.output
+#   stat -f %z /tmp/claude-.../tasks/<id>.output
+#
+# State: .claude/.poll-counts/<session_id> per-session counter file.
+# Slot-local (no /tmp global) — see PR #4812 slot-leak fix.
+#
+# Fails open on missing jq / unparseable input — never bricks Bash.
+
+set -uo pipefail
+
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+COUNTS_DIR="$REPO_ROOT/.claude/.poll-counts"
+THRESHOLD=3
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat 2>/dev/null || true)
+[ -z "$INPUT" ] && exit 0
+
+# Three jq calls (rather than one @tsv) so we preserve real newlines
+# inside .tool_input.command — @tsv encodes embedded newlines as
+# literal "\n" which would defeat the head -n1 first-line filter
+# below.
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
+[ -z "$SESSION_ID" ] && exit 0
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
+[ -z "$COMMAND" ] && exit 0
+
+# Real cat-polls are single-line chained one-liners
+# (cat ... ; ps -p N && echo RUN || echo DONE). Multi-line scripts
+# and heredocs aren't poll patterns, so look only at the first line —
+# this naturally drops heredoc bodies and Python/JS code blocks that
+# happen to mention the path shape in a string literal.
+#
+# Then strip -m "..." / -m '...' quoted args so a git commit message
+# describing the bug, or a crux gh pr body, doesn't trip the counter.
+# (Same defense pattern as block-no-verify.sh.)
+FIRST_LINE=$(echo "$COMMAND" | head -n1)
+STRIPPED=$(echo "$FIRST_LINE" \
+  | sed -E "s/-m \"[^\"]*\"//g" \
+  | sed -E "s/-m '[^']*'//g")
+
+# The signature is the *path shape*, not the verb — we match cat/tail/stat
+# (the common waiters) reading a (/private)?/tmp/claude*/.../tasks/<id>.*
+# file. Word boundaries on the verb avoid matching e.g. "concat" or random
+# subcommands. Allow command-start, pipe, semicolon, &&, or paren before
+# the verb so we catch chained polls (`cat ... ; ps -p N`).
+POLL_REGEX='(^|[[:space:]|;&(])(cat|tail|stat)([[:space:]]+-[^[:space:]]+)*[[:space:]]+[^|;&]*(/private)?/tmp/claude[-_][^[:space:]]*/tasks/[^[:space:]|;&)>]+'
+
+echo "$STRIPPED" | grep -qE "$POLL_REGEX" || exit 0
+
+mkdir -p "$COUNTS_DIR" 2>/dev/null || exit 0
+
+# UUIDs are safe but defense-in-depth: filenames cannot escape the dir.
+SAFE_ID=$(printf '%s' "$SESSION_ID" | tr -cd 'a-zA-Z0-9-')
+[ -n "$SAFE_ID" ] || exit 0
+COUNT_FILE="$COUNTS_DIR/$SAFE_ID"
+
+CURRENT=$(cat "$COUNT_FILE" 2>/dev/null | tr -d '[:space:]' || true)
+[[ "$CURRENT" =~ ^[0-9]+$ ]] || CURRENT=0
+NEW=$((CURRENT + 1))
+echo "$NEW" > "$COUNT_FILE"
+
+if [ "$NEW" -lt "$THRESHOLD" ]; then
+  exit 0
+fi
+
+# Strip angle brackets from anything we echo in the reminder body (defense
+# against a hypothetical session_id or command containing </system-reminder>
+# fragments). The command itself isn't echoed back, but be safe with the count.
+SAFE_NEW=$(printf '%s' "$NEW" | tr -d '<>')
+
+cat >&2 <<EOF
+BLOCKED: subagent task-output cat-polling detected ($SAFE_NEW occurrences this session, threshold=$THRESHOLD).
+
+This is the polling anti-pattern: when waiting on a dispatched subagent
+or background process, agents reach for repeated 'cat /tmp/.../tasks/*.output'
+instead of streaming the output. The W18 simulation showed this wastes
+5-16% of bash calls in long sessions; one session burned 143 cat-polls in
+325 minutes.
+
+Use Monitor instead — it streams stdout events as they happen, with no
+busy-wait. If Monitor's schema isn't loaded yet, fetch it first:
+
+  ToolSearch({ query: "select:Monitor", max_results: 1 })
+
+Then call Monitor with the target you were polling and a predicate that
+matches your exit condition. For 'wait until done', the runtime emits one
+event per stdout line and resolves when the loop exits.
+
+If you genuinely need a one-shot forensic read of a finished task file,
+that's fine — the counter only fires on the third occurrence in a
+session. To unblock the current call, switch to Monitor.
+
+See .claude/rules/wait-on-subagents.md for the full pattern guide and
+QUA-1069 for the data behind this hook.
+EOF
+exit 2

--- a/.claude/rules/wait-on-subagents.md
+++ b/.claude/rules/wait-on-subagents.md
@@ -1,0 +1,66 @@
+# Waiting on Subagents — Use Monitor, Not `cat`
+
+When you dispatch a subagent (`Agent` / `TaskCreate` / `./ws dispatch`) or
+launch a background process (`Bash` with `run_in_background`), **wait on
+it with `Monitor`, not by repeated `cat` of its task-output file**.
+
+## The rule
+
+- ✅ Use `Monitor({ target: ..., until: ..., timeout_seconds: ... })` to
+  stream the subagent's output until your exit predicate matches.
+- ❌ Do NOT repeatedly run `cat /tmp/claude-*/.../tasks/<id>.output`,
+  `tail -f` it, `stat -f %z` it for size deltas, or chain it with
+  `ps -p N && echo RUN || echo DONE` poll loops.
+- ❌ Do NOT pair the above with `echo wait` or `sleep` shims to
+  approximate streaming — `Monitor` already does this correctly.
+
+A `PreToolUse` hook (`.claude/hooks/block-cat-polling.sh`) detects the
+anti-pattern and **blocks Bash at the 3rd occurrence per session** with
+exit 2. There is no env-var bypass — the threshold exists because manual
+soft rules didn't change the behavior (Monitor was available the whole
+time the W18 spike happened, and agents reached for `cat` reflexively
+anyway).
+
+## The schema-not-loaded escape hatch
+
+`Monitor` is a deferred tool. Its full schema isn't in your prompt by
+default — you have to fetch it once per session before the first call:
+
+```
+ToolSearch({ query: "select:Monitor", max_results: 1 })
+```
+
+After that, `Monitor` is callable like any other tool for the rest of
+the session. If you find yourself reaching for `cat /tmp/.../tasks/*`
+because you don't remember Monitor's parameters, **load the schema
+first** — that one-time `ToolSearch` is much cheaper than the polling
+budget it replaces.
+
+## Why this matters
+
+Polling burns context and bash budget without making progress. Full
+33-day, 744-session analysis (QUA-1069):
+
+- Baseline polling rate: ~1.3-1.8% of bash calls.
+- W18 worst week: 5.9% of bash calls (3.3× baseline).
+- W18 worst session: 143 cat-polls + 133 `echo wait` calls in 325
+  minutes, slot a9.
+
+The hook's simulated impact: prevent ~62% of all observed polling
+calls (1,495 of 2,400+ in the 33-day window) by tripping at the 3rd
+match in the 193 sessions that exceeded the threshold.
+
+## Legitimate one-shot reads
+
+A single `cat` of a finished task file for forensics (e.g., recovering
+the last lines of a crashed run, debugging a hook the subagent
+triggered) is fine — the counter only fires on the third occurrence in
+a session. If you genuinely need to read the file once, do it and move
+on. The hook is targeted at busy-wait, not at one-shot reads.
+
+## See also
+
+- `.claude/hooks/block-cat-polling.sh` — the enforcing hook
+- QUA-1069 — the simulation data and rationale behind the threshold
+- [12-Factor Agents](https://github.com/humanlayer/12-factor-agents) —
+  exit between cycles, don't poll inside them

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,6 +75,10 @@
           },
           {
             "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-cat-polling.sh\""
+          },
+          {
+            "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/require-stage-approved.sh\"",
             "timeout": 15
           }

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ crux/coverage/
 .claude/active-branch
 .claude/session.pid
 .claude/last-heartbeat
+.claude/.poll-counts/
 .claude/review-done
 .claude/review-phases-done
 .claude/simplify-done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,7 @@ These cover the session lifecycle and the always-applicable conventions. They au
 - `.claude/rules/implementation-quality.md` — Thoroughness, testing depth, self-review
 - `.claude/rules/slot-isolation.md` — Don't touch other agent slots
 - `.claude/rules/worktree-isolation-bug.md` — Known Claude Code worktree CWD bug (DO NOT USE `isolation: "worktree"`)
+- `.claude/rules/wait-on-subagents.md` — Use `Monitor` to wait on dispatched subagents; `cat`-polling is hook-blocked at 3 occurrences (QUA-1069)
 
 Phase-loaded guidance (only fires when the corresponding skill runs):
 


### PR DESCRIPTION
## Summary

Adds a `PreToolUse` Bash hook that detects the wait-for-completion anti-pattern — repeated `cat /tmp/claude-*/.../tasks/*.output` of a dispatched subagent's task file — and forces `Monitor` instead. Blocks at the **3rd occurrence per session** with exit 2 + a `<system-reminder>` pointing at the canonical `Monitor` invocation and the `ToolSearch({ query: "select:Monitor" })` schema-load.

Per-session counter at `.claude/.poll-counts/<session_id>` (slot-local; no `/tmp` global, per PR #4812 slot-leak fix).

## Why

Full 33-day analysis (744 sessions, 76,735 bash calls) showed:
- Baseline polling rate W14–W17: 1.3–1.8% of bash calls
- W18 spike: **5.9%** (3.3× baseline) — 65% of all polling in the entire 5-week window
- Worst session (slot a9): **143 cat-polls + 133 `echo wait`** in 325 minutes

`Monitor` was available the whole time. Soft rules in CLAUDE.md didn't change behavior — agents reached for `cat` reflexively because Monitor is a deferred tool (its schema must be loaded via `ToolSearch` first). The hook simulation against actual data: would have prevented **~62%** of all observed polling (~1,495 of ~2,400 calls) by tripping in the 193 sessions that exceeded the threshold.

## Acceptance criteria

- [x] Hook script exists and registered in `.claude/settings.json` PreToolUse for Bash
- [x] End-to-end smoke test against `lw/aN` slot path (per QUA-471 lore)
- [x] Tier-1 rule added pointing at canonical `Monitor` usage
- [x] Manually verified: simulated 3 cat-polls in this session, hook fires (see below)

## Files

- `.claude/hooks/block-cat-polling.sh` — the enforcing hook
- `.claude/hooks/__tests__/test-block-cat-polling.sh` — 40-test smoke suite
- `.claude/rules/wait-on-subagents.md` — Tier-1 rule
- `.claude/settings.json` — hook registration in `PreToolUse[Bash]`
- `.gitignore` — `.claude/.poll-counts/` (per-session counters, gitignored)
- `CLAUDE.md` — rule added to always-loaded list

## Design choices

- **Threshold = 3** matches the spec; 1st/2nd matches are silent so a one-shot forensic read of a finished task file isn't punished
- **Per-session counter** keyed by `session_id` from the hook input; survives compaction/resume since session_id is stable
- **First-line-only matching** drops heredoc bodies and Python/JS string literals containing the path shape (real polls are single-line chained one-liners)
- **`-m "..."` and `-m '...'` stripping** so `git commit -m "fix cat-polling"` doesn't false-positive (same defense pattern as `block-no-verify.sh`)
- **No env-var bypass** — soft rules already failed in W18; the threshold is the enforcement
- **Slot-local state** (`.claude/.poll-counts/`, not `/tmp/<global>`) per PR #4812 slot-leak fix

## Test plan

- [x] `bash .claude/hooks/__tests__/test-block-cat-polling.sh` — 40/40 pass
  - W18 worst-case patterns (cat with `tail`, `head`, ps-chained polls)
  - tail / stat verb variants
  - Slot path detection (`lw/a9` with UUID dirs)
  - Session isolation (counters don't bleed between session_ids)
  - Negative cases (regular cat, project files, non-tasks paths)
  - Tool-name guard (Edit/Write ignored)
  - False-positive defenses (heredoc bodies, `git commit -m` messages)
  - Fail-open paths (missing session_id, unparseable input, empty input)
- [x] `pnpm crux w validate gate --scope=content --fix` — passes
- [x] End-to-end smoke test in this real slot — hook fires correctly at threshold

## References

- QUA-1069 — simulation data and rationale
- Worst-case transcript: `~/.claude/projects/-Users-ozziegooen-Documents-GitHub-nosync-lw-a9/c7413678-...jsonl`
- [12-Factor Agents](https://github.com/humanlayer/12-factor-agents) — exit between cycles, don't poll inside them

Fixes QUA-1069
