### PR TITLE
qua-1081: prevent root postinstall regressions in sub-app docker builds

### DIFF
--- a/.github/workflows/sub-app-docker-smoke.yml
+++ b/.github/workflows/sub-app-docker-smoke.yml
@@ -1,40 +1,48 @@
 name: Sub-app Dockerfile smoke test
 
-# Builds one representative sub-app Dockerfile (discord-bot, the smallest) on
-# any PR that could regress the root `postinstall` script's behavior inside a
-# sub-app docker install layer. The three sub-app images
-# (apps/wiki-server, apps/discord-bot, apps/groundskeeper) all COPY the root
-# package.json before crux/ is on disk and then run `pnpm install --filter X`,
-# which fires the root postinstall. If that script references files not yet
-# copied, the build crashes — exactly what broke the 2026-05-03 release
-# (QUA-1053 / postmortem QUA-1081).
+# Builds one representative sub-app Dockerfile (discord-bot — fewest workspace
+# deps before the install layer) on any PR that could regress the root
+# `postinstall` script's behavior inside a sub-app docker install layer.
+# The three sub-app images (apps/wiki-server, apps/discord-bot,
+# apps/groundskeeper) all COPY the root package.json before crux/ is on disk
+# and then run `pnpm install --filter X`, which fires the root postinstall.
+# If that script references files not yet copied, the build crashes — exactly
+# what broke the 2026-05-03 release (QUA-1053 / postmortem QUA-1081).
 #
-# Discord-bot is chosen because it's the cheapest of the three (smallest image,
-# fewest workspace deps) but exercises the same install layer.
+# Discord-bot is chosen because it has the fewest workspace dependencies
+# (no `packages/*` deps in its install filter) so the install layer is the
+# fastest to build of the three. Its produced image is actually larger than
+# groundskeeper's (it bakes content/docs and data/ for the /ask command), but
+# what we care about here is what runs *during install*, not image size.
 #
 # See docs/agent-rules/dockerfile-postinstall-trap.md for the full pattern.
 
 on:
   pull_request:
+    branches: [main]
     paths:
       # Root manifest / lockfile changes are the QUA-1053 failure shape — they
       # affect every sub-app's install layer.
       - "package.json"
       - "pnpm-lock.yaml"
-      # Discord-bot's own Dockerfile + workspace package.json — we're building
-      # this image, so changes that affect its install path should be tested.
-      - "apps/discord-bot/Dockerfile"
+      # Any sub-app Dockerfile change — including a *new* sub-app — should run
+      # the smoke test, because new Dockerfiles introduced after this workflow
+      # may re-encounter the same install-layer trap.
+      - "apps/*/Dockerfile"
+      # Discord-bot's workspace package.json — we're building this image, so a
+      # change to its scripts could break the install layer.
       - "apps/discord-bot/package.json"
       - ".github/workflows/sub-app-docker-smoke.yml"
 
 concurrency:
-  group: sub-app-docker-smoke-${{ github.event.pull_request.number || github.sha }}
+  group: sub-app-docker-smoke-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   build:
     name: Build discord-bot Dockerfile (no push)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 
@@ -50,8 +58,17 @@ jobs:
           context: .
           file: apps/discord-bot/Dockerfile
           push: false
-          # Reuse the same cache scope as the production discord-bot build so
-          # this PR check piggybacks on warm layers when nothing in the install
-          # path has changed.
+          # READ from the production discord-bot scope so PR builds can reuse
+          # warm layers from the most recent prod build (e.g. when only the
+          # postinstall script changed but pnpm-lock.yaml didn't, the install
+          # layer's content hash matches and pnpm-store + node_modules are
+          # cached). PR builds cannot poison this scope: GHA cache enforces
+          # branch isolation, so writes from PR contexts only land in the
+          # PR-scoped namespace.
           cache-from: type=gha,scope=discord-bot
-          cache-to: type=gha,scope=discord-bot-smoke,mode=max
+          # WRITE to a separate scope so PR-specific layers don't compete with
+          # production cache entries. mode=min only persists the final layer
+          # (not every intermediate), which keeps the GHA cache pool (10 GB
+          # per repo, LRU eviction) from thrashing the production discord-bot
+          # entries when a PR-burst lands.
+          cache-to: type=gha,scope=discord-bot-smoke,mode=min

--- a/.github/workflows/sub-app-docker-smoke.yml
+++ b/.github/workflows/sub-app-docker-smoke.yml
@@ -1,0 +1,57 @@
+name: Sub-app Dockerfile smoke test
+
+# Builds one representative sub-app Dockerfile (discord-bot, the smallest) on
+# any PR that could regress the root `postinstall` script's behavior inside a
+# sub-app docker install layer. The three sub-app images
+# (apps/wiki-server, apps/discord-bot, apps/groundskeeper) all COPY the root
+# package.json before crux/ is on disk and then run `pnpm install --filter X`,
+# which fires the root postinstall. If that script references files not yet
+# copied, the build crashes — exactly what broke the 2026-05-03 release
+# (QUA-1053 / postmortem QUA-1081).
+#
+# Discord-bot is chosen because it's the cheapest of the three (smallest image,
+# fewest workspace deps) but exercises the same install layer.
+#
+# See docs/agent-rules/dockerfile-postinstall-trap.md for the full pattern.
+
+on:
+  pull_request:
+    paths:
+      # Root manifest / lockfile changes are the QUA-1053 failure shape — they
+      # affect every sub-app's install layer.
+      - "package.json"
+      - "pnpm-lock.yaml"
+      # Discord-bot's own Dockerfile + workspace package.json — we're building
+      # this image, so changes that affect its install path should be tested.
+      - "apps/discord-bot/Dockerfile"
+      - "apps/discord-bot/package.json"
+      - ".github/workflows/sub-app-docker-smoke.yml"
+
+concurrency:
+  group: sub-app-docker-smoke-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build discord-bot Dockerfile (no push)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build discord-bot image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/discord-bot/Dockerfile
+          push: false
+          # Reuse the same cache scope as the production discord-bot build so
+          # this PR check piggybacks on warm layers when nothing in the install
+          # path has changed.
+          cache-from: type=gha,scope=discord-bot
+          cache-to: type=gha,scope=discord-bot-smoke,mode=max

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,7 @@ These live in `docs/agent-rules/`. They are **NOT** auto-loaded — to keep cach
 | LLM prompt construction — escaping user content | `docs/agent-rules/llm-prompt-safety.md` |
 | Dispatching subagents from a coordinator session | `docs/agent-rules/dispatched-agent-review.md` |
 | PR patrol — health gate, fleet-level signals | `docs/agent-rules/patrol-health-gate.md` |
+| Editing the root `package.json` `postinstall` (or any lifecycle script), or adding/changing a sub-app `Dockerfile` | `docs/agent-rules/dockerfile-postinstall-trap.md` |
 
 Plus historical: `docs/audits/things-denormalization-audit.md` (denorm columns dropped in QUA-507 / migration 0204; retained for pre-QUA-507 composer logic per thing_type and for the `*_display_name` sibling pattern audit before proposing a new cache column).
 

--- a/apps/discord-bot/Dockerfile
+++ b/apps/discord-bot/Dockerfile
@@ -5,7 +5,15 @@ RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 
 WORKDIR /repo
 
-# Copy workspace manifests and lockfile first for layer caching
+# Copy workspace manifests and lockfile first for layer caching.
+#
+# IMPORTANT: `pnpm install` below fires the ROOT package.json's `postinstall`
+# script before `crux/` (or any other source) is on disk. If that script
+# references files not yet copied, the build crashes here — that's what broke
+# the 2026-05-03 release (QUA-1053 / postmortem QUA-1081). Keep the root
+# postinstall guarded with `if [ -f ... ]; then ...; fi`.
+#
+# See docs/agent-rules/dockerfile-postinstall-trap.md.
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/discord-bot/package.json ./apps/discord-bot/
 

--- a/apps/groundskeeper/Dockerfile
+++ b/apps/groundskeeper/Dockerfile
@@ -12,7 +12,15 @@ RUN npm install -g @anthropic-ai/claude-code@2.1.63
 
 WORKDIR /repo
 
-# Copy workspace manifests and lockfile first for layer caching
+# Copy workspace manifests and lockfile first for layer caching.
+#
+# IMPORTANT: `pnpm install` below fires the ROOT package.json's `postinstall`
+# script before `crux/` (or any other source) is on disk. If that script
+# references files not yet copied, the build crashes here — that's what broke
+# the 2026-05-03 release (QUA-1053 / postmortem QUA-1081). Keep the root
+# postinstall guarded with `if [ -f ... ]; then ...; fi`.
+#
+# See docs/agent-rules/dockerfile-postinstall-trap.md.
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/groundskeeper/package.json ./apps/groundskeeper/
 

--- a/apps/wiki-server/Dockerfile
+++ b/apps/wiki-server/Dockerfile
@@ -5,7 +5,15 @@ RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 
 WORKDIR /repo
 
-# Copy workspace manifests and lockfile first for layer caching
+# Copy workspace manifests and lockfile first for layer caching.
+#
+# IMPORTANT: `pnpm install` below fires the ROOT package.json's `postinstall`
+# script before `crux/` (or any other source) is on disk. If that script
+# references files not yet copied, the build crashes here — that's what broke
+# the 2026-05-03 release (QUA-1053 / postmortem QUA-1081). Keep the root
+# postinstall guarded with `if [ -f ... ]; then ...; fi`.
+#
+# See docs/agent-rules/dockerfile-postinstall-trap.md.
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/wiki-server/package.json ./apps/wiki-server/
 COPY packages/id-utils/package.json ./packages/id-utils/

--- a/docs/agent-rules/dockerfile-postinstall-trap.md
+++ b/docs/agent-rules/dockerfile-postinstall-trap.md
@@ -16,7 +16,9 @@ RUN pnpm install --frozen-lockfile --filter <name>
 
 `pnpm install` runs the **root** `package.json`'s `postinstall` script during this layer — *before* the rest of the repo (including `crux/`) has been copied. If `postinstall` references files that have not been copied yet, the docker build crashes with `Cannot find module '/repo/<file>'` and the deploy fails.
 
-`Dockerfile.worker` is exempt: it uses an isolated `docker/worker/package.json`, so the root `postinstall` never fires inside it. The trap only hits the three full-monorepo sub-app images.
+If you reorder a Dockerfile so it `COPY crux/`s before `pnpm install`, the unguarded form of `postinstall` will work — but the smoke workflow (see "CI prevention" below) is the only thing keeping that ordering honest, so prefer to keep the guard regardless. Every reorder is one git operation away from being undone.
+
+`Dockerfile.worker` is exempt: it uses an isolated `docker/worker/package.json`, so the root `postinstall` never fires inside it. The worker has its own dependency-coverage protection — `crux/validate/validate-workspace-dep-coverage.ts` (gate-enforced) ensures every `file:` workspace dep declared in `docker/worker/package.json` has a matching `COPY` line in `Dockerfile.worker`. That validator does not protect the three sub-app Dockerfiles, and this trap doc does not cover the worker. Each is the only protection for its own image.
 
 ## The fix
 
@@ -47,16 +49,19 @@ A non-zero exit in the guard would be required to short-circuit `&&`, but `proce
 
 ## CI prevention
 
-`.github/workflows/sub-app-docker-smoke.yml` builds the discord-bot Dockerfile on any PR that touches root `package.json`, `pnpm-lock.yaml`, or any of the three sub-app Dockerfiles. Discord-bot is the cheapest of the three (smallest image, fewest workspace deps) but it exercises the same failure mode — root `postinstall` fires during its install layer.
+`.github/workflows/sub-app-docker-smoke.yml` builds the discord-bot Dockerfile on any PR that touches root `package.json`, `pnpm-lock.yaml`, any sub-app Dockerfile (matched as `apps/*/Dockerfile`, so newly-added sub-apps are covered too), or `apps/discord-bot/package.json`.
 
-If you add a new sub-app Dockerfile or change which file is "smallest," update the workflow accordingly.
+Discord-bot is chosen because it has the fewest workspace dependencies in its install filter (no `packages/*` deps, unlike wiki-server) — so its install layer is the fastest to build of the three. Its produced image is actually larger than groundskeeper's because it bakes wiki content for the `/ask` command, but image size doesn't affect what runs during the install layer, which is the only thing this smoke test exercises.
+
+If you add a new sub-app Dockerfile, the workflow already runs against it via the `apps/*/Dockerfile` glob, but the build itself still targets discord-bot. That's intentional: every sub-app shares the same install-layer surface for the QUA-1053 failure class, and discord-bot is the cheapest representative.
 
 ## Audit rule
 
-Any script in the **root** `package.json` (especially lifecycle hooks: `preinstall`, `install`, `postinstall`, `prepare`) must either:
+Any lifecycle script in the **root** `package.json` (`preinstall`, `install`, `postinstall`, `prepare`) must not crash when `crux/`, `apps/`, `packages/`, or any other source directory is missing. In practice that means one of:
 
-1. Reference only files that exist in the repo root before any sub-app docker COPY happens (i.e. the root manifest itself), **or**
-2. Guard with POSIX `if [ -f ... ]; then ...; fi` so the docker install layer is a clean no-op.
+1. The script *only references files that exist in the repo root before any sub-app docker COPY happens* — i.e. the root manifest itself, or files baked into the layer that runs the script.
+2. The script *executes* a path under `crux/` etc., so it must be guarded with POSIX `if [ -f ... ]; then ...; fi` to be a clean no-op when the file is missing.
+3. The script *only references* (without executing) a path — e.g. `git config merge.foo.driver 'node crux/git/merge.mjs'` registers a path as a config string but does not invoke it. These are safe even though they textually reference `crux/`. The current root `prepare` is in this category.
 
 The same trap does *not* apply to scripts in `apps/<name>/package.json` — those only fire when their own package is being installed, which happens after the relevant `COPY apps/<name>/` lines.
 
@@ -64,4 +69,9 @@ The same trap does *not* apply to scripts in `apps/<name>/package.json` — thos
 
 - QUA-1053 — original regression (PR #4838)
 - QUA-1081 — postmortem and prevention (this doc, the smoke workflow)
-- Deploy chain that surfaced it: PRs #4840, #4846, #4848, #4849, #4850
+- Deploy chain that surfaced and resolved it:
+  - PR #4840 — initial release (failed: wiki-server / discord-bot / groundskeeper docker builds crashed in postinstall)
+  - PR #4846 — first hotfix (broken: replaced try/catch with `accessSync` but kept the `&& cmd` chain — same bug)
+  - PR #4848 — second release attempt (still hit the broken postinstall via the broken hotfix)
+  - PR #4849 — working hotfix (replaced the entire chain with `if [ -f ... ]; then ...; fi`)
+  - PR #4850 — clean release after the working hotfix

--- a/docs/agent-rules/dockerfile-postinstall-trap.md
+++ b/docs/agent-rules/dockerfile-postinstall-trap.md
@@ -1,0 +1,67 @@
+# Sub-app Dockerfile postinstall trap
+
+Read this before adding a new sub-app `Dockerfile` (e.g. `apps/<name>/Dockerfile`), changing the `postinstall` script in the root `package.json`, or modifying the `COPY` order in any of the existing sub-app Dockerfiles (`apps/wiki-server`, `apps/discord-bot`, `apps/groundskeeper`).
+
+## The trap
+
+The three sub-app Dockerfiles all follow the same shape:
+
+```dockerfile
+WORKDIR /repo
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/<name>/package.json ./apps/<name>/
+RUN pnpm install --frozen-lockfile --filter <name>
+# ... later: COPY apps/<name>/ ./apps/<name>/, COPY crux/ ./crux/, etc.
+```
+
+`pnpm install` runs the **root** `package.json`'s `postinstall` script during this layer — *before* the rest of the repo (including `crux/`) has been copied. If `postinstall` references files that have not been copied yet, the docker build crashes with `Cannot find module '/repo/<file>'` and the deploy fails.
+
+`Dockerfile.worker` is exempt: it uses an isolated `docker/worker/package.json`, so the root `postinstall` never fires inside it. The trap only hits the three full-monorepo sub-app images.
+
+## The fix
+
+The root `postinstall` must short-circuit if the file it depends on is missing. **Use POSIX shell, not `node -e`:**
+
+```jsonc
+// package.json
+"postinstall": "if [ -f crux/build.mjs ]; then node crux/build.mjs; fi"
+```
+
+This exits 0 cleanly when `crux/build.mjs` is absent (the docker install layer) and runs the build when it's present (local dev, CI, full clones).
+
+### Why not `node -e ... && cmd`?
+
+This is the pattern QUA-1053 introduced and QUA-1081 (the postmortem) replaced:
+
+```jsonc
+// BROKEN — do not use this shape
+"postinstall": "node -e \"try{require.resolve('esbuild')}catch{process.exit(0)}\" && node crux/build.mjs"
+```
+
+It is logically broken in both branches:
+
+- If `esbuild` resolves: try succeeds → script ends → exit 0 → `&&` runs `node crux/build.mjs`. Crashes if `crux/build.mjs` isn't on disk.
+- If `esbuild` is missing: catch fires → `process.exit(0)` → exit 0 → `&&` *still* runs `node crux/build.mjs`. The "guard" never short-circuits.
+
+A non-zero exit in the guard would be required to short-circuit `&&`, but `process.exit(0)` (and a successful try block) both exit 0. Either use POSIX `if`/`||` to actually skip the body, or do the file existence check inside the script you're conditionally running. The first hotfix attempt (PR #4846) replaced the `try/catch` with `accessSync` but kept the `&& cmd` chain — same bug, no fix. PR #4849 was the working fix.
+
+## CI prevention
+
+`.github/workflows/sub-app-docker-smoke.yml` builds the discord-bot Dockerfile on any PR that touches root `package.json`, `pnpm-lock.yaml`, or any of the three sub-app Dockerfiles. Discord-bot is the cheapest of the three (smallest image, fewest workspace deps) but it exercises the same failure mode — root `postinstall` fires during its install layer.
+
+If you add a new sub-app Dockerfile or change which file is "smallest," update the workflow accordingly.
+
+## Audit rule
+
+Any script in the **root** `package.json` (especially lifecycle hooks: `preinstall`, `install`, `postinstall`, `prepare`) must either:
+
+1. Reference only files that exist in the repo root before any sub-app docker COPY happens (i.e. the root manifest itself), **or**
+2. Guard with POSIX `if [ -f ... ]; then ...; fi` so the docker install layer is a clean no-op.
+
+The same trap does *not* apply to scripts in `apps/<name>/package.json` — those only fire when their own package is being installed, which happens after the relevant `COPY apps/<name>/` lines.
+
+## Related
+
+- QUA-1053 — original regression (PR #4838)
+- QUA-1081 — postmortem and prevention (this doc, the smoke workflow)
+- Deploy chain that surfaced it: PRs #4840, #4846, #4848, #4849, #4850


### PR DESCRIPTION
## Summary

Postmortem follow-ups for QUA-1053 (PR #4838), which broke the 2026-05-03 release because a root `package.json` `postinstall` referenced `crux/build.mjs` without guarding for the sub-app docker install layer where `crux/` is not yet on disk. PR #4849 already replaced the broken script with a POSIX shell `if [ -f ... ]; then ...; fi`. This PR adds the prevention pieces called out in the postmortem (QUA-1081):

- **CI smoke test** — `.github/workflows/sub-app-docker-smoke.yml` builds the discord-bot Dockerfile (fewest workspace deps in its install filter, so the install layer is the fastest of the three sub-apps to build) on PRs that touch root `package.json`, `pnpm-lock.yaml`, `apps/*/Dockerfile` (glob — catches new sub-apps too), or `apps/discord-bot/package.json`. Catches the QUA-1053 failure shape in PR CI instead of at deploy time. Reads from the existing `discord-bot` GHA cache for warm prod layers, writes to a separate `discord-bot-smoke` scope with `mode=min` so PR builds never poison or evict the production cache. `timeout-minutes: 15` so a hung build doesn't squat on a runner for the GHA default 6h. `branches: [main]` so release PRs to production don't re-run the smoke for changes that already passed through main.
- **Docs** — new `docs/agent-rules/dockerfile-postinstall-trap.md` explains the trap, the POSIX-shell fix, and why `node -e "..." && cmd` is structurally broken (both branches exit 0 → `&&` always continues). Linked from a row in the CLAUDE.md Tier 2 table and from a comment block at the top of each of the three sub-app Dockerfiles, near the `COPY package.json` line where the trap fires. Cross-references `validate-workspace-dep-coverage.ts` so a reader knows the worker has separate protections.
- **Audit** — grep of all `package.json` files for `node -e ... && cmd` patterns: zero remaining instances. The broken pattern only existed in the root `postinstall` and was already replaced by PR #4849.

## Test plan

- [x] `actionlint -shellcheck= .github/workflows/sub-app-docker-smoke.yml` passes
- [x] All other workflows still pass actionlint
- [x] `pnpm crux w validate gate --scope=content --fix` passes on both commits
- [x] Hostile-reviewer subagent run on initial commit; HIGH and MEDIUM findings addressed in second commit (paths widened to `apps/*/Dockerfile`, `mode=min` cache, `timeout-minutes: 15`, `branches: [main]`, doc accuracy fixes including "fewest workspace deps" framing and tightened audit rule)
- [x] Red-team threat scenarios traced through the workflow; confirms regression vectors (broken postinstall, broken preinstall/prepare, lockfile-only changes, removed postinstall, re-introduced `node -e ... && cmd`) all trip the smoke check
- [x] Action versions match sister workflows (`docker/build-push-action@v6`, `actions/checkout@v4`, `docker/setup-buildx-action@v3`)
- [ ] **In CI on this PR**: the new smoke job DOES run (root `package.json` is unchanged in this diff, but `apps/wiki-server/Dockerfile`, `apps/groundskeeper/Dockerfile`, and `apps/discord-bot/Dockerfile` all changed — the `apps/*/Dockerfile` glob matches, so the smoke will build discord-bot)
- [ ] **In CI on this PR**: discord-bot build succeeds (the postinstall is currently the working POSIX-shell form; only a regression would trip the check)

Fixes QUA-1081


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated Docker image validation to CI to catch build failures early.

* **Documentation**
  * Improved guidance on a known failure mode in container builds and how to properly guard against it to ensure reliable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->