### PR TITLE
qua-1061: resolve PG benchmark rows by stableId

### DIFF
--- a/apps/web/src/app/benchmarks/__tests__/benchmark-utils.test.ts
+++ b/apps/web/src/app/benchmarks/__tests__/benchmark-utils.test.ts
@@ -9,12 +9,17 @@ import type { AnyEntity } from "@/data/tablebase";
 // Mock @/data before importing benchmark-utils
 vi.mock("@/data", () => ({
   getTypedEntities: vi.fn(),
+  getTypedEntityByStableId: vi.fn(),
   getBenchmarkResults: vi.fn(),
   isBenchmark: (e: AnyEntity) => (e as { entityType: string }).entityType === "benchmark",
   isAiModel: (e: AnyEntity) => (e as { entityType: string }).entityType === "ai-model",
 }));
 
-import { getTypedEntities, getBenchmarkResults } from "@/data";
+import {
+  getTypedEntities,
+  getTypedEntityByStableId,
+  getBenchmarkResults,
+} from "@/data";
 import {
   getBenchmarkResultsFromModels,
   formatTestedBy,
@@ -22,6 +27,7 @@ import {
 } from "../benchmark-utils";
 
 const mockGetTypedEntities = vi.mocked(getTypedEntities);
+const mockGetTypedEntityByStableId = vi.mocked(getTypedEntityByStableId);
 const mockGetBenchmarkResults = vi.mocked(getBenchmarkResults);
 
 // --- Test data factories ---
@@ -85,9 +91,14 @@ function makePGResult(
 beforeEach(() => {
   vi.clearAllMocks();
 
-  // Default: empty entities and no PG data
+  // Default: empty entities and no PG data. The stableId resolver falls
+  // back to the entity list so it stays consistent with the slug index
+  // mockGetTypedEntities provides.
   mockGetTypedEntities.mockReturnValue([]);
   mockGetBenchmarkResults.mockReturnValue({});
+  mockGetTypedEntityByStableId.mockImplementation((sid: string) =>
+    mockGetTypedEntities().find((e) => e.stableId === sid),
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -372,6 +383,40 @@ describe("getBenchmarkResultsFromModels — PG keyed by stableId (QUA-1061)", ()
     const results = getBenchmarkResultsFromModels();
     const row = results.get("mmlu")![0];
     expect(row.testedByOrgName).toBe("Apollo Research");
+    // testedByOrgId must be normalized to the canonical slug — the leaderboard
+    // renderer uses it as a URL segment (`/organizations/${testedByOrgId}`),
+    // so a raw `sid_*` would render an ugly link bypassing static generation.
+    expect(row.testedByOrgId).toBe("apollo");
+  });
+
+  it("normalizes developer field to slug when developer is referenced by stableId", () => {
+    const openaiOrg = {
+      id: "openai",
+      title: "OpenAI",
+      entityType: "organization" as const,
+      tags: [],
+      wikiId: null,
+      stableId: "sid_OpenAIxyz",
+      relatedEntries: [],
+    } as unknown as AnyEntity;
+
+    const gpt4 = makeAiModel("gpt-4", "GPT-4", [], "sid_GPT4abc123");
+    (gpt4 as unknown as { developer: string }).developer = "sid_OpenAIxyz";
+
+    mockGetTypedEntities.mockReturnValue([
+      makeBenchmark("mmlu", "MMLU"),
+      gpt4,
+      openaiOrg,
+    ]);
+
+    mockGetBenchmarkResults.mockReturnValue({
+      sid_GPT4abc123: [makePGResult("mmlu", 87.5, "%")],
+    });
+
+    const results = getBenchmarkResultsFromModels();
+    const row = results.get("mmlu")![0];
+    expect(row.developer).toBe("openai");
+    expect(row.developerName).toBe("OpenAI");
   });
 
   it("skips PG rows whose stableId does not match any entity", () => {

--- a/apps/web/src/app/benchmarks/__tests__/benchmark-utils.test.ts
+++ b/apps/web/src/app/benchmarks/__tests__/benchmark-utils.test.ts
@@ -30,6 +30,7 @@ function makeAiModel(
   id: string,
   title: string,
   benchmarks: Array<{ name: string; score: number; unit?: string }> = [],
+  stableId?: string,
 ): AnyEntity {
   return {
     id,
@@ -37,6 +38,7 @@ function makeAiModel(
     entityType: "ai-model" as const,
     developer: undefined,
     wikiId: null,
+    stableId,
     benchmarks,
     tags: [],
     description: undefined,
@@ -260,6 +262,133 @@ describe("getBenchmarkResultsFromModels — PG data takes priority", () => {
     // claude-3 uses inline score
     expect(claudeResult).toBeDefined();
     expect(claudeResult!.score).toBe(82.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QUA-1061: PG keys are stableIds (sid_*), not slugs — must still resolve
+// ---------------------------------------------------------------------------
+describe("getBenchmarkResultsFromModels — PG keyed by stableId (QUA-1061)", () => {
+  it("resolves PG model keyed by stableId to the matching slug-keyed entity", () => {
+    // Production reality: PG `benchmark_results.modelId` is the entity's
+    // stableId (sid_*), but `entityById` is keyed by slug. The merge must
+    // resolve PG stableId keys back to the slug-keyed entity.
+    mockGetTypedEntities.mockReturnValue([
+      makeBenchmark("mmlu", "MMLU"),
+      makeAiModel("gpt-4", "GPT-4", [], "sid_GPT4abc123"),
+    ]);
+
+    mockGetBenchmarkResults.mockReturnValue({
+      sid_GPT4abc123: [makePGResult("mmlu", 87.5, "%")],
+    });
+
+    const results = getBenchmarkResultsFromModels();
+    const mmluResults = results.get("mmlu");
+    expect(mmluResults).toBeDefined();
+    expect(mmluResults).toHaveLength(1);
+    expect(mmluResults![0].modelId).toBe("gpt-4");
+    expect(mmluResults![0].score).toBe(87.5);
+  });
+
+  it("PG (stableId-keyed) wins over inline for same (model, benchmark) pair", () => {
+    mockGetTypedEntities.mockReturnValue([
+      makeBenchmark("mmlu", "MMLU"),
+      makeAiModel(
+        "gpt-4",
+        "GPT-4",
+        [{ name: "MMLU", score: 86.4, unit: "%" }],
+        "sid_GPT4abc123",
+      ),
+    ]);
+
+    // PG keyed by stableId (real prod shape) with a different score
+    mockGetBenchmarkResults.mockReturnValue({
+      sid_GPT4abc123: [makePGResult("mmlu", 87.5, "%")],
+    });
+
+    const results = getBenchmarkResultsFromModels();
+    const mmluResults = results.get("mmlu");
+    expect(mmluResults).toHaveLength(1);
+    expect(mmluResults![0].score).toBe(87.5);
+  });
+
+  it("resolves developer entity via stableId when developer field is a stableId", () => {
+    const openaiOrg = {
+      id: "openai",
+      title: "OpenAI",
+      entityType: "organization" as const,
+      tags: [],
+      wikiId: null,
+      stableId: "sid_OpenAIxyz",
+      relatedEntries: [],
+    } as unknown as AnyEntity;
+
+    const gpt4 = makeAiModel("gpt-4", "GPT-4", [], "sid_GPT4abc123");
+    // The model's developer field references the org by stableId (PG-style)
+    (gpt4 as unknown as { developer: string }).developer = "sid_OpenAIxyz";
+
+    mockGetTypedEntities.mockReturnValue([
+      makeBenchmark("mmlu", "MMLU"),
+      gpt4,
+      openaiOrg,
+    ]);
+
+    mockGetBenchmarkResults.mockReturnValue({
+      sid_GPT4abc123: [makePGResult("mmlu", 87.5, "%")],
+    });
+
+    const results = getBenchmarkResultsFromModels();
+    const row = results.get("mmlu")![0];
+    // developerName must resolve from the stableId-referenced org
+    expect(row.developerName).toBe("OpenAI");
+  });
+
+  it("resolves testedByOrgId via stableId when PG references org by stableId", () => {
+    const apolloOrg = {
+      id: "apollo",
+      title: "Apollo Research",
+      entityType: "organization" as const,
+      tags: [],
+      wikiId: null,
+      stableId: "sid_ApolloOrg",
+      relatedEntries: [],
+    } as unknown as AnyEntity;
+
+    mockGetTypedEntities.mockReturnValue([
+      makeBenchmark("mmlu", "MMLU"),
+      makeAiModel("gpt-4", "GPT-4", [], "sid_GPT4abc123"),
+      apolloOrg,
+    ]);
+
+    mockGetBenchmarkResults.mockReturnValue({
+      sid_GPT4abc123: [
+        makePGResult("mmlu", 87.5, "%", {
+          testedBy: "apollo",
+          testedByOrgId: "sid_ApolloOrg",
+        }),
+      ],
+    });
+
+    const results = getBenchmarkResultsFromModels();
+    const row = results.get("mmlu")![0];
+    expect(row.testedByOrgName).toBe("Apollo Research");
+  });
+
+  it("skips PG rows whose stableId does not match any entity", () => {
+    mockGetTypedEntities.mockReturnValue([
+      makeBenchmark("mmlu", "MMLU"),
+      makeAiModel("gpt-4", "GPT-4", [], "sid_GPT4abc123"),
+    ]);
+
+    mockGetBenchmarkResults.mockReturnValue({
+      sid_GPT4abc123: [makePGResult("mmlu", 87.5, "%")],
+      sid_unknownXX: [makePGResult("mmlu", 99.9, "%")],
+    });
+
+    const results = getBenchmarkResultsFromModels();
+    const mmluResults = results.get("mmlu");
+    expect(mmluResults).toHaveLength(1);
+    expect(mmluResults![0].modelId).toBe("gpt-4");
   });
 });
 

--- a/apps/web/src/app/benchmarks/benchmark-utils.ts
+++ b/apps/web/src/app/benchmarks/benchmark-utils.ts
@@ -207,17 +207,31 @@ function mergeWithPGResults(
   pgResults: Record<string, PGRowShape[]>,
   entityById: Map<string, AnyEntity>,
 ): Map<string, BenchmarkResultRow[]> {
+  // QUA-1061: PG benchmark_results rows reference entities by stableId
+  // (sid_*), but `entityById` is keyed by slug. Resolve via either form so
+  // PG rows actually reach the leaderboard.
+  const entityByStableId = new Map<string, AnyEntity>();
+  for (const e of entityById.values()) {
+    if (e.stableId) entityByStableId.set(e.stableId, e);
+  }
+  const resolveEntity = (key: string): AnyEntity | undefined =>
+    entityById.get(key) ?? entityByStableId.get(key);
+
   // Deep-copy inline results so we don't mutate the original
   const merged = new Map<string, BenchmarkResultRow[]>();
   for (const [benchmarkId, rows] of inlineResults) {
     merged.set(benchmarkId, [...rows]);
   }
 
-  // Build a set of (benchmarkId, modelId) pairs covered by PG
+  // Build a set of (benchmarkId, slug) pairs covered by PG. We resolve the
+  // PG key to its canonical slug so the inline filter below — keyed by
+  // slug — actually matches.
   const pgCoveredPairs = new Set<string>();
-  for (const [modelId, scores] of Object.entries(pgResults)) {
+  for (const [modelKey, scores] of Object.entries(pgResults)) {
+    const model = resolveEntity(modelKey);
+    if (!model) continue;
     for (const s of scores) {
-      pgCoveredPairs.add(`${s.benchmarkId}:${modelId}`);
+      pgCoveredPairs.add(`${s.benchmarkId}:${model.id}`);
     }
   }
 
@@ -234,15 +248,15 @@ function mergeWithPGResults(
   }
 
   // Add PG entries
-  for (const [modelId, scores] of Object.entries(pgResults)) {
-    const model = entityById.get(modelId);
+  for (const [modelKey, scores] of Object.entries(pgResults)) {
+    const model = resolveEntity(modelKey);
     if (!model) continue;
 
     const developerField = isAiModel(model) ? model.developer : undefined;
-    const developerEntity = developerField ? entityById.get(developerField) : null;
+    const developerEntity = developerField ? resolveEntity(developerField) : null;
 
     for (const s of scores) {
-      const orgEntity = s.testedByOrgId ? entityById.get(s.testedByOrgId) : null;
+      const orgEntity = s.testedByOrgId ? resolveEntity(s.testedByOrgId) : null;
       const row: BenchmarkResultRow = {
         modelId: model.id,
         modelTitle: model.title,

--- a/apps/web/src/app/benchmarks/benchmark-utils.ts
+++ b/apps/web/src/app/benchmarks/benchmark-utils.ts
@@ -1,4 +1,12 @@
-import { getTypedEntities, isBenchmark, isAiModel, getBenchmarkResults, type BenchmarkEntity, type AnyEntity } from "@/data";
+import {
+  getTypedEntities,
+  getTypedEntityByStableId,
+  isBenchmark,
+  isAiModel,
+  getBenchmarkResults,
+  type BenchmarkEntity,
+  type AnyEntity,
+} from "@/data";
 
 /**
  * Get all benchmark entities.
@@ -209,13 +217,10 @@ function mergeWithPGResults(
 ): Map<string, BenchmarkResultRow[]> {
   // QUA-1061: PG benchmark_results rows reference entities by stableId
   // (sid_*), but `entityById` is keyed by slug. Resolve via either form so
-  // PG rows actually reach the leaderboard.
-  const entityByStableId = new Map<string, AnyEntity>();
-  for (const e of entityById.values()) {
-    if (e.stableId) entityByStableId.set(e.stableId, e);
-  }
+  // PG rows actually reach the leaderboard. `getTypedEntityByStableId` is
+  // a cached lazy index that also handles legacy bare-10-char stableIds.
   const resolveEntity = (key: string): AnyEntity | undefined =>
-    entityById.get(key) ?? entityByStableId.get(key);
+    entityById.get(key) ?? getTypedEntityByStableId(key);
 
   // Deep-copy inline results so we don't mutate the original
   const merged = new Map<string, BenchmarkResultRow[]>();
@@ -257,16 +262,20 @@ function mergeWithPGResults(
 
     for (const s of scores) {
       const orgEntity = s.testedByOrgId ? resolveEntity(s.testedByOrgId) : null;
+      // Normalize references to the canonical slug when an entity resolved.
+      // The leaderboard renderer uses `testedByOrgId` as a URL segment
+      // (`/organizations/${testedByOrgId}`), so leaving a raw `sid_*` here
+      // would render an ugly link that bypasses static generation.
       const row: BenchmarkResultRow = {
         modelId: model.id,
         modelTitle: model.title,
         wikiId: model.wikiId ?? null,
-        developer: developerField ?? null,
+        developer: developerEntity?.id ?? developerField ?? null,
         developerName: developerEntity?.title ?? null,
         score: s.score,
         unit: s.unit ?? undefined,
         testedBy: s.testedBy ?? null,
-        testedByOrgId: s.testedByOrgId ?? null,
+        testedByOrgId: orgEntity?.id ?? s.testedByOrgId ?? null,
         testedByOrgName: orgEntity?.title ?? null,
         evaluationDate: s.evaluationDate ?? null,
         methodologyNotes: s.methodologyNotes ?? null,


### PR DESCRIPTION
## Summary

`mergeWithPGResults()` in `apps/web/src/app/benchmarks/benchmark-utils.ts` looked up models via `entityById.get(modelId)` keyed by entity slug, but PG `benchmark_results.modelId` is the entity's stableId (`sid_*`). Result: every PG-sourced score was silently dropped from `/benchmarks/[slug]/` leaderboards (0/52 PG models resolved on prod data), and the QUA-743 provenance columns never had a row to render.

## Fix

- Resolve PG model keys via `getTypedEntityByStableId` (cached lazy index from tablebase) when the slug-keyed `entityById` misses, so PG `sid_*` keys actually find their entity. Same resolution applied to the developer field and `testedByOrgId`.
- The `(benchmarkId, model)` pair set used to filter inline duplicates now keys on the resolved canonical slug so the inline-filter step matches.
- Output rows normalize `developer` and `testedByOrgId` to canonical slugs (not raw `sid_*`) — the leaderboard renderer at `[slug]/page.tsx:415` uses `testedByOrgId` as a URL segment, so leaving a raw stableId would render `/organizations/sid_*` URLs that bypass static generation.

Verified locally:

```
PG models: 52
Resolve via entityById.get(id): 0   -> 52 (after fix, via getTypedEntityByStableId)
sid_ leaks in 366 output rows:      0
```

## Behavior change (per the issue's risk note)

This is not a pure bug fix — pre-fix inline always wins; post-fix PG wins for any (model, benchmark) pair PG covers.

- 84 new (model, benchmark) rows now appear on leaderboards
- 273 pairs that previously fell through to inline now use PG
  - 4 of those have materially different scores: humaneval/gpt-3-5-turbo (48.1 → 68), gpqa-diamond/claude-opus-4-1 (81 → 80.9), math-benchmark/claude-3-sonnet (40.5 → 43.1), mmlu/claude-3-sonnet (79 → 78.3)
- 7 entirely new benchmark leaderboards become populated: browsecomp, mbpp, aider-polyglot, frontiermath, winogrande, arc-challenge, truthfulqa

## Tests

7 new unit tests in `benchmark-utils.test.ts` (26 total, all pass):

- PG keyed by stableId resolves to slug-keyed entity
- PG (stableId-keyed) wins over inline for same (model, benchmark) pair
- Developer entity resolves via stableId reference
- testedByOrgId resolves via stableId reference (asserts slug normalization for the URL contract)
- Developer field normalized to slug when referenced via stableId
- PG rows whose stableId does not match any entity are skipped (not crashed)

Hostile-reviewer subagent flagged 1 HIGH (raw sid_ leaking into URL builder) + 2 MEDIUM (reinventing cached getTypedEntityByStableId infra; missing slug assertion). All addressed in the second commit.

## Test plan
- [x] Unit tests: 26 passing locally including 7 new tests for the QUA-1061 fix
- [x] Repro confirmed pre-fix (0/52 PG models resolved); fix verified post-fix (52/52 resolved, 366 rows in merged output, 0 `sid_` leaks)
- [x] Full validation gate green (74/74 checks; full Next.js build included)
- [ ] CI green on the PR
- [ ] Spot-check `/benchmarks/mmlu`, `/benchmarks/aime-2025`, `/benchmarks/frontiermath` on the deployed preview — leaderboards should now contain PG rows
- [ ] Confirm the 4 score changes above are intended (PG is the authoritative source per the merge comment)

Fixes QUA-1061


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced entity reference resolution in benchmark results to ensure consistent data normalization across multiple reference formats.
  * Improved matching logic for benchmark and model pairs to maintain data integrity.

* **Tests**
  * Expanded test coverage for entity resolution and benchmark result processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->