### PR TITLE
fix(deploy): guard root postinstall against missing crux/build.mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "setup": "bash scripts/setup.sh",
     "setup:quick": "bash scripts/setup.sh --quick",
     "setup:check": "bash scripts/setup.sh --check",
-    "postinstall": "node -e \"try{require.resolve('esbuild')}catch{process.exit(0)}\" && node crux/build.mjs",
+    "postinstall": "node -e \"try{require('fs').accessSync('crux/build.mjs');require.resolve('esbuild')}catch{process.exit(0)}\" && node crux/build.mjs",
     "prepare": "git config core.hooksPath .githooks || true; git config merge.drizzle-journal.driver 'node crux/git/drizzle-journal-merge.mjs %O %A %B %P' || true"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Hotfix for the 2026-05-03 release. The QUA-1053 root `postinstall` script (`node crux/build.mjs`) breaks any sub-app Dockerfile that copies the root `package.json` before the `crux/` directory.

This blocked PR #4840: **wiki-server, discord-bot, and groundskeeper** all failed at `pnpm install --frozen-lockfile --filter X` with:

```
. postinstall: Error: Cannot find module '/repo/crux/build.mjs'
```

Worker survived because `Dockerfile.worker` uses an isolated `docker/worker/package.json`, not the repo root one.

## The fix

Add an `accessSync('crux/build.mjs')` guard so the postinstall is a no-op when the file is absent.

```diff
-"postinstall": "node -e \"try{require.resolve('esbuild')}catch{process.exit(0)}\" && node crux/build.mjs",
+"postinstall": "node -e \"try{require('fs').accessSync('crux/build.mjs');require.resolve('esbuild')}catch{process.exit(0)}\" && node crux/build.mjs",
```

- Dev / CI / Worker (file present + esbuild resolvable) → builds dist as before. No behavior change.
- Sub-app Docker layers (file missing) → silently exits 0. Build proceeds.

## Verification

```
$ node -e "try{require('fs').accessSync('crux/build.mjs');require.resolve('esbuild');console.log('present-path: would run build')}catch(e){console.log('absent-path: would exit 0',e.message)}"
present-path: would run build

$ cd /tmp/no-crux && node -e "..."
absent-path: would exit 0 - ENOENT: no such file or directory, access 'crux/build.mjs'
```

## Why this is being shipped via release-time hotfix

Production state during this incident:
- Old wiki-server image still serving (uptime ~28h confirms no rollover)
- ArgoCD attempted sync, migration job hung 5+ minutes against the old image
- Migration `0223` (pipeline_runs cost columns) **not** yet applied to prod
- Worker did get the new image (its Dockerfile is unaffected)

After this PR merges, a new release PR (main → production) will re-trigger the docker builds with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)