### PR TITLE
qua-678: consolidate ~25 truncate() helpers into crux/lib/text-utils.ts

### DIFF
--- a/crux/analyze/analyze-entity-links.ts
+++ b/crux/analyze/analyze-entity-links.ts
@@ -21,6 +21,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join, relative } from 'path';
 import { findMdxFiles } from '../lib/file-utils.ts';
 import { parseFrontmatter, getContentBody } from '../lib/mdx-utils.ts';
+import { truncate } from '../lib/text-utils.ts';
 import { getColors } from '../lib/output.ts';
 import { CONTENT_DIR_ABS as CONTENT_DIR, loadPathRegistry, loadEntities, type Entity, type PathRegistry } from '../lib/content-types.ts';
 import { ENTITY_LINK_RE } from '../lib/patterns.ts';
@@ -344,7 +345,7 @@ function main(): void {
       console.log(`  ${colors.dim}[${page.readerImportance}]${colors.reset} ${page.title}`);
       if (page.context) {
         // Truncate context and highlight the matched term
-        let ctx = page.context.length > 80 ? page.context.slice(0, 80) + '...' : page.context;
+        let ctx = truncate(page.context, 83, { ellipsis: '...' });
         console.log(`    ${colors.dim}"${ctx}"${colors.reset}`);
       }
     }

--- a/crux/authoring/creator/sourcing.ts
+++ b/crux/authoring/creator/sourcing.ts
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import { getFetchedSourceContent } from './source-fetching.ts';
 import type { TopicPhaseContext } from './types.ts';
+import { truncate } from '../../lib/text-utils.ts';
 
 type SourcingContext = TopicPhaseContext;
 
@@ -148,7 +149,7 @@ export async function runSourcing(topic: string, { log, saveResult, getTopicDir 
       warnings.push({
         type: 'unverified-quote',
         person,
-        quote: quote.length > 60 ? quote.slice(0, 60) + '...' : quote,
+        quote: truncate(quote, 63, { ellipsis: '...' }),
         message: `Quote attributed to "${person}" not found in research - possible hallucination: "${quote.slice(0, 50)}..."`,
       });
     }

--- a/crux/authoring/page-creator.ts
+++ b/crux/authoring/page-creator.ts
@@ -37,6 +37,7 @@ import dotenv from 'dotenv';
 
 // Sub-modules
 import { checkForExistingPage } from './creator/duplicate-detection.ts';
+import { truncate } from '../lib/text-utils.ts';
 import { findCanonicalLinks } from './creator/canonical-links.ts';
 import { runPerplexityResearch, runScryResearch } from './creator/research.ts';
 import { registerResearchSources, fetchRegisteredSources, processDirections, loadSourceFile } from './creator/source-fetching.ts';
@@ -197,7 +198,7 @@ async function runPipeline(topic: string, tier: string = 'standard', directions:
     console.log(`Source file: ${sourceFilePath}`);
   }
   if (directions) {
-    console.log(`Directions: ${directions.slice(0, 80)}${directions.length > 80 ? '...' : ''}`);
+    console.log(`Directions: ${truncate(directions, 83, { ellipsis: '...' })}`);
   }
   if (pageType) {
     console.log(`Type: ${pageType}`);

--- a/crux/authoring/page-review.ts
+++ b/crux/authoring/page-review.ts
@@ -18,6 +18,7 @@ import { parseCliArgs } from '../lib/cli.ts';
 import { loadPages, findPage, getFilePath } from './page-improver/utils.ts';
 import { adversarialReviewPhase } from './page-improver/phases/adversarial-review.ts';
 import type { PageData, AdversarialReviewResult, PipelineOptions } from './page-improver/types.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -76,7 +77,7 @@ function printBatchSummary(results: Array<{ page: PageData; review: AdversarialR
   console.log('  ' + '─'.repeat(56));
 
   for (const { page, review } of sorted) {
-    const name = page.title.length > 35 ? page.title.slice(0, 32) + '...' : page.title;
+    const name = truncate(page.title, 35, { ellipsis: '...' });
     const gaps = String(review.gaps.length).padEnd(8);
     const reresearch = review.needsReResearch ? 'yes' : 'no';
     console.log(`  ${name.padEnd(38)}${gaps}${reresearch}`);

--- a/crux/auto-update/orchestrator.ts
+++ b/crux/auto-update/orchestrator.ts
@@ -17,6 +17,7 @@ import { buildDigest, normalizeTitle } from './digest.ts';
 import { routeDigest, COST_MAP, BATCH_COST_MAP } from './page-router.ts';
 import { getDueWatchlistUpdates, markWatchlistUpdated } from './watchlist.ts';
 import { recordAutoUpdateRun, insertAutoUpdateNewsItems } from '../lib/wiki-server/auto-update.ts';
+import { truncate } from '../lib/text-utils.ts';
 import type { AutoUpdateOptions, RunReport, RunResult, NewsDigest, UpdatePlan } from './types.ts';
 import { parseIntOpt } from '../lib/cli.ts';
 import { executeBatchImprove } from './batch-improve.ts';
@@ -353,7 +354,7 @@ export async function runPipeline(options: AutoUpdateOptions = {}): Promise<Pipe
         // Merge directions into the existing news-driven entry
         const existing = plan.pageUpdates.find(u => u.pageId === wu.pageId)!;
         const merged = wu.directions + '\n\nAlso from news routing: ' + existing.directions;
-        existing.directions = merged.length > 5000 ? merged.slice(0, 4997) + '...' : merged;
+        existing.directions = truncate(merged, 5000, { ellipsis: '...' });
         const tierRank: Record<string, number> = { polish: 1, standard: 2, deep: 3 };
         if (tierRank[wu.suggestedTier] > tierRank[existing.suggestedTier]) {
           existing.suggestedTier = wu.suggestedTier;

--- a/crux/auto-update/page-router.ts
+++ b/crux/auto-update/page-router.ts
@@ -19,6 +19,7 @@ import { CONTENT_DIR_ABS } from '../lib/content-types.ts';
 import { findMdxFiles } from '../lib/file-utils.ts';
 import { parseFrontmatter } from '../lib/mdx-utils.ts';
 import type { NewsDigest, DigestItem, UpdatePlan, PageUpdate, NewPageSuggestion } from './types.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 // ── Page Index ──────────────────────────────────────────────────────────────
 
@@ -248,9 +249,7 @@ export function deduplicatePageUpdates(updates: PageUpdate[]): PageUpdate[] {
 
   // Truncate directions that exceed the artifacts API limit
   for (const update of seen.values()) {
-    if (update.directions.length > MAX_DIRECTIONS_LENGTH) {
-      update.directions = update.directions.slice(0, MAX_DIRECTIONS_LENGTH - 3) + '...';
-    }
+    update.directions = truncate(update.directions, MAX_DIRECTIONS_LENGTH, { ellipsis: '...' });
   }
 
   return [...seen.values()];

--- a/crux/citations/audit-check.ts
+++ b/crux/citations/audit-check.ts
@@ -31,6 +31,7 @@ import { fileURLToPath } from 'url';
 import { parseCliArgs } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
 import { findPageFile } from '../lib/file-utils.ts';
+import { truncate } from '../lib/text-utils.ts';
 import { auditCitations, type CitationAudit } from '../lib/citation/citation-service.ts';
 
 const DEFAULT_THRESHOLD = 0.8;
@@ -120,11 +121,11 @@ async function main() {
     console.log(`  ${icon} [^${cit.footnoteRef}] ${c.bold}${label}${c.reset}`);
 
     if (cit.claim) {
-      const shortClaim = cit.claim.length > 100 ? cit.claim.slice(0, 100) + '…' : cit.claim;
+      const shortClaim = truncate(cit.claim, 101);
       console.log(`    ${c.dim}Claim:${c.reset} ${shortClaim}`);
     }
 
-    const shortUrl = cit.sourceUrl.length > 80 ? cit.sourceUrl.slice(0, 80) + '…' : cit.sourceUrl;
+    const shortUrl = truncate(cit.sourceUrl, 81);
     console.log(`    ${c.dim}URL:${c.reset} ${shortUrl}`);
 
     if (cit.explanation) {
@@ -132,9 +133,7 @@ async function main() {
     }
 
     if (cit.relevantQuote) {
-      const shortQuote = cit.relevantQuote.length > 120
-        ? cit.relevantQuote.slice(0, 120) + '…'
-        : cit.relevantQuote;
+      const shortQuote = truncate(cit.relevantQuote, 121);
       console.log(`    ${c.dim}Quote:${c.reset} "${shortQuote}"`);
     }
 

--- a/crux/citations/audit.ts
+++ b/crux/citations/audit.ts
@@ -18,6 +18,7 @@ import { fileURLToPath } from 'url';
 import { parseCliArgs } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
 import { findPageFile } from '../lib/file-utils.ts';
+import { truncate } from '../lib/text-utils.ts';
 import { stripFrontmatter } from '../lib/patterns.ts';
 import { extractCitationsFromContent } from '../lib/citation/citation-service.ts';
 import { DEFAULT_CITATION_MODEL } from '../lib/quote-extractor.ts';
@@ -212,10 +213,8 @@ async function main() {
     // Display proposals
     for (const p of proposals) {
       console.log(`  ${c.yellow}[^${p.footnote}]${c.reset} ${p.fixType}: ${p.explanation}`);
-      const origOneLine = p.original.replace(/\n/g, ' ');
-      const replOneLine = p.replacement.replace(/\n/g, ' ');
-      console.log(`    ${c.red}- ${origOneLine.length > 120 ? origOneLine.slice(0, 120) + '...' : origOneLine}${c.reset}`);
-      console.log(`    ${c.green}+ ${replOneLine.length > 120 ? replOneLine.slice(0, 120) + '...' : replOneLine}${c.reset}`);
+      console.log(`    ${c.red}- ${truncate(p.original, 123, { oneLine: true, ellipsis: '...' })}${c.reset}`);
+      console.log(`    ${c.green}+ ${truncate(p.replacement, 123, { oneLine: true, ellipsis: '...' })}${c.reset}`);
     }
 
     if (!apply) {

--- a/crux/citations/export-dashboard.ts
+++ b/crux/citations/export-dashboard.ts
@@ -22,6 +22,7 @@ import { getColors } from '../lib/output.ts';
 import { parseCliArgs } from '../lib/cli.ts';
 import { isServerAvailable } from '../lib/wiki-server/client.ts';
 import { getAccuracyDashboard, getAllQuotes } from '../lib/wiki-server/citations.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 // ---------------------------------------------------------------------------
 // Types (shared with the dashboard — keep in sync)
@@ -297,13 +298,8 @@ export const ACCURACY_DIR = join(PROJECT_ROOT, 'data', 'citation-accuracy');
 export const ACCURACY_PAGES_DIR = join(ACCURACY_DIR, 'pages');
 const SUMMARY_PATH = join(ACCURACY_DIR, 'summary.yaml');
 
-/** Max characters for claimText in exported YAML (dashboard uses line-clamp-2 anyway). */
+/** Max characters for claimText content in exported YAML (dashboard uses line-clamp-2 anyway). */
 const MAX_CLAIM_LENGTH = 150;
-
-function truncateClaim(text: string): string {
-  if (text.length <= MAX_CLAIM_LENGTH) return text;
-  return text.slice(0, MAX_CLAIM_LENGTH) + '...';
-}
 
 /**
  * Export dashboard data to YAML files.
@@ -319,7 +315,7 @@ export async function exportDashboardData(fromDbData?: DashboardExport | null): 
   const flaggedByPage = new Map<string, FlaggedCitation[]>();
   for (const fc of data.flaggedCitations) {
     const list = flaggedByPage.get(fc.pageId) || [];
-    list.push({ ...fc, claimText: truncateClaim(fc.claimText) });
+    list.push({ ...fc, claimText: truncate(fc.claimText, MAX_CLAIM_LENGTH + 3, { ellipsis: '...' }) });
     flaggedByPage.set(fc.pageId, list);
   }
 

--- a/crux/citations/extract-quotes.ts
+++ b/crux/citations/extract-quotes.ts
@@ -18,6 +18,7 @@ import { fileURLToPath } from 'url';
 import { findPageFile } from '../lib/file-utils.ts';
 import { stripFrontmatter } from '../lib/patterns.ts';
 import { getColors } from '../lib/output.ts';
+import { truncate } from '../lib/text-utils.ts';
 import { parseCliArgs } from '../lib/cli.ts';
 import { extractClaimSentence } from '../lib/citation/citation-archive.ts';
 import { extractCitationsFromContent } from '../lib/citation/citation-service.ts';
@@ -129,7 +130,7 @@ export async function extractQuotesForPage(
 
     if (verbose) {
       process.stdout.write(
-        `  [^${cit.footnote}] ${cit.url ? cit.url.slice(0, 60) + '...' : cit.linkText.slice(0, 40) + '...'}`,
+        `  [^${cit.footnote}] ${cit.url ? truncate(cit.url, 63, { ellipsis: '...' }) : truncate(cit.linkText, 43, { ellipsis: '...' })}`,
       );
     }
 
@@ -507,7 +508,7 @@ async function main() {
       );
       console.log(`  ${c.dim}Claim:${c.reset} ${q.claimText.slice(0, 120)}`);
       console.log(
-        `  ${c.dim}Quote:${c.reset} "${q.sourceQuote!.slice(0, 200)}${q.sourceQuote!.length > 200 ? '...' : ''}"`,
+        `  ${c.dim}Quote:${c.reset} "${truncate(q.sourceQuote!, 203, { ellipsis: '...' })}"`,
       );
       if (q.sourceLocation) {
         console.log(`  ${c.dim}Location:${c.reset} ${q.sourceLocation}`);

--- a/crux/citations/fix-inaccuracies.ts
+++ b/crux/citations/fix-inaccuracies.ts
@@ -51,6 +51,7 @@ import { extractQuotesForPage } from './extract-quotes.ts';
 import { exportDashboardData, ACCURACY_DIR, ACCURACY_PAGES_DIR } from './export-dashboard.ts';
 import type { FlaggedCitation } from './export-dashboard.ts';
 import { logBatchProgress } from './shared.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1892,8 +1893,8 @@ async function main() {
         if (verbose) {
           for (const p of proposals) {
             console.log(`  ${c.yellow}[^${p.footnote}]${c.reset} ${p.fixType}: ${p.explanation}`);
-            console.log(`    ${c.red}- ${truncate(p.original, 100)}${c.reset}`);
-            console.log(`    ${c.green}+ ${truncate(p.replacement, 100)}${c.reset}`);
+            console.log(`    ${c.red}- ${truncate(p.original, 103, { oneLine: true, ellipsis: '...' })}${c.reset}`);
+            console.log(`    ${c.green}+ ${truncate(p.replacement, 103, { oneLine: true, ellipsis: '...' })}${c.reset}`);
           }
         }
 
@@ -2090,10 +2091,6 @@ async function main() {
   process.exit(0);
 }
 
-function truncate(s: string, maxLen: number): string {
-  const oneLine = s.replace(/\n/g, ' ');
-  return oneLine.length > maxLen ? oneLine.slice(0, maxLen) + '...' : oneLine;
-}
 
 // Only run when executed directly
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/crux/commands/agent-workspace.ts
+++ b/crux/commands/agent-workspace.ts
@@ -30,6 +30,7 @@ import os from 'os';
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { getColors } from '../lib/output.ts';
+import { truncate } from '../lib/text-utils.ts';
 import {
   type Role,
   type SentinelEnv,
@@ -1102,7 +1103,7 @@ async function dispatchStatusCmd(args: string[], options: DispatchCliOptions): P
   lines.push(`  session: ${current.sessionId}`);
   lines.push(`  pid:     ${current.pid}  alive=${alive}`);
   lines.push(`  started: ${current.startedAt}  (${elapsedSec}s ago)`);
-  lines.push(`  prompt:  ${meta.prompt.length > 120 ? meta.prompt.slice(0, 119) + '…' : meta.prompt}`);
+  lines.push(`  prompt:  ${truncate(meta.prompt, 120)}`);
   if (meta.totalCostUsd !== undefined) {
     lines.push(`  cost:    $${meta.totalCostUsd.toFixed(4)}  turns: ${meta.numTurns}  duration: ${((meta.durationMs ?? 0) / 1000).toFixed(1)}s`);
   }

--- a/crux/commands/audit.ts
+++ b/crux/commands/audit.ts
@@ -17,6 +17,7 @@ import {
   listRecentAuditEntries,
   type AuditRecentResponse,
 } from '../lib/wiki-server/audit-log.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 interface CommandOptions extends BaseOptions {
   ci?: boolean;
@@ -41,11 +42,6 @@ function formatChangedAt(value: AuditEntry['changedAt']): string {
   if (!value) return '—';
   const d = new Date(value);
   return d.toISOString().slice(0, 19).replace('T', ' ') + 'Z';
-}
-
-function truncate(str: string, max: number): string {
-  if (str.length <= max) return str;
-  return str.slice(0, max - 1) + '…';
 }
 
 function summarizeRow(row: Record<string, unknown> | null | undefined): string {

--- a/crux/commands/clean-contradicted.ts
+++ b/crux/commands/clean-contradicted.ts
@@ -14,6 +14,7 @@ import type { CommandResult } from '../lib/command-types.ts';
 import { getFailures, type VerdictEntry } from '../lib/wiki-server/sourcing.ts';
 import { apiRequest } from '../lib/wiki-server/client.ts';
 import { deleteBatch } from '../lib/wiki-server/delete-batch.ts';
+import { truncate } from '../lib/text-utils.ts';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -208,7 +209,7 @@ export async function cleanContradictedCommand(
       const status = record ? '\x1b[31m✗\x1b[0m' : '\x1b[2m⊘\x1b[0m';
       lines.push(`  ${status} ${name}`);
       if (v.reasoning) {
-        lines.push(`    \x1b[2m${v.reasoning.slice(0, 150)}${v.reasoning.length > 150 ? '...' : ''}\x1b[0m`);
+        lines.push(`    \x1b[2m${truncate(v.reasoning, 153, { ellipsis: '...' })}\x1b[0m`);
       }
     }
     lines.push('');

--- a/crux/commands/factbase-sourcing.ts
+++ b/crux/commands/factbase-sourcing.ts
@@ -30,6 +30,7 @@ import { parseJsonResponse } from '../lib/anthropic.ts';
 import { storeSourcingEvidence, storeAggregateVerdict } from '../lib/sourcing/verdict-handler.ts';
 import { fetchVerdictRecordIds } from '../lib/wiki-server/sourcing-client.ts';
 import type { SourceFetchErrorType } from '../lib/search/paywall-detection.ts';
+import { truncate } from '../lib/text-utils.ts';
 import { fetchSourceContent } from '../lib/sourcing/source-fetcher.ts';
 import {
   SOURCE_CHECK_FALSE_POSITIVE_GUIDELINES,
@@ -413,8 +414,8 @@ export async function sourcingCommand(
       const asOf = fact.asOf ?? '';
       const source = fact.source ?? '';
       // Truncate long values and URLs for display
-      const valStr = val.length > 18 ? val.slice(0, 17) + '…' : val;
-      const srcStr = source.length > 50 ? source.slice(0, 49) + '…' : source;
+      const valStr = truncate(val, 18);
+      const srcStr = truncate(source, 50);
       lines.push(
         `${entity.name.slice(0, 23).padEnd(24)} ${(property?.name ?? fact.propertyId).slice(0, 23).padEnd(24)} ${valStr.padEnd(20)} ${asOf.padEnd(12)} ${srcStr}`,
       );

--- a/crux/commands/footnotes.ts
+++ b/crux/commands/footnotes.ts
@@ -14,6 +14,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { CONTENT_DIR_ABS } from '../lib/content-types.ts';
 import { findMdxFiles } from '../lib/file-utils.ts';
 import { batchedRequest, isServerAvailable } from '../lib/wiki-server/client.ts';
+import { truncate } from '../lib/text-utils.ts';
 import { normalizeUrlForDedup } from '../lib/footnote-parser.ts';
 import { buildKBFactSourceMap, type KBFactMatch } from '../lib/factbase-fact-lookup.ts';
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
@@ -373,9 +374,7 @@ async function migrateCrCommand(
         ? '\x1b[32mKB\x1b[0m'
         : '\x1b[33mrc\x1b[0m';
       // Truncate description to fit on one line
-      const desc = action.description.length > 50
-        ? action.description.slice(0, 50) + '...'
-        : action.description;
+      const desc = truncate(action.description, 53, { ellipsis: '...' });
       lines.push(`  ${arrow}  (${tag}: ${desc})`);
     }
     lines.push('');

--- a/crux/commands/matrix.ts
+++ b/crux/commands/matrix.ts
@@ -16,6 +16,7 @@ import type { CommandOptions as BaseOptions, CommandResult } from '../lib/comman
 import { readFileSync, existsSync, appendFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 const STUB_THRESHOLD = 100;
 const EXCLUSION_FILE = join(PROJECT_ROOT, '.matrix-improved.txt');
@@ -240,7 +241,7 @@ async function pagesCommand(_args: string[], options: CommandOptions): Promise<C
     `${'─'.repeat(3)} ${'─'.repeat(8)} ${'─'.repeat(8)} ${'─'.repeat(36)} ${'─'.repeat(16)} ${'─'.repeat(3)} ${'─'.repeat(4)} ${'─'.repeat(6)} ${'─'.repeat(30)}`,
   ].filter(Boolean);
   limited.forEach((p, i) => {
-    const title = p.title.length > 35 ? p.title.slice(0, 32) + '...' : p.title;
+    const title = truncate(p.title, 35, { ellipsis: '...' });
     const ac = p.action === 'create' ? '\x1b[33m' : '\x1b[32m';
     lines.push(`${String(i + 1).padStart(3)} ${p.wikiId.padEnd(8)} ${ac}${p.action.padEnd(8)}\x1b[0m ${title.padEnd(36)} ${p.entityType.padEnd(16)} ${String(p.quality).padStart(3)} ${(p.coveragePct + '%').padStart(4)} ${String(p.impactScore).padStart(6)} ${p.reasons.join(', ')}`);
   });

--- a/crux/commands/pages.ts
+++ b/crux/commands/pages.ts
@@ -12,6 +12,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { computeNBABatch, type PageInput } from '../lib/next-best-action.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 interface CommandOptions extends BaseOptions {
   type?: string;
@@ -69,7 +70,7 @@ async function nextActionCommand(_args: string[], options: CommandOptions): Prom
     const s = limited[i];
     const nid = s.wikiId !== s.id ? ` (${s.wikiId})` : '';
     const label = `${s.title}${nid}`;
-    const truncLabel = label.length > 39 ? label.slice(0, 36) + '...' : label;
+    const truncLabel = truncate(label, 39, { ellipsis: '...' });
     const scoreStr = s.priority.toFixed(2);
     const color = s.priority >= 0.8 ? '\x1b[31m' : s.priority >= 0.4 ? '\x1b[33m' : '\x1b[32m';
     const reason = s.reasons.length > 0 ? s.reasons.join(', ') : 'marginal deficit';

--- a/crux/commands/query.ts
+++ b/crux/commands/query.ts
@@ -40,6 +40,7 @@ import { getAllEditLogs } from '../lib/wiki-server/edit-logs.ts';
 import { getCitationBrokenQuotes } from '../lib/wiki-server/citations.ts';
 import { getRiskHistory, getRiskLatest } from '../lib/wiki-server/risk.ts';
 import { getHealth } from '../lib/wiki-server/health.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -91,7 +92,7 @@ export async function search(args: string[], options: Record<string, unknown>): 
     output += `${c.bold}${String(i + 1).padStart(2)}.${c.reset} ${c.cyan}${r.id}${c.reset}${typeStr}\n`;
     output += `    ${c.bold}${r.title}${c.reset} ${c.dim}(score: ${scoreStr})${c.reset}\n`;
     if (r.description) {
-      output += `    ${c.dim}${r.description.slice(0, 120)}${r.description.length > 120 ? '…' : ''}${c.reset}\n`;
+      output += `    ${c.dim}${truncate(r.description, 121)}${c.reset}\n`;
     }
     output += '\n';
   }
@@ -128,7 +129,7 @@ export async function entity(args: string[], options: Record<string, unknown>): 
   let output = `${c.bold}${c.blue}Entity: ${e.id}${c.reset}\n\n`;
   output += `  ${c.bold}Type:${c.reset}    ${e.entityType}\n`;
   output += `  ${c.bold}Title:${c.reset}   ${e.title}\n`;
-  if (e.description) output += `  ${c.bold}Desc:${c.reset}    ${e.description.slice(0, 200)}${e.description.length > 200 ? '…' : ''}\n`;
+  if (e.description) output += `  ${c.bold}Desc:${c.reset}    ${truncate(e.description, 201)}\n`;
   if (e.website) output += `  ${c.bold}Website:${c.reset} ${e.website}\n`;
   if (e.status) output += `  ${c.bold}Status:${c.reset}  ${e.status}\n`;
   if (e.tags?.length) output += `  ${c.bold}Tags:${c.reset}    ${e.tags.join(', ')}\n`;
@@ -356,11 +357,11 @@ export async function page(args: string[], options: Record<string, unknown>): Pr
   if (p.tags) output += `  ${c.bold}Tags:${c.reset}        ${p.tags}\n`;
   if (p.description) {
     output += `\n  ${c.bold}Description:${c.reset}\n`;
-    output += `  ${p.description.slice(0, 400)}${p.description.length > 400 ? '…' : ''}\n`;
+    output += `  ${truncate(p.description, 401)}\n`;
   }
   if (p.summary && options.summary) {
     output += `\n  ${c.bold}Summary:${c.reset}\n`;
-    output += `  ${p.summary.slice(0, 600)}${p.summary.length > 600 ? '…' : ''}\n`;
+    output += `  ${truncate(p.summary, 601)}\n`;
   }
 
   output += `\n  ${c.dim}Synced: ${p.syncedAt}${c.reset}`;
@@ -489,8 +490,8 @@ export async function citations(args: string[], options: Record<string, unknown>
       const scoreStr = b.verificationScore !== null ? ` (score: ${b.verificationScore.toFixed(2)})` : '';
       output += `${c.bold}${b.pageId}${c.reset} — footnote ${b.footnote}${scoreStr}\n`;
       if ('sourceTitle' in b && (b as Record<string, unknown>).sourceTitle) output += `  Source: ${(b as Record<string, unknown>).sourceTitle}\n`;
-      if (b.url) output += `  URL: ${c.dim}${b.url.slice(0, 80)}${b.url.length > 80 ? '…' : ''}${c.reset}\n`;
-      output += `  ${c.dim}${b.claimText.slice(0, 100)}${b.claimText.length > 100 ? '…' : ''}${c.reset}\n\n`;
+      if (b.url) output += `  URL: ${c.dim}${truncate(b.url, 81)}${c.reset}\n`;
+      output += `  ${c.dim}${truncate(b.claimText, 101)}${c.reset}\n\n`;
     }
 
     return { output: output.trimEnd(), exitCode: 0 };
@@ -534,7 +535,7 @@ export async function citations(args: string[], options: Record<string, unknown>
     if (q.verificationScore !== null) output += ` ${c.dim}(${q.verificationScore.toFixed(2)})${c.reset}`;
     output += '\n';
     if (q.sourceTitle) output += `  ${c.dim}Source: ${q.sourceTitle}${c.reset}\n`;
-    output += `  ${q.claimText.slice(0, 120)}${q.claimText.length > 120 ? '…' : ''}\n\n`;
+    output += `  ${truncate(q.claimText, 121)}\n\n`;
   }
 
   if (total > quotes.length) {

--- a/crux/commands/sourcing-apply-suggestions.ts
+++ b/crux/commands/sourcing-apply-suggestions.ts
@@ -47,6 +47,7 @@ import {
 } from '../lib/sourcing/index.ts';
 import { SOURCE_CHECK_RESPONSE_FORMAT } from '../lib/sourcing/prompt-guidelines.ts';
 import type { SourcingVerdict } from '../../apps/wiki-server/src/api-types.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 // ── Constants ────────────────────────────────────────────────────────
 
@@ -504,9 +505,7 @@ async function applyCommand(
   for (let i = 0; i < toApply.length; i++) {
     const candidate = toApply[i];
     const label = `${candidate.recordType}/${candidate.recordId}`.slice(0, 60);
-    const urlShort = candidate.suggestedUrl.length > 80
-      ? candidate.suggestedUrl.slice(0, 77) + '...'
-      : candidate.suggestedUrl;
+    const urlShort = truncate(candidate.suggestedUrl, 80, { ellipsis: '...' });
     console.log(`  [${i + 1}/${toApply.length}] ${label} → ${urlShort}`);
 
     summary.processed++;
@@ -630,8 +629,8 @@ function formatDryRunOutput(
   lines.push(`\x1b[1m${header}\x1b[0m`);
   lines.push('-'.repeat(120));
   for (const item of items.slice(0, 30)) {
-    const rid = item.recordId.length > 28 ? item.recordId.slice(0, 27) + '...' : item.recordId;
-    const url = item.suggestedUrl.length > 50 ? item.suggestedUrl.slice(0, 47) + '...' : item.suggestedUrl;
+    const rid = truncate(item.recordId, 30, { ellipsis: '...' });
+    const url = truncate(item.suggestedUrl, 50, { ellipsis: '...' });
     lines.push(
       `${String(item.id).padEnd(8)} ${item.recordType.padEnd(16)} ${rid.padEnd(30)} ${item.status.padEnd(14)} ${url}`,
     );

--- a/crux/commands/sourcing-audit-urls.ts
+++ b/crux/commands/sourcing-audit-urls.ts
@@ -27,6 +27,7 @@ import {
   extractHost,
   FLAG_THRESHOLD,
 } from '../lib/sourcing/url-quality.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 // Re-export for callers that still import from this file (Phase 1 compat).
 export { classifyByUrl, normalizeUrlForJoin, extractHost };
@@ -288,9 +289,9 @@ function formatHumanOutput(
     lines.push(bold('Sample flagged evidence:'));
     lines.push('-'.repeat(100));
     for (const r of flagged) {
-      const id = r.recordId.length > 24 ? r.recordId.slice(0, 22) + '..' : r.recordId;
+      const id = truncate(r.recordId, 24, { ellipsis: '..' });
       const field = r.fieldName ? `.${r.fieldName}` : '';
-      const url = r.sourceUrl.length > 60 ? r.sourceUrl.slice(0, 57) + '...' : r.sourceUrl;
+      const url = truncate(r.sourceUrl, 60, { ellipsis: '...' });
       lines.push(`  ${r.verdict.padEnd(14)} ${r.recordType.padEnd(18)} ${(id + field).padEnd(28)} ${url}`);
     }
   }

--- a/crux/commands/sourcing-backfill-homepages.ts
+++ b/crux/commands/sourcing-backfill-homepages.ts
@@ -28,6 +28,7 @@ import { loadResourcesPGFirst } from '../resource-io.ts';
 import { upsertResourceBatch, type UpsertResourceItem } from '../lib/wiki-server/resources.ts';
 import { classifyByUrl } from './sourcing-audit-urls.ts';
 import type { Resource } from '../resource-types.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 // ── Module constants ────────────────────────────────────────────────
 
@@ -261,7 +262,7 @@ async function backfillCommand(
   console.log(bold(`Sample URLs (first ${SAMPLE_URLS_SHOWN})`));
   console.log('-'.repeat(72));
   for (const c of limited.slice(0, SAMPLE_URLS_SHOWN)) {
-    const url = c.url.length > 65 ? c.url.slice(0, 62) + '...' : c.url;
+    const url = truncate(c.url, 65, { ellipsis: '...' });
     console.log(`  [conf=${c.confidence.toFixed(2)}] ${url}`);
   }
   console.log('');

--- a/crux/commands/sourcing-recheck.ts
+++ b/crux/commands/sourcing-recheck.ts
@@ -28,6 +28,7 @@ import {
   SOURCE_CHECK_CONSTANTS,
 } from '../lib/sourcing/index.ts';
 import { SOURCE_CHECK_RESPONSE_FORMAT } from '../lib/sourcing/prompt-guidelines.ts';
+import { truncate } from '../lib/text-utils.ts';
 import type { SourcingVerdict } from '../../apps/wiki-server/src/api-types.ts';
 import { extractQid } from '../lib/sourcing/wikidata-matcher.ts';
 
@@ -595,7 +596,7 @@ function formatDryRunOutput(
     const lastChecked = item.lastComputedAt
       ? new Date(item.lastComputedAt).toISOString().slice(0, 10)
       : 'never';
-    const id = item.recordId.length > 28 ? item.recordId.slice(0, 27) + '...' : item.recordId;
+    const id = truncate(item.recordId, 30, { ellipsis: '...' });
     lines.push(
       `${String(item.priority).padEnd(10)} ${item.verdict.padEnd(15)} ${item.recordType.padEnd(20)} ${id.padEnd(30)} ${lastChecked}`,
     );

--- a/crux/commands/sourcing-wiki-pages.ts
+++ b/crux/commands/sourcing-wiki-pages.ts
@@ -15,6 +15,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
+import { truncate } from '../lib/text-utils.ts';
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import {
   loadPages,
@@ -786,7 +787,7 @@ function formatDryRunOutput(
     const { page } = selectedPages[i];
     const slug = extractPageSlug(page);
     const importance = String(page.readerImportance ?? 0);
-    const title = page.title.length > 50 ? page.title.slice(0, 49) + '...' : page.title;
+    const title = truncate(page.title, 52, { ellipsis: '...' });
     lines.push(
       `${String(i + 1).padEnd(4)} ${slug.padEnd(30)} ${importance.padEnd(12)} ${title}`,
     );
@@ -846,7 +847,7 @@ function formatSummaryOutput(
     lines.push('-'.repeat(75));
 
     for (const r of results) {
-      const name = r.pageSlug.length > 28 ? r.pageSlug.slice(0, 27) + '...' : r.pageSlug;
+      const name = truncate(r.pageSlug, 30, { ellipsis: '...' });
       lines.push(
         `${name.padEnd(30)} ${String(r.totalClaims).padEnd(8)} ${String(r.confirmed).padEnd(5)} ${String(r.contradicted).padEnd(5)} ${String(r.outdated + r.staleClaims).padEnd(6)} ${String(r.unfootnotedClaims).padEnd(6)} ${String(r.errors).padEnd(5)}`,
       );

--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -18,6 +18,7 @@ import type { CommandOptions as BaseOptions, CommandResult } from '../lib/comman
 import type { TaskType } from '../tablebase/types.ts';
 import { TASK_TYPES, toSlug } from '../tablebase/types.ts';
 import { summarizeRecordForManifest } from '../tablebase/manifest-record.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 // Consolidated orphan domain imports
 import { commands as backfillGranteeIdsCommands } from './backfill-grantee-ids.ts';
@@ -1447,7 +1448,7 @@ async function sourceDiscoverCommand(args: string[], options: CommandOptions): P
       for (const s of result.sources) {
         lines.push(`  ${s.title} (${s.claims.length} claims)`);
         for (const c of s.claims.slice(0, 3)) {
-          lines.push(`    - ${c.claimText.slice(0, 100)}${c.claimText.length > 100 ? '...' : ''}`);
+          lines.push(`    - ${truncate(c.claimText, 103, { ellipsis: '...' })}`);
         }
         if (s.claims.length > 3) {
           lines.push(`    ... and ${s.claims.length - 3} more`);

--- a/crux/commands/wikidata-enrich.ts
+++ b/crux/commands/wikidata-enrich.ts
@@ -27,6 +27,7 @@ import {
   findEntityFilePath,
 } from '../lib/factbase-writer.ts';
 import type { Entity, Fact } from '../../packages/factbase/src/types.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -469,9 +470,7 @@ async function wikidataEnrichCommand(
     for (const nf of newFacts) {
       const displayValue =
         typeof nf.value === 'string'
-          ? nf.value.length > 60
-            ? nf.value.slice(0, 57) + '...'
-            : nf.value
+          ? truncate(nf.value, 60, { ellipsis: '...' })
           : String(nf.value);
       log(`    + ${nf.property}: ${displayValue}`);
     }

--- a/crux/generate/generate-data-diagrams.ts
+++ b/crux/generate/generate-data-diagrams.ts
@@ -10,6 +10,7 @@
 import { readFileSync, writeFileSync, readdirSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { parse as parseYaml } from 'yaml';
+import { truncate } from '../lib/text-utils.ts';
 
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
@@ -149,7 +150,7 @@ flowchart LR
     diagram += `    subgraph ${safeType}["${type}"]\n`;
     for (const node of typeNodes) {
       // Truncate long labels
-      const shortLabel = node.label.length > 25 ? node.label.slice(0, 22) + '...' : node.label;
+      const shortLabel = truncate(node.label, 25, { ellipsis: '...' });
       diagram += `        ${node.id}["${shortLabel}"]\n`;
     }
     diagram += `    end\n\n`;

--- a/crux/importance/rerank.ts
+++ b/crux/importance/rerank.ts
@@ -21,6 +21,7 @@ import { createLogger, createProgress } from '../lib/output.ts';
 import { loadPages } from '../lib/content-types.ts';
 import { createLlmClient, callLlm, MODELS } from '../lib/llm.ts';
 import { sleep } from '../lib/anthropic.ts';
+import { truncate } from '../lib/text-utils.ts';
 import {
   loadRanking,
   saveRanking,
@@ -163,9 +164,7 @@ interface PageInfo {
 function formatPageForBatch(page: PageInfo): string {
   let line = `- ${page.id}: "${page.title}"`;
   if (page.description) {
-    const desc = page.description.length > 120
-      ? page.description.slice(0, 117) + '...'
-      : page.description;
+    const desc = truncate(page.description, 120, { ellipsis: '...' });
     line += ` — ${desc}`;
   }
   if (page.category) {

--- a/crux/lib/agent-workspace/dispatch.ts
+++ b/crux/lib/agent-workspace/dispatch.ts
@@ -29,6 +29,7 @@ import {
 } from 'fs';
 import { spawn as cpSpawn, type ChildProcess, type SpawnOptions } from 'child_process';
 import { prepareClaudeSpawnEnv } from '../claude-cli.ts';
+import { truncate } from '../text-utils.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -395,8 +396,7 @@ export function writeMeta(env: DispatchEnv, rp: RunPaths, meta: RunMeta): void {
 // ---------------------------------------------------------------------------
 
 function clip(s: string, n = 160): string {
-  const oneLine = s.replace(/\s+/g, ' ').trim();
-  return oneLine.length > n ? oneLine.slice(0, n - 1) + '…' : oneLine;
+  return truncate(s.replace(/\s+/g, ' ').trim(), n);
 }
 
 /** Parse a single stream-json line into a summary, or `null` if unparseable. */

--- a/crux/lib/aiid/transform.ts
+++ b/crux/lib/aiid/transform.ts
@@ -15,6 +15,7 @@
  */
 
 import { generateId } from "../grant-import/id.ts";
+import { truncate } from "../text-utils.ts";
 
 /** AIID "incidents" collection row (subset we consume). */
 export interface AiidIncidentRaw {
@@ -265,11 +266,7 @@ function buildTags(
 
 /** Tighten a free-form summary into the column budget without hard-breaking words. */
 export function truncateSummary(text: string, max = SUMMARY_MAX_CHARS): string {
-  if (text.length <= max) return text;
-  const trimmed = text.slice(0, max - 3);
-  const lastSpace = trimmed.lastIndexOf(" ");
-  const base = lastSpace > max / 2 ? trimmed.slice(0, lastSpace) : trimmed;
-  return base + "...";
+  return truncate(text, max, { wordBoundary: true, ellipsis: "..." });
 }
 
 export interface TransformOptions {

--- a/crux/lib/footnote-parser.ts
+++ b/crux/lib/footnote-parser.ts
@@ -8,6 +8,7 @@
  */
 
 import { normalizeUrl, normalizeUrlForDedup } from "@longterm-wiki/url-utils";
+import { truncate } from "./text-utils.ts";
 
 // Re-export the canonical dedup helper for back-compat with existing
 // `import { normalizeUrlForDedup } from '../footnote-parser.ts'` callers.
@@ -169,7 +170,7 @@ function extractTitleFromText(text: string): string | null {
   if (/^https?:\/\//.test(cleaned)) return cleaned;
   // First sentence — find period followed by space or end (not mid-URL periods)
   const sentence = cleaned.match(/^.+?(?:\.\s|[!?]|$)/)?.[0]?.trim() || cleaned;
-  return sentence.length > 120 ? sentence.slice(0, 117) + "..." : sentence;
+  return truncate(sentence, 120, { ellipsis: "..." });
 }
 
 /**

--- a/crux/lib/oecd-aim/transform.ts
+++ b/crux/lib/oecd-aim/transform.ts
@@ -20,6 +20,7 @@
  */
 
 import { generateId } from "../grant-import/id.ts";
+import { truncate } from "../text-utils.ts";
 
 /** OECD AIM incident shape returned by `/api/v1/incidents/fetch-incidents`. */
 export interface OecdAimIncidentRaw {
@@ -167,11 +168,7 @@ export function generateIncidentId(sourceIncidentId: string): string {
 
 /** Tighten a free-form summary into the column budget without hard-breaking words. */
 export function truncateSummary(text: string, max = SUMMARY_MAX_CHARS): string {
-  if (text.length <= max) return text;
-  const trimmed = text.slice(0, max - 3);
-  const lastSpace = trimmed.lastIndexOf(" ");
-  const base = lastSpace > max / 2 ? trimmed.slice(0, lastSpace) : trimmed;
-  return base + "...";
+  return truncate(text, max, { wordBoundary: true, ellipsis: "..." });
 }
 
 /**

--- a/crux/lib/quote-extractor.ts
+++ b/crux/lib/quote-extractor.ts
@@ -9,6 +9,7 @@
 
 import { getApiKey } from './api-keys.ts';
 import { withRetry } from './resilience.ts';
+import { truncate } from './text-utils.ts';
 
 const OPENROUTER_API_KEY = getApiKey('OPENROUTER_API_KEY');
 const BASE_URL = 'https://openrouter.ai/api/v1/chat/completions';
@@ -57,11 +58,13 @@ function normalizeDifficulty(raw: unknown): string {
   return 'medium'; // default if unrecognizable
 }
 
+const TRUNCATION_MARKER = '\n\n[... truncated ...]';
+
 /** Truncate source text to MAX_SOURCE_CHARS, adding a truncation marker. */
 export function truncateSource(text: string): string {
-  return text.length > MAX_SOURCE_CHARS
-    ? text.slice(0, MAX_SOURCE_CHARS) + '\n\n[... truncated ...]'
-    : text;
+  return truncate(text, MAX_SOURCE_CHARS + TRUNCATION_MARKER.length, {
+    ellipsis: TRUNCATION_MARKER,
+  });
 }
 
 /** Strip markdown code fences from LLM JSON responses. */

--- a/crux/lib/rules/markdown-lists.ts
+++ b/crux/lib/rules/markdown-lists.ts
@@ -19,6 +19,7 @@
 
 import { createRule, Issue, Severity, FixType, type ContentFile, type ValidationEngine } from '../validation/validation-engine.ts';
 import { isInCodeBlock } from '../mdx-utils.ts';
+import { truncate } from '../text-utils.ts';
 
 // Pattern: line starting with a number > 1 followed by period and space
 const NUMBERED_LIST_PATTERN = /^(\d+)\.\s+/;
@@ -58,7 +59,7 @@ export const markdownListsRule = createRule({
                 rule: this.id,
                 file: content.path,
                 line: lineNum,
-                message: `Numbered list starting with "${listNumber}." needs a blank line before it (otherwise won't render as a list). Previous line: "${prevLine.slice(0, 50)}${prevLine.length > 50 ? '...' : ''}"`,
+                message: `Numbered list starting with "${listNumber}." needs a blank line before it (otherwise won't render as a list). Previous line: "${truncate(prevLine, 53, { ellipsis: '...' })}"`,
                 severity: Severity.ERROR,
                 fix: {
                   type: FixType.INSERT_LINE_BEFORE,

--- a/crux/lib/rules/no-url-footnotes.ts
+++ b/crux/lib/rules/no-url-footnotes.ts
@@ -25,6 +25,7 @@
  */
 
 import { Severity, Issue, type ContentFile, type ValidationEngine } from '../validation/validation-engine.ts';
+import { truncate } from '../text-utils.ts';
 
 /** Matches a footnote definition line: `[^N]: <rest>` */
 const FOOTNOTE_DEF_RE = /^\[\^(\d+)\]:\s*(.+)/;
@@ -88,9 +89,10 @@ export const noUrlFootnotesRule = {
         lowerBody.includes(phrase)
       );
 
+      const truncatedBody = truncate(body, 81);
       const message = isExplicitPlaceholder
-        ? `Footnote [^${footnoteNum}] has no URL and contains a placeholder: "${body.slice(0, 80)}${body.length > 80 ? '…' : ''}". Replace with a real source or remove the footnote.`
-        : `Footnote [^${footnoteNum}] has no URL: "${body.slice(0, 80)}${body.length > 80 ? '…' : ''}". Add a markdown link [Title](https://...) or a bare URL.`;
+        ? `Footnote [^${footnoteNum}] has no URL and contains a placeholder: "${truncatedBody}". Replace with a real source or remove the footnote.`
+        : `Footnote [^${footnoteNum}] has no URL: "${truncatedBody}". Add a markdown link [Title](https://...) or a bare URL.`;
 
       issues.push(
         new Issue({

--- a/crux/lib/session/sessions-list.test.ts
+++ b/crux/lib/session/sessions-list.test.ts
@@ -338,6 +338,9 @@ describe('truncate', () => {
     expect(truncate(null, 5)).toBe('—');
     expect(truncate(undefined, 5)).toBe('—');
   });
+  it('returns — for empty string (regression — empty string is falsy)', () => {
+    expect(truncate('', 5)).toBe('—');
+  });
 });
 
 describe('toDisplayRow', () => {

--- a/crux/lib/session/sessions-list.ts
+++ b/crux/lib/session/sessions-list.ts
@@ -196,7 +196,8 @@ export function sortSessions(rows: MergedSession[]): MergedSession[] {
 // ---------------------------------------------------------------------------
 
 export function truncate(s: string | null | undefined, width: number): string {
-  return truncateText(s, width, { fallback: '—' });
+  if (!s) return '—';
+  return truncateText(s, width);
 }
 
 export function formatAge(minutes: number | null): string {

--- a/crux/lib/session/sessions-list.ts
+++ b/crux/lib/session/sessions-list.ts
@@ -18,6 +18,7 @@
 
 import type { AgentSessionListResponse } from '../wiki-server/agent-sessions.ts';
 import type { ClaudeProcess } from './claude-processes.ts';
+import { truncate as truncateText } from '../text-utils.ts';
 
 type DbSession = AgentSessionListResponse['sessions'][number];
 
@@ -195,9 +196,7 @@ export function sortSessions(rows: MergedSession[]): MergedSession[] {
 // ---------------------------------------------------------------------------
 
 export function truncate(s: string | null | undefined, width: number): string {
-  if (!s) return '—';
-  if (s.length <= width) return s;
-  return s.slice(0, width - 1) + '…';
+  return truncateText(s, width, { fallback: '—' });
 }
 
 export function formatAge(minutes: number | null): string {

--- a/crux/lib/sourcing/orchestrator.ts
+++ b/crux/lib/sourcing/orchestrator.ts
@@ -5,6 +5,7 @@
 
 import type { CommandResult } from '../command-types.ts';
 import { loadDatabase, loadPages } from '../content-types.ts';
+import { truncate } from '../text-utils.ts';
 import { loadGraphFull } from '../factbase-loader.ts';
 import { createLlmClient } from '../llm.ts';
 import { submitBatch, pollBatch, getBatchResults, extractBatchResultText, sanitizeBatchCustomId } from '../anthropic-batch.ts';
@@ -761,9 +762,9 @@ function formatDryRunOutput(
 
   for (const item of topItems) {
     const status = item.neverVerified ? '\x1b[33mnew\x1b[0m' : 'verified';
-    const desc = item.description.length > 58 ? item.description.slice(0, 57) + '...' : item.description;
+    const desc = truncate(item.description, 60, { ellipsis: '...' });
     const src = item.sourceUrl
-      ? (item.sourceUrl.length > 30 ? item.sourceUrl.slice(0, 29) + '...' : item.sourceUrl)
+      ? truncate(item.sourceUrl, 32, { ellipsis: '...' })
       : '(none)';
     lines.push(
       `${item.kind.padEnd(8)} ${String(item.priority.toFixed(0)).padEnd(10)} ${status.padEnd(12)} ${desc.padEnd(60)} ${src}`,

--- a/crux/lib/sourcing/source-discover.ts
+++ b/crux/lib/sourcing/source-discover.ts
@@ -39,6 +39,7 @@ import { parseAndValidate } from '../json-parsing.ts';
 import { CostTracker } from '../cost-tracker.ts';
 import { sanitizeBatchCustomId, type BatchRequest } from '../anthropic-batch.ts';
 import { withPipelineRun } from '../pipeline-runs/lifecycle.ts';
+import { truncate } from '../text-utils.ts';
 
 // ── Constants ────────────────────────────────────────────────────────
 
@@ -174,14 +175,15 @@ type RawResponse = z.infer<typeof ResponseSchema>;
  * prompt size (cost) or pushing the real instructions out of context. */
 const MAX_USER_FIELD_LENGTH = 2000;
 
+const TRUNCATE_MARKER = '… (truncated)';
+
 /**
  * Truncate a possibly-untrusted string field to bound prompt size.
  * Returns null/undefined as-is so JSON encoding emits `null` not `"null"`.
  */
 function truncateField(s: string | null | undefined, max = MAX_USER_FIELD_LENGTH): string | null {
   if (s == null) return null;
-  if (s.length <= max) return s;
-  return s.slice(0, max) + '… (truncated)';
+  return truncate(s, max + TRUNCATE_MARKER.length, { ellipsis: TRUNCATE_MARKER });
 }
 
 /**

--- a/crux/lib/sourcing/url-resolves-verifier.ts
+++ b/crux/lib/sourcing/url-resolves-verifier.ts
@@ -46,6 +46,7 @@ import type { SourcingVerdict } from '../../../apps/wiki-server/src/api-types.ts
 import { getCitationContentByUrl } from '../wiki-server/citations.ts';
 import { lookupResourceByUrl, suggestResourcesApi } from '../wiki-server/resources.ts';
 import type { VerifyItem, VerifyResult } from './orchestrator-types.ts';
+import { truncate } from '../text-utils.ts';
 
 const CONFIDENCE_DEFINITE = 0.95;
 const CONFIDENCE_HIGH = 0.85;
@@ -310,6 +311,3 @@ function looksLikeUrl(s: string): boolean {
   return true;
 }
 
-function truncate(s: string, n: number): string {
-  return s.length <= n ? s : `${s.slice(0, n - 1)}…`;
-}

--- a/crux/lib/text-utils.test.ts
+++ b/crux/lib/text-utils.test.ts
@@ -21,6 +21,16 @@ describe('truncate', () => {
     it('honors custom fallback', () => {
       expect(truncate(null, 10, { fallback: '—' })).toBe('—');
     });
+
+    it('treats empty string as a non-null value (NOT fallback)', () => {
+      // Wrappers that want '' to map to fallback must guard with !s themselves.
+      // sessions-list's truncate() does this; see its test for the regression.
+      expect(truncate('', 10, { fallback: '—' })).toBe('');
+    });
+
+    it('preserves \\r in oneLine mode (only \\n is collapsed)', () => {
+      expect(truncate('a\r\nb', 10, { oneLine: true })).toBe('a\r b');
+    });
   });
 
   describe('ellipsis option', () => {
@@ -54,6 +64,20 @@ describe('truncate', () => {
       expect(truncate('abcdefghij', 5, { showCount: true, ellipsis: '...' })).toBe(
         'abcde… [truncated, 5 more chars]',
       );
+    });
+
+    it('ignores wordBoundary when showCount is true (showCount cuts at exact max)', () => {
+      // showCount documents content length, so backing up to a word boundary
+      // would break the "5 more chars" math. The cut must land at exactly max.
+      expect(
+        truncate('hello world foo', 5, { showCount: true, wordBoundary: true }),
+      ).toBe('hello… [truncated, 10 more chars]');
+    });
+
+    it('still collapses newlines when oneLine is set with showCount', () => {
+      expect(
+        truncate('a\nb\nc\nd\ne\nf', 3, { showCount: true, oneLine: true }),
+      ).toBe('a b… [truncated, 8 more chars]');
     });
   });
 

--- a/crux/lib/text-utils.test.ts
+++ b/crux/lib/text-utils.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { truncate } from './text-utils';
+
+describe('truncate', () => {
+  describe('default behavior — single-char ellipsis, budget-inclusive', () => {
+    it('returns short strings unchanged', () => {
+      expect(truncate('hi', 10)).toBe('hi');
+      expect(truncate('exactly 10', 10)).toBe('exactly 10');
+    });
+
+    it('truncates with ellipsis counting toward max', () => {
+      expect(truncate('a long string', 5)).toBe('a lo…');
+      expect(truncate('a long string', 5)).toHaveLength(5);
+    });
+
+    it('handles null/undefined with empty fallback', () => {
+      expect(truncate(null, 10)).toBe('');
+      expect(truncate(undefined, 10)).toBe('');
+    });
+
+    it('honors custom fallback', () => {
+      expect(truncate(null, 10, { fallback: '—' })).toBe('—');
+    });
+  });
+
+  describe('ellipsis option', () => {
+    it('supports 3-dot ASCII ellipsis', () => {
+      expect(truncate('a long string', 8, { ellipsis: '...' })).toBe('a lon...');
+      expect(truncate('a long string', 8, { ellipsis: '...' })).toHaveLength(8);
+    });
+
+    it('supports custom multi-char marker', () => {
+      expect(truncate('hello world', 9, { ellipsis: '… (cut)' })).toBe('he… (cut)');
+    });
+
+    it('handles ellipsis longer than max gracefully', () => {
+      expect(truncate('hello', 2, { ellipsis: '...' })).toBe('..');
+      expect(truncate('hello', 0, { ellipsis: '...' })).toBe('');
+    });
+  });
+
+  describe('showCount', () => {
+    it('appends a count annotation when truncating', () => {
+      expect(truncate('abcdefghij', 5, { showCount: true })).toBe(
+        'abcde… [truncated, 5 more chars]',
+      );
+    });
+
+    it('does nothing when input is short enough', () => {
+      expect(truncate('hi', 5, { showCount: true })).toBe('hi');
+    });
+
+    it('overrides ellipsis when both are set', () => {
+      expect(truncate('abcdefghij', 5, { showCount: true, ellipsis: '...' })).toBe(
+        'abcde… [truncated, 5 more chars]',
+      );
+    });
+  });
+
+  describe('wordBoundary', () => {
+    it('backs up to the last whitespace before the cut', () => {
+      expect(truncate('hello world foo', 10, { wordBoundary: true })).toBe('hello…');
+    });
+
+    it('keeps the cut at the budget if no space exists past half', () => {
+      // budget = 9, half = 4.5. Last space in 'verylongw' is at -1. Use full budget.
+      expect(truncate('verylongword extra', 10, { wordBoundary: true })).toBe('verylongw…');
+    });
+
+    it('falls back to budget cut when the only space is in the first half', () => {
+      // budget=9, sub='a longest', lastSpace=1, 1 < 4.5, so cut at budget.
+      expect(truncate('a longest possible run', 10, { wordBoundary: true })).toBe('a longest…');
+    });
+  });
+
+  describe('oneLine', () => {
+    it('collapses newlines to spaces before measuring', () => {
+      // After collapse: 'line1 line2 line3' (17 chars) → truncated to 11 chars.
+      expect(truncate('line1\nline2\nline3', 11, { oneLine: true })).toBe('line1 line…');
+    });
+
+    it('returns the collapsed form unchanged when shorter than max', () => {
+      expect(truncate('line1\nline2', 20, { oneLine: true })).toBe('line1 line2');
+    });
+
+    it('does not modify content shorter than max', () => {
+      expect(truncate('a\nb', 10, { oneLine: true })).toBe('a b');
+    });
+  });
+
+  describe('combined options', () => {
+    it('supports oneLine + custom ellipsis', () => {
+      expect(truncate('a\nb\nc\nd\ne', 6, { oneLine: true, ellipsis: '...' })).toBe('a b...');
+    });
+
+    it('supports wordBoundary + custom ellipsis', () => {
+      expect(
+        truncate('hello world foo bar', 12, { wordBoundary: true, ellipsis: '...' }),
+      ).toBe('hello...');
+      // budget = 12 - 3 = 9, sub = 'hello wor', lastSpace=5, 5 > 4.5, cut=5 → 'hello'.
+    });
+  });
+});

--- a/crux/lib/text-utils.ts
+++ b/crux/lib/text-utils.ts
@@ -8,9 +8,18 @@
  * so the result has length <= max. This matches the most common existing
  * helper (e.g. sessions-list, audit, t1-allowlist, url-resolves-verifier).
  *
- * For inline `slice(0, N) + '...'` call sites where the existing output
- * is `N` chars of content + 3 char ellipsis (length N+3), pass
- * `{ ellipsis: '...' }` and a `max` of `N + 3` to preserve identical output.
+ * Migrating an inline `slice(0, N) + '...'` call site:
+ *   - For inputs *strictly longer* than `N + ellipsis.length`, pass
+ *     `max = N + ellipsis.length` and `{ ellipsis }` to get identical output.
+ *   - For inputs in the boundary window `(N, N + ellipsis.length]`, the new
+ *     helper passes the input through unchanged; the old code appended the
+ *     marker even when it pushed length above N. Treat this as a strict
+ *     improvement — short inputs no longer carry a redundant marker.
+ *
+ * Empty-string handling: `''` is treated as a non-null string and returned
+ * unchanged (subject to truncation). For wrappers that want the empty-string
+ * sentinel of an old helper (e.g. sessions-list's `'—'`), check `!s` at the
+ * call site before delegating.
  */
 
 export interface TruncateOptions {

--- a/crux/lib/text-utils.ts
+++ b/crux/lib/text-utils.ts
@@ -1,0 +1,76 @@
+/**
+ * Single source of truth for string truncation across crux/.
+ *
+ * Replaces ~9 named `truncate()` / `truncateText()` helpers and dozens of
+ * inline `s.slice(0, N) + '...'` expressions. See QUA-678 for context.
+ *
+ * Default semantics: budget-inclusive — the ellipsis counts toward `max`,
+ * so the result has length <= max. This matches the most common existing
+ * helper (e.g. sessions-list, audit, t1-allowlist, url-resolves-verifier).
+ *
+ * For inline `slice(0, N) + '...'` call sites where the existing output
+ * is `N` chars of content + 3 char ellipsis (length N+3), pass
+ * `{ ellipsis: '...' }` and a `max` of `N + 3` to preserve identical output.
+ */
+
+export interface TruncateOptions {
+  /**
+   * The marker appended when truncation occurs. Counts toward `max`.
+   * Default `'…'` (single Unicode ellipsis, 1 char).
+   */
+  ellipsis?: string;
+  /**
+   * When true, format as `<max-chars-of-content>… [truncated, N more chars]`.
+   * Result length exceeds `max`. Overrides `ellipsis`.
+   * Used by tablebase manifest summaries.
+   */
+  showCount?: boolean;
+  /**
+   * Back up to the last whitespace boundary before the cut, so the last
+   * word isn't sliced mid-letter. Only fires if a space exists past the
+   * half-way point of the budget. Default false.
+   */
+  wordBoundary?: boolean;
+  /** Collapse newlines to spaces before measuring. Default false. */
+  oneLine?: boolean;
+  /** Returned for null/undefined input. Default `''`. */
+  fallback?: string;
+}
+
+/**
+ * Truncate a string so the result fits within `max` characters.
+ *
+ * - Default ellipsis is `'…'` (1 char) and counts toward `max`.
+ * - For 3-dot ASCII ellipsis, pass `{ ellipsis: '...' }`.
+ * - For the count-annotated form, pass `{ showCount: true }`.
+ */
+export function truncate(
+  s: string | null | undefined,
+  max: number,
+  opts: TruncateOptions = {},
+): string {
+  if (s == null) return opts.fallback ?? '';
+  const str = opts.oneLine ? s.replace(/\n/g, ' ') : s;
+  if (str.length <= max) return str;
+
+  if (opts.showCount) {
+    const more = str.length - max;
+    return `${str.slice(0, max)}… [truncated, ${more} more chars]`;
+  }
+
+  const ellipsis = opts.ellipsis ?? '…';
+  const budget = max - ellipsis.length;
+  if (budget <= 0) {
+    // `max` is too small to fit even the ellipsis. Return the leading slice
+    // of the ellipsis itself rather than producing a longer-than-max result.
+    return ellipsis.slice(0, Math.max(0, max));
+  }
+
+  let cut = budget;
+  if (opts.wordBoundary) {
+    const sub = str.slice(0, budget);
+    const lastSpace = sub.lastIndexOf(' ');
+    if (lastSpace > budget / 2) cut = lastSpace;
+  }
+  return str.slice(0, cut) + ellipsis;
+}

--- a/crux/lib/validation/validate-resource-refs.ts
+++ b/crux/lib/validation/validate-resource-refs.ts
@@ -12,6 +12,7 @@
  */
 
 import { loadResourceIdsPGFirst, loadResources } from '../../resource-io.ts';
+import { truncate } from '../text-utils.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -335,7 +336,7 @@ export function validateResourceTitles(
       issues.push({ title: trimmed, reason: `title too short (${trimmed.length} chars)` });
     } else if (trimmed.length > 300) {
       issues.push({
-        title: trimmed.slice(0, 60) + '...',
+        title: truncate(trimmed, 63, { ellipsis: '...' }),
         reason: `title too long (${trimmed.length} chars)`,
       });
     }

--- a/crux/lib/wiki-server/inline-sourcing.ts
+++ b/crux/lib/wiki-server/inline-sourcing.ts
@@ -6,6 +6,7 @@
 
 import type { InlineSourcing } from "../../../apps/wiki-server/src/routes/tablebase/sourcing-schema.ts";
 import { listVerdicts } from "./sourcing-client.ts";
+import { truncate } from "../text-utils.ts";
 
 export type { InlineSourcing };
 
@@ -73,7 +74,5 @@ function isAttachableVerdict(v: string): v is InlineSourcing["verdict"] {
 }
 
 function truncateEvidence(s: string): string {
-  if (s.length <= EVIDENCE_MAX_LENGTH) return s;
-  const head = s.slice(0, EVIDENCE_MAX_LENGTH - TRUNCATION_SUFFIX.length);
-  return head + TRUNCATION_SUFFIX;
+  return truncate(s, EVIDENCE_MAX_LENGTH, { ellipsis: TRUNCATION_SUFFIX });
 }

--- a/crux/scripts/refresh-frameworks.ts
+++ b/crux/scripts/refresh-frameworks.ts
@@ -33,6 +33,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { parse as parseYaml } from 'yaml';
 import { fileURLToPath } from 'url';
+import { truncate } from '../lib/text-utils.ts';
 
 import {
   fetchFramework,
@@ -437,8 +438,7 @@ async function main(): Promise<void> {
   }
 
   // Human-readable table.
-  const pad = (s: string, w: number) =>
-    s.length >= w ? s.slice(0, w - 1) + '…' : s.padEnd(w);
+  const pad = (s: string, w: number) => truncate(s, w).padEnd(w);
   console.log(
     `\nFramework refresh — ${summary.total} frameworks${dryRun ? ' (dry-run)' : ''}\n`,
   );
@@ -447,7 +447,7 @@ async function main(): Promise<void> {
   );
   console.log('  ' + '─'.repeat(30 + 24 + 16 + 6 + 3));
   for (const r of summary.results) {
-    const hash = r.contentHash ? r.contentHash.slice(0, 14) + '…' : '—';
+    const hash = truncate(r.contentHash, 15, { fallback: '—' });
     console.log(
       `  ${pad(r.frameworkKey, 30)} ${pad(r.status, 24)} ${pad(hash, 16)} ${pad(r.alertDelivered ? 'sent' : '—', 6)}`,
     );

--- a/crux/tablebase/agent.ts
+++ b/crux/tablebase/agent.ts
@@ -11,6 +11,7 @@ import { withPipelineRun } from '../lib/pipeline-runs/lifecycle.ts';
 import type { EnrichmentTask, TaskResult } from './types.ts';
 import { getSystemPrompt, getUserPrompt } from './prompts.ts';
 import { getToolDefinitions, buildToolHandlers } from './tools.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 const MAX_TOOL_TURNS = 25;
 
@@ -83,7 +84,7 @@ export async function runEnrichmentAgent(
         heartbeatPhase: 'tablebase-agent',
         costTracker: tracker,
         onToolResult: (toolName, result) => {
-          console.log(`[tablebase]   tool: ${toolName} → ${result.slice(0, 120)}${result.length > 120 ? '...' : ''}`);
+          console.log(`[tablebase]   tool: ${toolName} → ${truncate(result, 123, { ellipsis: '...' })}`);
           // Track records from submit_records calls
           const match = result.match(/Successfully submitted (\d+) records/);
           if (match) totalRecordsCreated += parseInt(match[1], 10);

--- a/crux/tablebase/manifest-record.ts
+++ b/crux/tablebase/manifest-record.ts
@@ -7,12 +7,13 @@
  * level. See QUA-672 for context.
  */
 
+import { truncate as truncateText } from '../lib/text-utils.ts';
+
 const TRUNCATE_FIELDS = new Set(['notes', 'background', 'description']);
 const TRUNCATE_AT = 300;
 
 function truncate(s: string): string {
-  if (s.length <= TRUNCATE_AT) return s;
-  return `${s.slice(0, TRUNCATE_AT)}… [truncated, ${s.length - TRUNCATE_AT} more chars]`;
+  return truncateText(s, TRUNCATE_AT, { showCount: true });
 }
 
 function truncateIfString(value: unknown): unknown {

--- a/crux/tablebase/reporter.ts
+++ b/crux/tablebase/reporter.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ScanSummary, EnrichmentTask, FieldGapReport } from './types.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
@@ -59,9 +60,7 @@ export function formatGaps(tasks: EnrichmentTask[], options?: { limit?: number }
   ];
 
   limited.forEach((task, i) => {
-    const name = task.entityName.length > 31
-      ? task.entityName.slice(0, 28) + '...'
-      : task.entityName;
+    const name = truncate(task.entityName, 31, { ellipsis: '...' });
     const impactColor = task.impactScore >= 100 ? RED : task.impactScore >= 50 ? YELLOW : GREEN;
 
     lines.push(

--- a/crux/validate/validate-display-formatting.ts
+++ b/crux/validate/validate-display-formatting.ts
@@ -21,6 +21,7 @@ import { join } from 'path';
 import { parse as parseYaml } from 'yaml';
 import { getColors } from '../lib/output.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { truncate } from '../lib/text-utils.ts';
 
 const ENTITIES_DIR = join(PROJECT_ROOT, 'data/entities');
 
@@ -129,7 +130,7 @@ function checkEntity(entity: YamlEntity, file: string): DisplayFormattingViolati
       file,
       entityId,
       field: hit.field,
-      value: hit.value.length > 80 ? hit.value.slice(0, 80) + '...' : hit.value,
+      value: truncate(hit.value, 83, { ellipsis: '...' }),
       reason: 'Contains "[object Object]" (serialization bug)',
     });
   }

--- a/crux/validate/validate-resource-quality.ts
+++ b/crux/validate/validate-resource-quality.ts
@@ -35,6 +35,7 @@ import { join } from "path";
 import { PROJECT_ROOT } from "../lib/content-types.ts";
 import { getColors } from "../lib/output.ts";
 import type { Resource } from "../resource-types.ts";
+import { truncate } from "../lib/text-utils.ts";
 
 const SNAPSHOT_FILE = join(PROJECT_ROOT, "data/resources-snapshot.json");
 
@@ -339,7 +340,7 @@ export function checkResource(resource: Resource): ResourceQualityIssue[] {
       resourceId: resource.id,
       url,
       field: "title",
-      message: `Title contains HTML tags: "${title.slice(0, 100)}${title.length > 100 ? "..." : ""}"`,
+      message: `Title contains HTML tags: "${truncate(title, 103, { ellipsis: "..." })}"`,
       severity: "error",
     });
   }

--- a/crux/wiki-server/sync-entity-assessments.ts
+++ b/crux/wiki-server/sync-entity-assessments.ts
@@ -36,6 +36,7 @@ import { join } from "path";
 import { fileURLToPath } from "url";
 import { parse as parseYaml } from "yaml";
 import { contentHash } from "../../packages/factbase/src/ids.ts";
+import { truncate } from "../lib/text-utils.ts";
 import { batchSync } from "./sync-common.ts";
 import {
   asString,
@@ -243,7 +244,7 @@ async function main() {
     },
     getEntityId: (a) => a.entityId,
     formatDryRun: (a) =>
-      `${a.entityId} [${a.assessor}] ${a.dimension}: ${a.rating.slice(0, 60)}${a.rating.length > 60 ? "…" : ""}`,
+      `${a.entityId} [${a.assessor}] ${a.dimension}: ${truncate(a.rating, 61)}`,
     sync: syncEntityAssessments,
     defaultBatchSize: DEFAULT_BATCH_SIZE,
   });


### PR DESCRIPTION
## Summary

Followup from QUA-672 simplify pass. Replaces 9 named `truncate*()` helpers and 30+ inline `s.slice(0, N) + '...'` expressions across `crux/` with one shared utility.

## API

```ts
truncate(s, max, opts?)
```

| Option | Default | Effect |
|---|---|---|
| `ellipsis` | `'…'` (1 char) | Marker; counts toward `max` |
| `showCount` | `false` | Format as `<max chars>… [truncated, N more chars]` |
| `wordBoundary` | `false` | Back up to last whitespace |
| `oneLine` | `false` | Collapse newlines to spaces first |
| `fallback` | `''` | Returned for null/undefined |

Default semantics: result length ≤ max (budget-inclusive). For 3-dot ASCII ellipsis pass `{ ellipsis: '...' }`.

## Scope

Replaced (named helpers): `truncate`, `truncateText`, `truncateClaim`, `truncateSummary`, `truncateField`, `truncateEvidence`, `truncateSource` across 11 crux files. Replaced inline patterns in 30+ additional files.

Skipped intentionally (special semantics):
- `truncateWithBalancedFences` (codebase-analysis.ts) — fence-aware, balances ``` ```
- `truncateToMonth` (grant-import/dates.ts) — date utility, not string
- `truncateForExtraction` (website-personnel-extractor.ts) — must match source exactly, no marker
- `apps/wiki-server/...t1-allowlist.ts` — apps/wiki-server intentionally avoids importing from crux to prevent dependency cycles

## Behavior notes

- For inputs in the boundary window `(N, N + ellipsis.length]` of always-append `slice(0, N) + '...'` migrations, the new helper passes the input through unchanged. The old code appended the marker even when it pushed length above N. Treated as a cosmetic improvement, but documented in the JSDoc so future migrations don't expect strict byte-for-byte equality.
- Empty-string handling: `''` is a non-null string and returned unchanged (subject to truncation). Wrappers that want the empty-string sentinel of an old helper (e.g. sessions-list's `'—'`) must guard with `!s` at the call site. Caught and fixed during hostile review of this PR.

## Test plan

- [x] 22 unit tests for the new `truncate()` covering defaults, all options, edge cases (max=0, ellipsis longer than max, wordBoundary boundary conditions, showCount + oneLine/wordBoundary interactions, `\r` preservation under oneLine, empty string with fallback)
- [x] Regression test in `sessions-list.test.ts` for empty-string falsy semantics
- [x] All 6 affected test suites pass (sessions-list, quote-extractor, aiid/transform, oecd-aim/transform, auto-update orchestrator, text-utils) — 168/168
- [x] Typecheck clean for all 3 projects (`apps/web`, `apps/wiki-server`, `crux`); no errors in touched files
- [x] `pnpm crux w validate gate --no-cache --scope=content` passes (3/3 checks, 32.0s)
- [x] `/agent-review-pr` 7-phase review passed; HIGH severity finding (empty-string regression) fixed in commit 80717cc79
- [x] Spot-checked CLI commands that exercise refactored truncate paths (`crux query search`, `crux sys sessions list`, `crux sys audits list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-678
