### PR TITLE
QUA-1071: deprecate /loop maintain-pr-patrol + add idle-cycle breaker

### DIFF
--- a/.claude/commands/maintain-pr-patrol.md
+++ b/.claude/commands/maintain-pr-patrol.md
@@ -1,196 +1,40 @@
 ---
-description: Scan all open PRs for issues and fix them in priority order.
-effort: medium
+description: DEPRECATED — use the launchd patrol daemon instead. Do not run patrol cycles inside a Claude session.
+effort: low
 ---
 
-# PR Patrol
+# DEPRECATED — Do Not Run Patrol In-Session
 
-Scan all open PRs for issues and fix them in priority order.
+**Stop. Do not proceed with PR patrol from inside this session.**
 
-**CONTINUOUS OPERATION:** After completing a scan+fix cycle, wait 2-3 minutes then scan again. Keep looping until the user says to stop or switches tasks. Do NOT stop after one pass and wait for re-invocation — "patrol" means continuous monitoring.
+This skill used to run continuous patrol cycles inside a single Claude Code session. That architecture caused **$1,877 in cache-read costs across 4 mega-sessions in April 2026** (QUA-1071). Each cycle in a `/loop` paid `cache_read` on the entire accumulated transcript, so 92–95% of the cost was the agent re-reading its own past, not producing new work.
 
-## Health gate — MANDATORY first step each cycle
+The fix is structural: patrol now runs as a stateless Node daemon spawned by launchd. Each fix attempt is a fresh `claude --print` child with no conversation history.
 
-Before scanning or fixing any PR, check fleet-level health. The daemon (`crux/pr-patrol/index.ts`) does this automatically at the start of `runCheckCycle`, but if you're running patrol by hand, invoke it explicitly:
+## What to do instead
 
-```bash
-pnpm exec tsx -e "import('./crux/pr-patrol/health-gate.ts').then(m => m.runHealthGate().then(d => { console.log(JSON.stringify({ proceed: d.proceed, reason: d.reason, emitted: d.emittedIssues.length }, null, 2)); process.exit(d.proceed ? 0 : 2); }))"
-```
-
-If the gate returns `proceed: false` (exit code 2), **do NOT then go fix PRs** — the gate's entire purpose is to stop the symptom-patch cycle. Note: `proceed: false` can result from any of three conditions, which emit different JSONL events (or none):
-
-- **A new unhealthy fingerprint** → emits `health_gate_tripped` + `cycle_summary{health_gate_tripped: true}`.
-- **All unhealthy fingerprints cooldown-suppressed** → still halts PR work, but emits only `cycle_summary{health_gate_tripped: true}` (no new `health_gate_tripped` event, because the same escalation was emitted within the last 30 min).
-- **Third consecutive scanner error** → emits `health_scan_error` + halts. No `health_gate_tripped` in this path.
-
-Check `~/.cache/pr-patrol/runs.jsonl` for the specific event to understand why the gate tripped before deciding how to respond.
-
-When the gate is red, **DO NOT**:
-- Bump a ratchet baseline to unblock a CI signal
-- Revert a rename because endpoints are 404ing on prod (the deploy is probably stuck, not the rename)
-- Dispatch an agent to fix a PR whose failure is a symptom of the fleet-level issue
-- Merge a "fix the fix" PR into a pipeline that's already broken
-
-Instead: escalate to the coordinator. The escalation reason names the specific subsystem (deploy pipeline, main CI, ratchet drift) and points at the prescriptive fix pattern. See `.claude/rules/patrol-health-gate.md`.
-
-Emergency escape hatch: `PATROL_DISABLE_HEALTH_GATE=1` bypasses the gate entirely. Use ONLY when the gate itself is broken, never to work around a red prod.
-
-## Branch Agent mode (Phase 1 — per-PR watchdog)
-
-For PRs needing sustained attention, use **branch-agent** instead of waiting for the daemon:
+For continuous coverage:
 
 ```bash
-pnpm crux gh pr-patrol branch-agent <PR#>   # Watch PR until fixed/merged
+./scripts/launchd/pr-patrol.sh install   # one-time, idempotent
+./scripts/launchd/pr-patrol.sh status    # check daemon liveness
+./scripts/launchd/pr-patrol.sh tail      # watch the live log
 ```
 
-This runs multiple short fix sessions (15 min each) with CI waits between them.
-Use this when a PR keeps timing out or needs several rounds of CodeRabbit feedback.
+After install you also get the `lw-patrol` shim (QUA-1037). Background: QUA-987 (launchd supervisor), QUA-1071 (this deprecation + idle-cycle breaker).
 
-## Escalation order — automation first, human last
-
-When fixing any PR, work through issues in this order:
-1. **Fix code issues** — CI failures, merge conflicts, test failures
-2. **Add labels you can verify** — e.g. `gate:rules-ok` if you've confirmed the rule is satisfied
-3. **Address ALL bot comments** — CodeRabbit Critical/Major/Minor must be attempted, not skipped
-4. **Complete unchecked checklist items** — update PR body when tasks are done
-5. **Flag for human review** — only AFTER exhausting all automated fixes
-
-## Phase 1: Scan all open PRs
-
-Fetch all open PRs and detect issues:
+For a single one-shot pass:
 
 ```bash
-gh pr list --repo quantified-uncertainty/longterm-wiki --state open --limit 50 \
-  --json number,title,headRefName,mergeable,statusCheckRollup,updatedAt,body,labels
+pnpm crux gh pr-patrol once
 ```
 
-For each PR, check **ALL THREE** of these on every cycle (not just CI):
-
-| Issue | Detection | Priority |
-|-------|-----------|----------|
-| **Merge conflict** | `mergeable == "CONFLICTING"` | P0 (score: 100) |
-| **CI failure** | `statusCheckRollup` has `FAILURE` conclusion | P1 (score: 80) |
-| **Bot review (major)** | Unresolved Major/Minor/Critical bot comment (CodeRabbit etc.) | P2 (score: 55) |
-| **Missing issue reference** | PR body lacks `Closes #N` / `Fixes #N` | P2 (score: 40) |
-| **Stale** (>48h no update) | `updatedAt` comparison | P3 (score: 30) |
-| **Missing test plan** | PR body lacks `## Test plan` section | P3 (score: 20) |
-| **Bot review (nitpick)** | Unresolved nitpick-only bot comments | P3 (score: 15) |
-
-**CRITICAL: The scan loop MUST check unresolved review threads via GraphQL on every cycle.** Checking only `gh pr checks` for CI failures misses CodeRabbit threads entirely. Use this query every cycle:
-```bash
-gh api graphql -f query='{ repository(owner: "quantified-uncertainty", name: "longterm-wiki") { pullRequests(states: OPEN, first: 20) { nodes { number reviewThreads(first: 20) { nodes { isResolved } } } } } }' --jq '.data.repository.pullRequests.nodes[] | select(.reviewThreads.nodes | map(select(.isResolved == false)) | length > 0) | "PR #\(.number): \(.reviewThreads.nodes | map(select(.isResolved == false)) | length) unresolved"'
-```
-
-**Skip PRs with the `agent:working` label** — another session is already on them.
-
-## Phase 2: Prioritize
-
-Score each PR by summing the scores of its detected issues. Sort descending. Display the full queue:
-
-```text
-Priority queue (N items):
-  [score=180] PR #123: conflict,ci-failure — Fix authentication flow
-  [score=40]  PR #456: missing-issue-ref — Update entity types
-```
-
-### Cross-PR dependency chain (QUA-287 Phase 3)
-
-When a PR appears to depend on another open PR (detected via GitHub cross-reference events or `#NNNN` tokens in CI/gate error output that validate against the open-PR list), the queue renders a dependency arrow:
-
-```text
-Priority queue (N items):
-  [score=135] PR #4188: stuck                                    — Baseline schema bump
-  [score=80]  PR #4157: ci-failure → blocked on #4188            — Feature A on new schema
-  [score=80]  PR #4162: ci-failure → blocked on #4188, #4190     — Feature B on new schema
-```
-
-This surfaces "Miss #4" from QUA-284: when one baseline-bump PR holds up multiple siblings, the queue now makes that explicit. Sources of the cross-PR link (in order of trust):
-
-1. **GitHub `CrossReferencedEvent` timeline items** (reason: `cross-referenced`) — most reliable; fired when another PR mentions this one.
-2. **`#NNNN` tokens in failing check/gate output** (reason: `gate error`) — validated against the open-PR list to drop incidental mentions.
-3. **`#NNNN` tokens in bot-review comment bodies** (reason: `bot comment`) — same validation.
-
-### Priority boost for stuck blockers
-
-If a PR has `stuckCycles >= 3` AND is listed as `blocked on` by ≥2 other PRs, it gets a `BLOCKING_STUCK_BONUS` (+50) on top of its issue-based score. This ensures a stuck baseline-bump PR that's holding up multiple siblings surfaces at the top of the queue, not buried behind individual CI-failure PRs.
-
-Implementation: `rankPrsWithDeps()` in `crux/pr-patrol/scoring.ts`.
-
-## Phase 3: Fix (one PR at a time)
-
-Work through the queue starting with the highest-priority PR.
-
-**IMPORTANT: Never `git checkout` PR branches in the current directory.** This causes branch confusion in multi-session slots. Use one of these isolation strategies:
-
-**Option A (preferred): Spawn a subagent with worktree isolation.**
-For each PR fix, use the Agent tool with `isolation: "worktree"`. The subagent gets an isolated copy of the repo and can safely checkout the PR branch without affecting the parent session.
-
-**Option B: Use git worktrees manually.**
-```bash
-git worktree add /tmp/pr-fix-<N> <branch>
-# ... make fixes in /tmp/pr-fix-<N> ...
-cd /tmp/pr-fix-<N> && git push
-git worktree remove /tmp/pr-fix-<N>
-```
-
-**Option C: For metadata-only fixes (PR body edits, labels), use `gh` CLI.**
-These don't require checking out the branch at all.
-
-### Merge conflicts
-1. Spawn a subagent (worktree-isolated) or create a worktree for the PR branch
-2. Rebase on main: `git rebase origin/main`
-3. Resolve conflicts — prefer the PR's changes where intent is clear
-4. For generated files (database.json, lock files), regenerate: `pnpm build-data:content`
-5. `git rebase --continue` then `git push --force-with-lease`
-
-### CI failures
-1. Check what failed: `gh pr checks <N>`
-2. Read CI logs to understand the failure
-3. Spawn a subagent (worktree-isolated) to fix the issue, verify with `pnpm build` / `pnpm test`
-4. Subagent commits and pushes
-
-### Bot review comments (CodeRabbit etc.)
-1. Bot comment details are included directly in the fix prompt (fetched via GraphQL `reviewThreads`)
-2. For Major/Minor/Critical issues: verify the concern is valid, then fix (in a worktree-isolated subagent)
-3. For Nitpick issues: fix only if trivial and clearly correct
-4. Look for "Prompt for AI Agents" sections — they contain ready-made fix instructions
-
-### Missing test plan
-1. Read the PR diff to understand what changed
-2. Add a `## Test plan` section to the PR body via `gh pr edit` (no checkout needed)
-
-### Missing issue reference
-1. Search for related issues: `gh issue list --search "keywords"`
-2. If a match exists, add `Closes #N` to the PR body (no checkout needed)
-3. If no match, skip — not all PRs need an issue
-
-### Stale PRs
-1. Rebase on main in a worktree to pick up latest changes
-2. Push to re-trigger CI
-
-## Phase 4: Report
-
-After processing, summarize:
-- How many PRs were scanned
-- What issues were found and fixed
-- What's still in the queue (if any)
-
-## Guardrails
-
-- **One PR at a time.** Finish one fix before starting the next.
-- **Only fix detected issues.** Don't refactor or improve unrelated code on the PR's branch.
-- **Use `--force-with-lease`** not `--force` when pushing rebased branches.
-- **Don't dismiss reviews.** Fix the requested changes and let the reviewer re-approve.
-- **If a conflict is too complex**, note it and move to the next PR.
-- **Run `pnpm crux w validate gate --fix`** after any code changes.
-
-## Daemon mode
-
-For continuous monitoring, use the crux command:
+For a single PR's automated fix cycle:
 
 ```bash
-pnpm crux gh pr-patrol                       # 5-min interval, continuous
-pnpm crux gh pr-patrol once                  # Single pass
-pnpm crux gh pr-patrol once --dry-run        # Preview only
-pnpm crux gh pr-patrol --interval=120        # Custom interval
+pnpm crux gh pr-patrol branch-agent <PR#>
 ```
+
+## If you landed here from `/loop maintain-pr-patrol`
+
+Reply to the user that this skill is deprecated and ask them to install the launchd daemon (above) instead. Do **not** scan PRs in a loop from this session — that is exactly the pattern this deprecation exists to prevent.

--- a/crux/pr-patrol/idle-tracker.test.ts
+++ b/crux/pr-patrol/idle-tracker.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createIdleState,
+  nextCycle,
+  type IdleTrackerConfig,
+} from './idle-tracker.ts';
+
+const CONFIG: IdleTrackerConfig = {
+  tripThreshold: 20,
+  baseSleepSeconds: 30,
+  maxSleepSeconds: 1800,
+};
+
+describe('idle-tracker', () => {
+  it('starts at streak 0', () => {
+    expect(createIdleState()).toEqual({ noOpStreak: 0 });
+  });
+
+  it('didWork keeps streak at 0 and uses base sleep', () => {
+    const result = nextCycle(createIdleState(), true, CONFIG);
+    expect(result.state.noOpStreak).toBe(0);
+    expect(result.sleepSeconds).toBe(30);
+    expect(result.justTripped).toBe(false);
+  });
+
+  it('no-op increments streak but keeps base sleep below threshold', () => {
+    let state = createIdleState();
+    for (let i = 1; i < 20; i++) {
+      const r = nextCycle(state, false, CONFIG);
+      expect(r.state.noOpStreak).toBe(i);
+      expect(r.sleepSeconds).toBe(30);
+      expect(r.justTripped).toBe(false);
+      state = r.state;
+    }
+  });
+
+  it('engages exactly once at the threshold', () => {
+    let state = createIdleState();
+    let trips = 0;
+    for (let i = 1; i <= 25; i++) {
+      const r = nextCycle(state, false, CONFIG);
+      if (r.justTripped) trips++;
+      state = r.state;
+    }
+    expect(trips).toBe(1);
+  });
+
+  it('justTripped fires on the K=20 boundary', () => {
+    let state = createIdleState();
+    let result;
+    for (let i = 0; i < 20; i++) {
+      result = nextCycle(state, false, CONFIG);
+      state = result.state;
+    }
+    expect(result!.state.noOpStreak).toBe(20);
+    expect(result!.justTripped).toBe(true);
+    expect(result!.sleepSeconds).toBe(30); // base * 2^0
+  });
+
+  it('doubles sleep on each cycle past the threshold', () => {
+    let state: { noOpStreak: number } = { noOpStreak: 20 };
+    const sleeps: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const r = nextCycle(state, false, CONFIG);
+      sleeps.push(r.sleepSeconds);
+      state = r.state;
+    }
+    // streak=21,22,23,24,25 → overshoot=1,2,3,4,5 → sleep=60,120,240,480,960
+    expect(sleeps).toEqual([60, 120, 240, 480, 960]);
+  });
+
+  it('caps sleep at maxSleepSeconds', () => {
+    let state: { noOpStreak: number } = { noOpStreak: 25 };
+    for (let i = 0; i < 10; i++) {
+      const r = nextCycle(state, false, CONFIG);
+      state = r.state;
+      expect(r.sleepSeconds).toBeLessThanOrEqual(CONFIG.maxSleepSeconds);
+    }
+  });
+
+  it('stays at max sleep deep into the streak', () => {
+    let state: { noOpStreak: number } = { noOpStreak: 100 };
+    const r = nextCycle(state, false, CONFIG);
+    expect(r.sleepSeconds).toBe(CONFIG.maxSleepSeconds);
+  });
+
+  it('didWork after backoff resets streak and base sleep', () => {
+    let state: { noOpStreak: number } = { noOpStreak: 30 };
+    const r = nextCycle(state, true, CONFIG);
+    expect(r.state.noOpStreak).toBe(0);
+    expect(r.sleepSeconds).toBe(30);
+    expect(r.justTripped).toBe(false);
+  });
+
+  it('justTripped does not re-fire after the boundary', () => {
+    let state: { noOpStreak: number } = { noOpStreak: 20 };
+    for (let i = 0; i < 5; i++) {
+      const r = nextCycle(state, false, CONFIG);
+      expect(r.justTripped).toBe(false);
+      state = r.state;
+    }
+  });
+
+  it('justTripped re-arms after a work cycle resets the streak', () => {
+    let state: { noOpStreak: number } = { noOpStreak: 19 };
+    const trip1 = nextCycle(state, false, CONFIG);
+    expect(trip1.justTripped).toBe(true);
+    const reset = nextCycle(trip1.state, true, CONFIG);
+    expect(reset.state.noOpStreak).toBe(0);
+    // Climb back up: now at streak 0, need 20 more no-ops to trip again.
+    state = reset.state;
+    for (let i = 0; i < 19; i++) state = nextCycle(state, false, CONFIG).state;
+    const trip2 = nextCycle(state, false, CONFIG);
+    expect(trip2.justTripped).toBe(true);
+  });
+
+  it('handles tripThreshold=1 (degenerate but valid)', () => {
+    const cfg = { ...CONFIG, tripThreshold: 1 };
+    const r = nextCycle(createIdleState(), false, cfg);
+    expect(r.justTripped).toBe(true);
+    expect(r.sleepSeconds).toBe(cfg.baseSleepSeconds);
+  });
+
+  it('handles base=max (no backoff possible)', () => {
+    const cfg = { ...CONFIG, baseSleepSeconds: 60, maxSleepSeconds: 60 };
+    let state: { noOpStreak: number } = { noOpStreak: 30 };
+    const r = nextCycle(state, false, cfg);
+    expect(r.sleepSeconds).toBe(60);
+  });
+
+  it('clamps to base when misconfigured base > max (defensive)', () => {
+    // base=2400 > max=1800: cap would shorten the base interval, which
+    // is wrong. The clamp keeps sleep >= base.
+    const cfg = { ...CONFIG, baseSleepSeconds: 2400, maxSleepSeconds: 1800 };
+    let state: { noOpStreak: number } = { noOpStreak: 30 };
+    const r = nextCycle(state, false, cfg);
+    expect(r.sleepSeconds).toBeGreaterThanOrEqual(cfg.baseSleepSeconds);
+  });
+});

--- a/crux/pr-patrol/idle-tracker.ts
+++ b/crux/pr-patrol/idle-tracker.ts
@@ -1,0 +1,88 @@
+/**
+ * Idle-cycle circuit breaker for the PR patrol daemon.
+ *
+ * Background (QUA-1071): patrol cycles every `intervalSeconds` even when the
+ * PR queue is empty. Each cycle does GraphQL fetches, deploy-health checks,
+ * etc. — cheap individually but pointless when there's nothing to do. After
+ * `tripThreshold` consecutive no-op cycles the breaker engages and the daemon
+ * exponentially backs off the inter-cycle sleep up to `maxSleepSeconds`. Any
+ * cycle that does real work (a PR fix, a main-branch fix, a merge enqueue,
+ * an undraft) resets the streak and restores `baseSleepSeconds`.
+ *
+ * The state is intentionally in-memory: a daemon restart resets the streak,
+ * which is the correct behavior — restarts imply a new opportunity to find
+ * work, and the supervisor's 30s respawn cadence already provides a floor.
+ */
+
+export interface IdleTrackerState {
+  /** Number of consecutive cycles where no work was done. */
+  noOpStreak: number;
+}
+
+export interface IdleTrackerConfig {
+  /** Streak length at which the breaker engages. AC #4 of QUA-1071: K=20. */
+  tripThreshold: number;
+  /** Sleep before next cycle when no backoff is active. */
+  baseSleepSeconds: number;
+  /** Maximum sleep after exponential backoff. Cap so the daemon never goes silent for hours. */
+  maxSleepSeconds: number;
+}
+
+export interface IdleTrackerStep {
+  state: IdleTrackerState;
+  /** Sleep duration in seconds before the next cycle. */
+  sleepSeconds: number;
+  /** True only on the cycle that crossed the threshold (single-shot). */
+  justTripped: boolean;
+}
+
+export const DEFAULT_TRIP_THRESHOLD = 20;
+export const DEFAULT_MAX_SLEEP_SECONDS = 30 * 60;
+
+export function createIdleState(): IdleTrackerState {
+  return { noOpStreak: 0 };
+}
+
+/**
+ * Compute the next state and sleep duration after a cycle.
+ *
+ * - `didWork = true` resets the streak and uses base sleep.
+ * - Below `tripThreshold`: streak increments, sleep stays at base.
+ * - At/above `tripThreshold`: sleep doubles for each cycle past the threshold,
+ *   capped at `maxSleepSeconds`. Formula: base * 2^(streak - threshold).
+ */
+export function nextCycle(
+  state: IdleTrackerState,
+  didWork: boolean,
+  config: IdleTrackerConfig,
+): IdleTrackerStep {
+  if (didWork) {
+    return {
+      state: { noOpStreak: 0 },
+      sleepSeconds: config.baseSleepSeconds,
+      justTripped: false,
+    };
+  }
+  const newStreak = state.noOpStreak + 1;
+  if (newStreak < config.tripThreshold) {
+    return {
+      state: { noOpStreak: newStreak },
+      sleepSeconds: config.baseSleepSeconds,
+      justTripped: false,
+    };
+  }
+  const overshoot = newStreak - config.tripThreshold;
+  const desired = config.baseSleepSeconds * Math.pow(2, overshoot);
+  // Clamp to [base, max]. Backoff must never shorten the base interval —
+  // it can only grow it. This protects against misconfig where
+  // baseSleepSeconds > maxSleepSeconds.
+  const sleepSeconds = Math.max(
+    config.baseSleepSeconds,
+    Math.min(desired, config.maxSleepSeconds),
+  );
+  return {
+    state: { noOpStreak: newStreak },
+    sleepSeconds,
+    justTripped: newStreak === config.tripThreshold,
+  };
+}

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -345,10 +345,19 @@ function preflightChecks(config: PatrolConfig): string[] {
 // ── Check cycle ──────────────────────────────────────────────────────────────
 
 /**
- * Outcome of a single check cycle. `didWork = true` means the daemon performed
- * something potentially queue-shrinking (PR fix, main-branch fix, merge enqueue,
- * undraft). The idle-cycle circuit breaker (QUA-1071) uses this to drive
- * exponential backoff after K=20 consecutive `didWork = false` cycles.
+ * Outcome of a single check cycle. `didWork = true` means the cycle should
+ * count against the idle-cycle circuit breaker (QUA-1071), i.e. the breaker
+ * resets and stays at base interval. Two flavors of "work":
+ *
+ *   1. Queue-shrinking work: a PR was processed, a merge was enqueued, or a
+ *      draft was undrafted. Computed at the bottom of `runCheckCycle`.
+ *   2. Active-but-non-queue-shrinking signals: health-gate tripped, main-branch
+ *      fix attempted. Returned via the early-return paths so the daemon keeps
+ *      polling at base interval to detect fleet recovery — backing off when
+ *      the fleet is unhealthy would extend MTTR.
+ *
+ * The breaker drives exponential backoff after K=20 consecutive
+ * `didWork = false` cycles.
  */
 export interface CheckCycleResult {
   didWork: boolean;
@@ -665,8 +674,9 @@ async function runCheckCycle(
 
   // ── Cycle summary ──────────────────────────────────────────────────
 
-  // A cycle "did work" if it actually moved the queue forward. Idle-cycle
-  // breaker (QUA-1071) treats the inverse of this as a no-op.
+  // Queue-shrinking work this cycle. The early-return paths above (health-gate
+  // tripped, main-branch fix) handle their own `didWork` per CheckCycleResult's
+  // contract — see the JSDoc on the interface for the full taxonomy.
   const didWork =
     fixedPr !== null ||
     enqueuedPrs.length > 0 ||
@@ -784,9 +794,16 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
       const cycleResult = await runCheckCycle(cycleCount, config);
       didWork = cycleResult.didWork;
     } catch (e) {
-      log(
-        `${cl.red}Check cycle failed: ${e instanceof Error ? e.message : String(e)}${cl.reset}`,
-      );
+      const msg = e instanceof Error ? e.message : String(e);
+      log(`${cl.red}Check cycle failed: ${msg}${cl.reset}`);
+      // Persist the failure to JSONL so the breaker's eventual engagement is
+      // attributable to a stream of errors rather than a "no work needed"
+      // streak. The normal cycle_summary won't have run when this throws.
+      appendJsonl(JSONL_FILE_INTERNAL, {
+        type: 'cycle_error',
+        cycle_number: cycleCount,
+        error: msg,
+      });
     }
 
     // Periodic reflection
@@ -801,8 +818,11 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
     const step = nextIdleCycle(idleState, didWork, idleConfig);
     idleState = step.state;
     if (step.justTripped) {
+      // The engagement cycle itself sleeps at base interval (overshoot=0);
+      // backoff doubles starting on the next idle cycle. Be honest about
+      // that in the log so operators reading it don't expect immediate growth.
       log(
-        `${cl.yellow}⚠ Idle-cycle breaker engaged after ${idleState.noOpStreak} no-op cycles — exponentially backing off (max ${idleConfig.maxSleepSeconds}s).${cl.reset}`,
+        `${cl.yellow}⚠ Idle-cycle breaker engaged after ${idleState.noOpStreak} no-op cycles — sleeping ${step.sleepSeconds}s now; backoff begins next cycle (max ${idleConfig.maxSleepSeconds}s).${cl.reset}`,
       );
       appendJsonl(JSONL_FILE_INTERNAL, {
         type: 'idle_breaker_engaged',

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -122,6 +122,12 @@ import { checkDeployHealth as libCheckDeployHealth } from '../lib/pr-analysis/de
 import type { DeployHealthStatus } from '../lib/pr-analysis/deploy-status.ts';
 import { runHealthGate } from './health-gate.ts';
 import { runReflection } from './reflection.ts';
+import {
+  createIdleState,
+  nextCycle as nextIdleCycle,
+  DEFAULT_TRIP_THRESHOLD,
+  DEFAULT_MAX_SLEEP_SECONDS,
+} from './idle-tracker.ts';
 
 const cl = getColors();
 
@@ -338,10 +344,20 @@ function preflightChecks(config: PatrolConfig): string[] {
 
 // ── Check cycle ──────────────────────────────────────────────────────────────
 
+/**
+ * Outcome of a single check cycle. `didWork = true` means the daemon performed
+ * something potentially queue-shrinking (PR fix, main-branch fix, merge enqueue,
+ * undraft). The idle-cycle circuit breaker (QUA-1071) uses this to drive
+ * exponential backoff after K=20 consecutive `didWork = false` cycles.
+ */
+export interface CheckCycleResult {
+  didWork: boolean;
+}
+
 async function runCheckCycle(
   cycleCount: number,
   config: PatrolConfig,
-): Promise<void> {
+): Promise<CheckCycleResult> {
   logHeader(`Check cycle #${cycleCount}`);
 
   // 0. Health gate (QUA-300 Phase 3) — check fleet-level signals FIRST.
@@ -360,7 +376,9 @@ async function runCheckCycle(
       health_gate_tripped: true,
       health_gate_reason: gate.reason,
     });
-    return;
+    // Health-gate halts the queue but is itself a real signal — count as work
+    // so the idle breaker doesn't back off when the fleet is actively unhealthy.
+    return { didWork: true };
   }
 
   // 0a. Check if a tracked main-branch fix PR has been merged
@@ -402,7 +420,7 @@ async function runCheckCycle(
       pr_processed: null,
       main_branch_fix: true,
     });
-    return; // Main takes the whole cycle; PRs wait
+    return { didWork: true }; // Main takes the whole cycle; PRs wait
   }
 
   // 0b. Check deploy health
@@ -647,6 +665,13 @@ async function runCheckCycle(
 
   // ── Cycle summary ──────────────────────────────────────────────────
 
+  // A cycle "did work" if it actually moved the queue forward. Idle-cycle
+  // breaker (QUA-1071) treats the inverse of this as a no-op.
+  const didWork =
+    fixedPr !== null ||
+    enqueuedPrs.length > 0 ||
+    undraftedNumbers.size > 0;
+
   appendJsonl(JSONL_FILE_INTERNAL, {
     type: 'cycle_summary',
     cycle_number: cycleCount,
@@ -662,7 +687,9 @@ async function runCheckCycle(
     merge_eligible: eligibleForMerge.length,
     deploy_healthy: deployHealth.healthy,
     deploy_failing_since: deployHealth.failingSince ?? undefined,
+    did_work: didWork,
   });
+  return { didWork };
 }
 
 // ── Daemon loop ─────────────────────────────────────────────────────────────
@@ -740,10 +767,22 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
   }
 
   let cycleCount = 0;
+  let idleState = createIdleState();
+  const idleConfig = {
+    tripThreshold: DEFAULT_TRIP_THRESHOLD,
+    baseSleepSeconds: config.intervalSeconds,
+    maxSleepSeconds: DEFAULT_MAX_SLEEP_SECONDS,
+  };
+
   while (!shuttingDown) {
     cycleCount++;
+    // A check-cycle exception is treated as no-op so a persistent error
+    // (e.g. GitHub auth dropped) progresses the breaker toward backoff
+    // rather than spinning at base interval forever.
+    let didWork = false;
     try {
-      await runCheckCycle(cycleCount, config);
+      const cycleResult = await runCheckCycle(cycleCount, config);
+      didWork = cycleResult.didWork;
     } catch (e) {
       log(
         `${cl.red}Check cycle failed: ${e instanceof Error ? e.message : String(e)}${cl.reset}`,
@@ -759,8 +798,26 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
       }
     }
 
-    log(`${cl.dim}Sleeping ${config.intervalSeconds}s until next check...${cl.reset}`);
-    await new Promise((r) => setTimeout(r, config.intervalSeconds * 1000));
+    const step = nextIdleCycle(idleState, didWork, idleConfig);
+    idleState = step.state;
+    if (step.justTripped) {
+      log(
+        `${cl.yellow}⚠ Idle-cycle breaker engaged after ${idleState.noOpStreak} no-op cycles — exponentially backing off (max ${idleConfig.maxSleepSeconds}s).${cl.reset}`,
+      );
+      appendJsonl(JSONL_FILE_INTERNAL, {
+        type: 'idle_breaker_engaged',
+        cycle_number: cycleCount,
+        no_op_streak: idleState.noOpStreak,
+        next_sleep_seconds: step.sleepSeconds,
+      });
+    } else if (idleState.noOpStreak > idleConfig.tripThreshold) {
+      log(
+        `${cl.dim}Idle ${idleState.noOpStreak} cycles — sleeping ${step.sleepSeconds}s.${cl.reset}`,
+      );
+    } else {
+      log(`${cl.dim}Sleeping ${step.sleepSeconds}s until next check...${cl.reset}`);
+    }
+    await new Promise((r) => setTimeout(r, step.sleepSeconds * 1000));
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes QUA-1071 (framing A — narrow scope). Addresses the structural anti-pattern that produced **$1,877 in cache-read costs across 4 mega-sessions** in April 2026.

**Two changes:**

1. **Deprecate `/loop maintain-pr-patrol`** — the in-Claude-session loop pattern was the actual cause of the incident (each cycle paid `cache_read` on the entire growing transcript). The skill is now a hard-stop pointer to the launchd daemon (already shipped in QUA-987). The daemon is structurally stateless: each fix attempt is a fresh `claude --print` child with no conversation history.

2. **Idle-cycle circuit breaker on the daemon** (AC #4) — after K=20 consecutive no-op cycles (no PR processed, no merge enqueued, no draft undrafted), the daemon exponentially backs off the inter-cycle sleep up to 30 minutes. Any work cycle resets the streak to base interval. State is in-memory; daemon restart resets the streak.

## Empirical context

The W16/W18 patrol cohort (161 + 160 sessions) already runs the right architecture and costs $1.34/session. The W14/W15 mega-sessions ($469/session avg) all came from the in-Claude-session `/loop` pattern. So the daemon was already doing the right thing — the bleed was a parallel pathway that this PR removes.

## Deferred to QUA-1078

Acceptance criteria #2 (inline budget cap) and #5 (50k input-token kill) require migrating `spawnClaude` from text-mode `--print --verbose` to `--output-format stream-json`. Six callers parse `result.output` for noOp / fix-PR / stop signals, and the operator's `tail -f run.log` UX needs a re-renderer to keep working. Since the daemon doesn't have the cache-accumulation problem (each spawn is fresh), the inline cap is defense-in-depth rather than fixing an active bleed — split out as QUA-1078.

AC #3 (stream-json fan-out within cycle) and AC #6 (PG-persisted state) are out of scope for framing A.

## Files

- `crux/pr-patrol/idle-tracker.ts` (new) — pure helper for the breaker logic
- `crux/pr-patrol/idle-tracker.test.ts` (new) — 14 unit tests covering streak counting, threshold engagement (single-shot trip), exponential backoff, max-sleep cap, work-resets-streak, and the misconfigured `base > max` case
- `crux/pr-patrol/index.ts` — `runCheckCycle` now returns `{ didWork: boolean }`; `runDaemon` wires the idle tracker into the outer loop
- `.claude/commands/maintain-pr-patrol.md` — replaced 196 lines of in-session patrol instructions with a deprecation pointer to the daemon

## Test plan

- [x] 14 new idle-tracker unit tests pass
- [x] All 488 existing pr-patrol tests still pass (no regressions)
- [x] Skill deprecation: frontmatter `description` updated; Claude Code's skill list now shows `maintain-pr-patrol: DEPRECATED — use the launchd patrol daemon instead`
- [ ] Live verification: install the daemon and observe a real backoff (not done in this PR — would require letting the daemon idle for 10+ minutes against a real empty queue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
