### PR TITLE
fix(deploy): use POSIX shell guard in root postinstall (v2 hotfix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "setup": "bash scripts/setup.sh",
     "setup:quick": "bash scripts/setup.sh --quick",
     "setup:check": "bash scripts/setup.sh --check",
-    "postinstall": "node -e \"try{require('fs').accessSync('crux/build.mjs');require.resolve('esbuild')}catch{process.exit(0)}\" && node crux/build.mjs",
+    "postinstall": "if [ -f crux/build.mjs ]; then node crux/build.mjs; fi",
     "prepare": "git config core.hooksPath .githooks || true; git config merge.drizzle-journal.driver 'node crux/git/drizzle-journal-merge.mjs %O %A %B %P' || true"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

PR #4846 (v1 hotfix) **did not work**. `process.exit(0)` exits *successfully*, so the `&&` proceeds to `node crux/build.mjs` regardless — and that crashes with `MODULE_NOT_FOUND` whenever `crux/build.mjs` isn't on disk. Discord-bot and groundskeeper failed *again* on the workflow_dispatch reruns after #4848 merged.

The original QUA-1053 postinstall pattern was logically broken from day one. It only "worked" in dev / CI / Worker because those contexts always have `crux/` on disk.

## The fix

Replace the `node -e ... && node crux/build.mjs` chain with a POSIX shell `if`, which actually short-circuits when the file is absent:

```diff
-"postinstall": "node -e \"try{require('fs').accessSync('crux/build.mjs');require.resolve('esbuild')}catch{process.exit(0)}\" && node crux/build.mjs",
+"postinstall": "if [ -f crux/build.mjs ]; then node crux/build.mjs; fi",
```

## Verification

```
$ cd /tmp && sh -c 'if [ -f crux/build.mjs ]; then echo would-build; fi'; echo "exit=$?"
exit=0

$ cd lw/main && sh -c 'if [ -f crux/build.mjs ]; then echo would-build; fi'; echo "exit=$?"
would-build
exit=0
```

Once merged, a new release PR will re-trigger the wiki-server / discord-bot / groundskeeper docker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)