### PR TITLE
fix(agent-checklist): exit 0 on missing checklist for `complete`

### DIFF
--- a/crux/commands/agent-checklist.test.ts
+++ b/crux/commands/agent-checklist.test.ts
@@ -809,11 +809,13 @@ describe('agent-checklist complete', () => {
     vi.clearAllMocks();
   });
 
-  it('returns error when no checklist file exists', async () => {
+  it('exits 0 with a friendly no-op note when no checklist file exists (QUA-1074)', async () => {
+    // /agent-end calls `agent-checklist complete 2>/dev/null || true` — exit 1 here pollutes
+    // logs and was getting miscounted as a 10× failure spike by transcript scanners.
     mockExistsSync.mockReturnValue(false);
     const result = await commands.complete([], {});
-    expect(result.exitCode).toBe(1);
-    expect(result.output).toContain('No checklist found');
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('nothing to complete');
   });
 
   it('exits 1 when unchecked items remain', async () => {

--- a/crux/commands/agent-checklist.ts
+++ b/crux/commands/agent-checklist.ts
@@ -487,7 +487,9 @@ async function complete(_args: string[], options: CommandOptions): Promise<Comma
   const c = log.colors;
 
   if (!existsSync(CHECKLIST_PATH)) {
-    return { output: `${c.red}No checklist found.${c.reset}\n`, exitCode: 1 };
+    // Exit 0: /agent-end calls this as a best-effort no-op (`complete 2>/dev/null || true`).
+    // Exiting 1 here pollutes logs and gets miscounted as failures by transcript scanners. See QUA-1074.
+    return { output: `${c.dim}No checklist found — nothing to complete.${c.reset}\n`, exitCode: 0 };
   }
 
   const markdown = readFileSync(CHECKLIST_PATH, 'utf-8');


### PR DESCRIPTION
## Summary

`/agent-end` invokes `pnpm crux sys agent-checklist complete 2>/dev/null || true` as a best-effort no-op, but the inner exit 1 was polluting logs and being miscounted as a 10× failure spike by transcript scanners. Treat "no checklist file" as a clean no-op: dim friendly note, exit 0.

Real validation paths still behave correctly:
- Unchecked items remain → exit 1 (unchanged)
- All items checked → exit 0 (unchanged)
- `/agent-ship` still gates on `complete` returning 0 (the missing-file branch never fires there because init created the file)

Per the correction comment on QUA-1074, the original "Option B / add a complete subcommand" framing was based on a false premise — `complete` already exists. This is the actual 2-line fix.

## Test plan

- [x] Updated unit test for the missing-checklist branch (now expects exit 0 + "nothing to complete")
- [x] All 52 tests in `agent-checklist.test.ts` pass
- [x] CLI smoke test: exercised all 3 branches end-to-end (missing → exit 0, unchecked → exit 1, all-checked → exit 0)
- [x] Gate passes (71 checks)
- [x] Typecheck on apps/web, wiki-server, crux: no new errors in changed files

## Notes

- Filed QUA-1079 for unrelated stale-snapshot test failures observed during `pnpm test` (4 failures in `crux/wiki-server/snapshot-resources.test.ts`, all pre-existing baseline noise from a stale gitignored snapshot).

Fixes QUA-1074
