### PR TITLE
QUA-991: drop stale evidence rows from headline aggregation

### DIFF
--- a/apps/wiki-server/src/__tests__/recompute-verdict.test.ts
+++ b/apps/wiki-server/src/__tests__/recompute-verdict.test.ts
@@ -419,6 +419,57 @@ describe("recomputeVerdict — stale-evidence handling (QUA-991)", () => {
     ]);
   });
 
+  it("reasoning surfaces winner + fresh dissent + stale exclusion in one string", async () => {
+    // Most informative shape: a fresh confirmed wins, a fresh contradicted
+    // dissents, and a stale partial is excluded. The 3-clause format is what
+    // the `/internal/sourcing` UIs parse — pin it so a future format tweak
+    // doesn't silently break those surfaces.
+    const CURRENT = "claude-haiku-4-5-20251001";
+    const OLD = "claude-3-5-sonnet-20241022";
+    dispatch = (q) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        return [
+          {
+            verdict: "confirmed",
+            relevance_score: 1.0,
+            confidence: 0.95,
+            checked_at: new Date("2026-05-01T00:00:00Z"),
+            checker_model: CURRENT,
+          },
+          {
+            verdict: "contradicted",
+            relevance_score: 1.0,
+            confidence: 0.7,
+            checked_at: new Date("2026-05-01T00:00:00Z"),
+            checker_model: CURRENT,
+          },
+          {
+            verdict: "partial",
+            relevance_score: 1.0,
+            confidence: 0.6,
+            checked_at: new Date("2026-04-01T00:00:00Z"),
+            checker_model: OLD,
+          },
+        ];
+      }
+      if (/^update/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        return [{ record_id: "fact_test" }];
+      }
+      return [];
+    };
+    const result = await recomputeVerdict(getDrizzleDb(), {
+      recordType: "fact",
+      recordId: "fact_test",
+      fieldName: null,
+    });
+    // Headline: contradicted wins via priority(0) over confirmed(4) at equal weight.
+    // Stale partial is excluded because a fresh row exists.
+    expect(result.aggregate.verdict).toBe("contradicted");
+    expect(result.reasoning).toMatch(/1 → contradicted/);
+    expect(result.reasoning).toMatch(/dissent: 1 → confirmed/);
+    expect(result.reasoning).toMatch(/stale \(excluded\): 1 → partial/);
+  });
+
   it("loadEvidenceRows reads checker_model so the staleness filter has the data it needs", async () => {
     // Pin the SELECT shape — if a future refactor drops checker_model
     // from the projection, the staleness filter would silently regress

--- a/apps/wiki-server/src/__tests__/recompute-verdict.test.ts
+++ b/apps/wiki-server/src/__tests__/recompute-verdict.test.ts
@@ -230,6 +230,216 @@ describe("recomputeVerdict — end-to-end", () => {
   });
 });
 
+describe("recomputeVerdict — stale-evidence handling (QUA-991)", () => {
+  beforeEach(() => {
+    capturedQueries = [];
+    dispatch = () => [];
+  });
+
+  // Acceptance criterion (a): one fresh confirmed + one stale partial →
+  // confirmed. The stuck-partial regression on prod (≈500 records sampled
+  // 2026-05-01) is exactly this shape — a fresh re-check writes confirmed
+  // but the QUA-650 retro-scan's partial row blocked promotion via
+  // priority-tiebreak. After the QUA-991 fix, the stale row is dropped
+  // from the headline.
+  it("fresh confirmed + stale partial → confirmed (acceptance a)", async () => {
+    const CURRENT = "claude-haiku-4-5-20251001";
+    const OLD = "claude-3-5-sonnet-20241022";
+    let updateBody = "";
+    let updateParams: unknown[] = [];
+    dispatch = (q, p) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        return [
+          {
+            verdict: "confirmed",
+            relevance_score: 1.0,
+            confidence: 0.95,
+            checked_at: new Date("2026-05-01T00:00:00Z"),
+            checker_model: CURRENT,
+          },
+          {
+            verdict: "partial",
+            relevance_score: 1.0,
+            confidence: 0.6,
+            checked_at: new Date("2026-04-21T00:00:00Z"),
+            checker_model: OLD,
+          },
+        ];
+      }
+      if (/^update/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        updateBody = q;
+        updateParams = [...p];
+        return [{ record_id: "investment_test" }];
+      }
+      return [];
+    };
+
+    const result = await recomputeVerdict(getDrizzleDb(), {
+      recordType: "investment",
+      recordId: "investment_test",
+      fieldName: null,
+    });
+
+    expect(result.aggregate.verdict).toBe("confirmed");
+    expect(result.aggregate.contributing[0].verdict).toBe("confirmed");
+    expect(result.aggregate.droppedStale.map((c) => c.verdict)).toEqual([
+      "partial",
+    ]);
+    expect(result.reasoning).toMatch(/1 → confirmed/);
+    expect(result.reasoning).toMatch(/stale \(excluded\): 1 → partial/);
+    // The persisted reasoning + verdict must match what the API returns.
+    expect(updateBody).toMatch(/source_check_verdicts/i);
+    expect(updateParams).toContain("confirmed");
+  });
+
+  // Acceptance criterion (b): only stale rows → current behavior. When no
+  // fresh row exists, an old reading is better than nothing — fall back
+  // to the legacy weighted-priority tiebreak.
+  it("only stale rows → behaves like today (acceptance b)", async () => {
+    const OLD = "claude-3-5-sonnet-20241022";
+    dispatch = (q) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        return [
+          {
+            verdict: "partial",
+            relevance_score: 1.0,
+            confidence: 0.6,
+            checked_at: new Date("2026-04-01T00:00:00Z"),
+            checker_model: OLD,
+          },
+          {
+            verdict: "partial",
+            relevance_score: 1.0,
+            confidence: 0.7,
+            checked_at: new Date("2026-04-10T00:00:00Z"),
+            checker_model: OLD,
+          },
+        ];
+      }
+      if (/^update/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        return [{ record_id: "investment_test" }];
+      }
+      return [];
+    };
+
+    const result = await recomputeVerdict(getDrizzleDb(), {
+      recordType: "investment",
+      recordId: "investment_test",
+      fieldName: null,
+    });
+
+    expect(result.aggregate.verdict).toBe("partial");
+    expect(result.aggregate.droppedStale).toEqual([]);
+    expect(result.aggregate.contributing[0].rowCount).toBe(2);
+    expect(result.reasoning).not.toMatch(/stale \(excluded\)/);
+  });
+
+  // Acceptance criterion (c): two fresh rows tied → priority tiebreak
+  // unchanged. partial(2) < confirmed(4), so partial wins exactly as before
+  // QUA-991 — the new stale filter must not silently change the legacy
+  // tiebreak for the all-fresh case.
+  it("two fresh rows tied → priority-based tiebreak unchanged (acceptance c)", async () => {
+    const CURRENT = "claude-haiku-4-5-20251001";
+    dispatch = (q) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        return [
+          {
+            verdict: "confirmed",
+            relevance_score: 0.8,
+            confidence: 0.9,
+            checked_at: new Date("2026-05-01T00:00:00Z"),
+            checker_model: CURRENT,
+          },
+          {
+            verdict: "partial",
+            relevance_score: 0.8,
+            confidence: 0.7,
+            checked_at: new Date("2026-05-01T00:00:00Z"),
+            checker_model: CURRENT,
+          },
+        ];
+      }
+      if (/^update/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        return [{ record_id: "investment_test" }];
+      }
+      return [];
+    };
+
+    const result = await recomputeVerdict(getDrizzleDb(), {
+      recordType: "investment",
+      recordId: "investment_test",
+      fieldName: null,
+    });
+
+    // Same checkedAt across both buckets — recency tie-break is silent,
+    // priority decides: partial(2) beats confirmed(4).
+    expect(result.aggregate.verdict).toBe("partial");
+    expect(result.aggregate.droppedStale).toEqual([]);
+  });
+
+  it("treats NULL checker_model as stale (matches isStaleModel semantics)", async () => {
+    // Legacy rows from before the checker_model column was populated have
+    // NULL checker_model. The QUA-991 fix must treat them as stale so
+    // they're excluded from the headline when a fresh row exists.
+    const CURRENT = "claude-haiku-4-5-20251001";
+    dispatch = (q) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        return [
+          {
+            verdict: "confirmed",
+            relevance_score: 1.0,
+            confidence: 0.95,
+            checked_at: new Date("2026-05-01T00:00:00Z"),
+            checker_model: CURRENT,
+          },
+          {
+            verdict: "partial",
+            relevance_score: 1.0,
+            confidence: 0.6,
+            checked_at: new Date("2026-03-01T00:00:00Z"),
+            checker_model: null, // legacy row
+          },
+        ];
+      }
+      if (/^update/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        return [{ record_id: "p_test" }];
+      }
+      return [];
+    };
+
+    const result = await recomputeVerdict(getDrizzleDb(), {
+      recordType: "personnel",
+      recordId: "p_test",
+      fieldName: null,
+    });
+
+    expect(result.aggregate.verdict).toBe("confirmed");
+    expect(result.aggregate.droppedStale.map((c) => c.verdict)).toEqual([
+      "partial",
+    ]);
+  });
+
+  it("loadEvidenceRows reads checker_model so the staleness filter has the data it needs", async () => {
+    // Pin the SELECT shape — if a future refactor drops checker_model
+    // from the projection, the staleness filter would silently regress
+    // to "everything looks fresh" and re-introduce the QUA-991 bug.
+    let selectQuery = "";
+    dispatch = (q) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        selectQuery = q;
+        return [];
+      }
+      return [];
+    };
+    await recomputeVerdict(getDrizzleDb(), {
+      recordType: "personnel",
+      recordId: "p_test",
+      fieldName: null,
+    });
+    expect(selectQuery).toMatch(/checker_model/i);
+  });
+});
+
 describe("recomputeVerdictBestEffort", () => {
   beforeEach(() => {
     capturedQueries = [];

--- a/apps/wiki-server/src/__tests__/sourcing-aggregation.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-aggregation.test.ts
@@ -22,6 +22,24 @@ function row(
   return { verdict, relevanceScore, confidence, checkedAt };
 }
 
+function staleRow(
+  verdict: EvidenceRow["verdict"],
+  relevanceScore: number | null = 1.0,
+  confidence: number | null = null,
+  checkedAt: Date | null = null,
+): EvidenceRow {
+  return { verdict, relevanceScore, confidence, checkedAt, isStale: true };
+}
+
+function freshRow(
+  verdict: EvidenceRow["verdict"],
+  relevanceScore: number | null = 1.0,
+  confidence: number | null = null,
+  checkedAt: Date | null = null,
+): EvidenceRow {
+  return { verdict, relevanceScore, confidence, checkedAt, isStale: false };
+}
+
 describe("aggregateEvidence — empty / degenerate input", () => {
   it("returns 'unchecked' for an empty evidence list", () => {
     const r = aggregateEvidence([]);
@@ -407,5 +425,163 @@ describe("aggregateEvidence — droppedLowRelevance (QUA-792)", () => {
     expect(r.droppedLowRelevance.map((c) => c.verdict)).toEqual([
       "contradicted",
     ]);
+  });
+});
+
+describe("aggregateEvidence — droppedStale (QUA-991)", () => {
+  // Real-world scenario from QUA-991: ~500 records on prod (sampled
+  // 2026-05-01) sit at `partial` because a stale `partial` row from an
+  // older checker model (or a QUA-650 retro-scan's "subject mismatch"
+  // sweep) ties weight with a fresh `confirmed` row from the current
+  // model — and `partial` outranks `confirmed` in the priority tiebreak,
+  // so re-verification can never lift the aggregate. The fix excludes
+  // stale rows from the headline when at least one fresh row exists.
+  it("fresh confirmed beats stale partial — the canonical QUA-991 case", () => {
+    const r = aggregateEvidence([
+      freshRow("confirmed", 1.0, 0.95),
+      staleRow("partial", 1.0, 0.6),
+    ]);
+    expect(r.verdict).toBe("confirmed");
+    expect(r.contributing.map((c) => c.verdict)).toEqual(["confirmed"]);
+    expect(r.droppedStale.map((c) => c.verdict)).toEqual(["partial"]);
+    expect(r.droppedStale[0].rowCount).toBe(1);
+  });
+
+  it("falls back to current behavior when every row is stale", () => {
+    // No fresh row → stale rows feed the headline as before. This is the
+    // ticket's case (b): re-verification didn't happen, so an old reading
+    // is better than nothing.
+    const r = aggregateEvidence([
+      staleRow("partial", 1.0, 0.6),
+      staleRow("partial", 1.0, 0.7),
+    ]);
+    expect(r.verdict).toBe("partial");
+    expect(r.droppedStale).toEqual([]);
+    expect(r.contributing[0].rowCount).toBe(2);
+  });
+
+  it("priority tiebreak still applies between two fresh rows", () => {
+    // Ticket's case (c): if both contributors are fresh, nothing changes —
+    // contradicted (priority 0) still wins over confirmed (priority 4) at
+    // equal weight, the same as before QUA-991.
+    const r = aggregateEvidence([
+      freshRow("contradicted", 0.8),
+      freshRow("confirmed", 0.8),
+    ]);
+    expect(r.verdict).toBe("contradicted");
+    expect(r.droppedStale).toEqual([]);
+  });
+
+  it("treats undefined isStale as fresh (back-compat for legacy callers)", () => {
+    // Tests written before QUA-991 don't supply isStale. Those rows must
+    // still aggregate, otherwise the existing test corpus regresses to
+    // unchecked/empty behavior.
+    const r = aggregateEvidence([
+      row("confirmed", 1.0, 0.9), // isStale undefined
+      row("partial", 1.0, 0.7), // isStale undefined
+    ]);
+    expect(r.verdict).toBe("partial"); // priority tiebreak: partial(2) < confirmed(4)
+    expect(r.droppedStale).toEqual([]);
+  });
+
+  it("treats null isStale as fresh", () => {
+    // Defensive: explicit null behaves the same as undefined.
+    const r = aggregateEvidence([
+      { verdict: "confirmed", relevanceScore: 1.0, confidence: 0.9, isStale: null },
+      staleRow("partial", 1.0, 0.6),
+    ]);
+    expect(r.verdict).toBe("confirmed");
+    expect(r.droppedStale.map((c) => c.verdict)).toEqual(["partial"]);
+  });
+
+  it("aggregates stale-row counts per verdict for the dissent breakdown", () => {
+    const r = aggregateEvidence([
+      freshRow("confirmed", 0.9, 0.9),
+      staleRow("partial", 1.0, 0.5),
+      staleRow("partial", 0.8, 0.4),
+      staleRow("contradicted", 0.7, 0.6),
+    ]);
+    expect(r.verdict).toBe("confirmed");
+    const stalePartial = r.droppedStale.find((c) => c.verdict === "partial");
+    const staleContradicted = r.droppedStale.find(
+      (c) => c.verdict === "contradicted",
+    );
+    expect(stalePartial?.rowCount).toBe(2);
+    expect(stalePartial?.weight).toBeCloseTo(1.8, 5);
+    expect(staleContradicted?.rowCount).toBe(1);
+    expect(staleContradicted?.weight).toBeCloseTo(0.7, 5);
+  });
+
+  it("excludes stale rows even when their weight would dominate", () => {
+    // Without the QUA-991 filter, three stale partials (weight 3.0) would
+    // beat one fresh confirmed (weight 1.0). The fresh row alone now wins.
+    const r = aggregateEvidence([
+      freshRow("confirmed", 1.0, 0.95),
+      staleRow("partial", 1.0, 0.4),
+      staleRow("partial", 1.0, 0.5),
+      staleRow("partial", 1.0, 0.6),
+    ]);
+    expect(r.verdict).toBe("confirmed");
+    expect(r.droppedStale[0].rowCount).toBe(3);
+  });
+
+  it("returns 'unchecked' when all stale rows are excluded and the lone fresh row is below threshold", () => {
+    // Edge case: when the sole fresh row is sub-relevance, the headline
+    // becomes 'unchecked' — we don't fall back to stale rows just because
+    // the fresh row was weak. Documents this so a future tweak doesn't
+    // silently re-introduce the QUA-991 bug for low-relevance fresh rows.
+    const r = aggregateEvidence([
+      freshRow("confirmed", 0.1), // below DEFAULT_MIN_RELEVANCE = 0.3
+      staleRow("partial", 1.0, 0.6),
+    ]);
+    expect(r.verdict).toBe("unchecked");
+    expect(r.droppedStale.map((c) => c.verdict)).toEqual(["partial"]);
+    expect(r.droppedLowRelevance.map((c) => c.verdict)).toEqual(["confirmed"]);
+  });
+
+  it("excludes not_applicable stale rows the same way fresh ones are excluded (never voting)", () => {
+    // not_applicable always wins the drop, regardless of staleness.
+    const r = aggregateEvidence([
+      freshRow("confirmed", 0.9, 0.9),
+      { verdict: "not_applicable", relevanceScore: 0.9, confidence: 0.99, isStale: true },
+    ]);
+    expect(r.verdict).toBe("confirmed");
+    expect(r.droppedNotApplicable).toBe(1);
+    expect(r.droppedStale).toEqual([]); // not_applicable was filtered before stale check
+  });
+
+  it("recency tie-break (QUA-992) cannot rescue a stale row in the presence of a fresh row", () => {
+    // Stale + recent (e.g. a recent re-check by an old model that's been
+    // demoted) still loses to fresh — the staleness filter runs before the
+    // recency tie-break.
+    const old = new Date("2026-04-01T00:00:00Z");
+    const evenOlder = new Date("2026-01-01T00:00:00Z");
+    const r = aggregateEvidence([
+      freshRow("confirmed", 1.0, 0.9, evenOlder),
+      staleRow("partial", 1.0, 0.6, old), // recent but stale
+    ]);
+    expect(r.verdict).toBe("confirmed");
+  });
+});
+
+describe("buildReasoning surfacing droppedStale (QUA-991)", () => {
+  // The `reasoning` string is persisted to source_check_verdicts.reasoning;
+  // it is what an operator sees in `/api/sourcing/verdicts/...`. It must
+  // mention stale exclusion so a previously-`partial` record's flip to
+  // `confirmed` is auditable.
+  it("includes a 'stale (excluded)' clause when stale rows were dropped", async () => {
+    // Re-import here so we don't leak the helper into other test files.
+    // It's an internal helper; we go through aggregateEvidence + a tiny
+    // reasoning shim because recompute-verdict.ts owns the canonical impl.
+    const aggregate = aggregateEvidence([
+      freshRow("confirmed", 1.0, 0.95),
+      staleRow("partial", 1.0, 0.6),
+    ]);
+    expect(aggregate.droppedStale).toHaveLength(1);
+    // The integration-level reasoning string is exercised in
+    // recompute-verdict.test.ts; this test pins the contributing/droppedStale
+    // shape that the reasoning builder reads from.
+    expect(aggregate.contributing[0].verdict).toBe("confirmed");
+    expect(aggregate.droppedStale[0].verdict).toBe("partial");
   });
 });

--- a/apps/wiki-server/src/__tests__/sourcing-verdict-detail-stale.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-verdict-detail-stale.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Read-side integration test for QUA-991 stale-evidence handling.
+ *
+ * `recompute-verdict.test.ts` covers the write path (recomputeVerdict +
+ * loadEvidenceRows). This file pins the OTHER aggregation site — the
+ * `GET /verdicts/:recordType/:recordId` handler in `sourcing.ts:759` that
+ * re-runs `aggregateEvidence` on read for the detail-page render. If a
+ * future refactor drops `isStale: isStaleModel(...)` from the read-side
+ * map-build, the public detail page would silently re-display the stuck
+ * `partial` verdict even though the persisted row reads `confirmed` —
+ * exactly the QUA-991 prod symptom returning by another path.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { mockDbModule, type SqlDispatcher } from "./test-utils.js";
+
+const CURRENT = "claude-haiku-4-5-20251001";
+const OLD = "claude-3-5-sonnet-20241022";
+
+interface VerdictRow {
+  record_type: string;
+  record_id: string;
+  field_name: string | null;
+  entity_id: string | null;
+  display_name: string | null;
+  entity_display_name: string | null;
+  verdict: string;
+  confidence: number | null;
+  reasoning: string | null;
+  sources_checked: number;
+  needs_recheck: boolean;
+  next_check_due: Date | null;
+  last_computed_at: Date;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface EvidenceRow {
+  id: number;
+  record_type: string;
+  record_id: string;
+  field_name: string | null;
+  entity_id: string | null;
+  expected_value: string | null;
+  resource_id: string | null;
+  source_url: string | null;
+  extracted_value: string | null;
+  extracted_quote: string | null;
+  verdict: string;
+  confidence: number | null;
+  relevance_score: number | null;
+  is_primary_source: boolean;
+  checker_model: string | null;
+  notes: string | null;
+  checked_at: Date | null;
+}
+
+let verdictStore: VerdictRow[] = [];
+let evidenceStore: EvidenceRow[] = [];
+
+const dispatch: SqlDispatcher = (query) => {
+  const q = query.toLowerCase().trim();
+  if (q.startsWith("select") && q.includes("from \"source_check_verdicts\"")) {
+    return verdictStore;
+  }
+  if (q.startsWith("select") && q.includes("from \"source_check_evidence\"")) {
+    return evidenceStore;
+  }
+  // Anything else (claim_provenance fetches, etc.) returns empty.
+  return [];
+};
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { sourcingRoute } = await import("../routes/sourcing/sourcing.js");
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route("/", sourcingRoute);
+  return app;
+}
+
+describe("GET /verdicts/:recordType/:recordId — read-side stale handling (QUA-991)", () => {
+  beforeEach(() => {
+    verdictStore = [];
+    evidenceStore = [];
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+  });
+
+  function seedVerdict(over: Partial<VerdictRow> = {}): void {
+    const now = new Date();
+    verdictStore.push({
+      record_type: "investment",
+      record_id: "inv_test",
+      field_name: null,
+      entity_id: null,
+      display_name: null,
+      entity_display_name: null,
+      verdict: "partial",
+      confidence: 0.6,
+      reasoning: "1 → confirmed; dissent: 1 → partial",
+      sources_checked: 2,
+      needs_recheck: false,
+      next_check_due: null,
+      last_computed_at: now,
+      created_at: now,
+      updated_at: now,
+      ...over,
+    });
+  }
+
+  function seedEvidence(over: Partial<EvidenceRow> = {}): void {
+    const now = new Date();
+    evidenceStore.push({
+      id: evidenceStore.length + 1,
+      record_type: "investment",
+      record_id: "inv_test",
+      field_name: null,
+      entity_id: null,
+      expected_value: null,
+      resource_id: null,
+      source_url: "https://example.com",
+      extracted_value: null,
+      extracted_quote: null,
+      verdict: "confirmed",
+      confidence: 0.95,
+      relevance_score: 1.0,
+      is_primary_source: false,
+      checker_model: CURRENT,
+      notes: null,
+      checked_at: now,
+      ...over,
+    });
+  }
+
+  it("read-side aggregation drops stale rows when a fresh row is present", async () => {
+    seedVerdict();
+    seedEvidence({
+      verdict: "confirmed",
+      confidence: 0.95,
+      checker_model: CURRENT,
+      checked_at: new Date("2026-05-01T00:00:00Z"),
+    });
+    seedEvidence({
+      verdict: "partial",
+      confidence: 0.6,
+      checker_model: OLD,
+      checked_at: new Date("2026-04-21T00:00:00Z"),
+    });
+
+    const res = await buildApp().request("/verdicts/investment/inv_test");
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      verdictAggregations: Record<
+        string,
+        { verdict: string; droppedStale: { verdict: string; rowCount: number }[] }
+      >;
+    };
+
+    const aggregate = body.verdictAggregations[""];
+    // Live aggregation reflects the QUA-991 fix even though the persisted
+    // verdict row still says "partial" (it'll re-flip on the next recompute).
+    expect(aggregate.verdict).toBe("confirmed");
+    expect(aggregate.droppedStale).toHaveLength(1);
+    expect(aggregate.droppedStale[0]).toMatchObject({
+      verdict: "partial",
+      rowCount: 1,
+    });
+  });
+
+  it("read-side aggregation falls back to current behavior when every row is stale", async () => {
+    seedVerdict();
+    seedEvidence({
+      verdict: "partial",
+      checker_model: OLD,
+      checked_at: new Date("2026-04-01T00:00:00Z"),
+    });
+    seedEvidence({
+      verdict: "partial",
+      checker_model: OLD,
+      checked_at: new Date("2026-04-10T00:00:00Z"),
+    });
+
+    const res = await buildApp().request("/verdicts/investment/inv_test");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      verdictAggregations: Record<
+        string,
+        { verdict: string; droppedStale: unknown[] }
+      >;
+    };
+
+    expect(body.verdictAggregations[""].verdict).toBe("partial");
+    expect(body.verdictAggregations[""].droppedStale).toEqual([]);
+  });
+
+  it("treats NULL checker_model as stale on the read side", async () => {
+    seedVerdict();
+    seedEvidence({
+      verdict: "confirmed",
+      checker_model: CURRENT,
+      checked_at: new Date("2026-05-01T00:00:00Z"),
+    });
+    seedEvidence({
+      verdict: "partial",
+      checker_model: null,
+      checked_at: new Date("2026-03-01T00:00:00Z"),
+    });
+
+    const res = await buildApp().request("/verdicts/investment/inv_test");
+    const body = (await res.json()) as {
+      verdictAggregations: Record<
+        string,
+        { verdict: string; droppedStale: { verdict: string }[] }
+      >;
+    };
+
+    expect(body.verdictAggregations[""].verdict).toBe("confirmed");
+    expect(body.verdictAggregations[""].droppedStale.map((c) => c.verdict)).toEqual([
+      "partial",
+    ]);
+  });
+});

--- a/apps/wiki-server/src/routes/sourcing/checker-model.ts
+++ b/apps/wiki-server/src/routes/sourcing/checker-model.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared "is this evidence row stale?" definition.
+ *
+ * Lives in a separate file from `sourcing.ts` because both `sourcing.ts`
+ * (route handlers) and `recompute-verdict.ts` (called BY `sourcing.ts`)
+ * need the helper. Putting it in `sourcing.ts` would create a cycle:
+ * sourcing.ts → recompute-verdict.ts → sourcing.ts.
+ */
+
+/**
+ * The current checker model used by the sourcing pipeline.
+ * Evidence rows checked with a different model are flagged as stale.
+ * Update this when the pipeline switches to a newer model.
+ */
+export const CURRENT_CHECKER_MODEL = "claude-haiku-4-5-20251001";
+
+/**
+ * True if the row's `checker_model` is missing or differs from
+ * `CURRENT_CHECKER_MODEL`. NULL counts as stale because legacy rows
+ * predate the column. The QUA-991 aggregation fix uses this to drop
+ * stale rows from the headline verdict when at least one fresh row
+ * is present.
+ */
+export function isStaleModel(checkerModel: string | null): boolean {
+  if (!checkerModel) return true;
+  return checkerModel !== CURRENT_CHECKER_MODEL;
+}

--- a/apps/wiki-server/src/routes/sourcing/recompute-verdict.ts
+++ b/apps/wiki-server/src/routes/sourcing/recompute-verdict.ts
@@ -15,6 +15,7 @@ import {
   type EvidenceRow,
   type AggregationResult,
 } from "./sourcing-aggregation.js";
+import { isStaleModel } from "./checker-model.js";
 import { logger } from "../../logger.js";
 
 /**
@@ -95,6 +96,9 @@ async function loadEvidenceRows(
       // evidence is most recent. Required so a fresh re-check supersedes
       // stale evidence at equal weight.
       checkedAt: recordSources.checkedAt,
+      // QUA-991: needed so the aggregator can drop stale evidence when a
+      // fresh re-check is present. NULL counts as stale.
+      checkerModel: recordSources.checkerModel,
     })
     .from(recordSources)
     .where(
@@ -109,6 +113,7 @@ async function loadEvidenceRows(
     relevanceScore: r.relevanceScore,
     confidence: r.confidence,
     checkedAt: r.checkedAt,
+    isStale: isStaleModel(r.checkerModel),
   }));
 }
 
@@ -116,6 +121,11 @@ async function loadEvidenceRows(
  * Human-readable `reasoning` string for `source_check_verdicts.reasoning`.
  * Reflects the aggregator's contributing breakdown so the disagree-warning
  * surface (QUA-792) can render the same computation without re-deriving it.
+ *
+ * QUA-991: when stale rows were excluded from the headline because a fresh
+ * row was present, append them as a separate clause so an operator inspecting
+ * the reasoning can see why a previously-`partial` record now reads as
+ * `confirmed`.
  */
 function buildReasoning(aggregate: AggregationResult): string {
   if (aggregate.verdict === "unchecked") {
@@ -129,8 +139,12 @@ function buildReasoning(aggregate: AggregationResult): string {
   const fmt = (c: { rowCount: number; verdict: string }) =>
     `${c.rowCount} → ${c.verdict}`;
   const [winner, ...dissent] = aggregate.contributing;
-  if (dissent.length === 0) return fmt(winner);
-  return `${fmt(winner)}; dissent: ${dissent.map(fmt).join(", ")}`;
+  const parts = [fmt(winner)];
+  if (dissent.length > 0) parts.push(`dissent: ${dissent.map(fmt).join(", ")}`);
+  if (aggregate.droppedStale.length > 0) {
+    parts.push(`stale (excluded): ${aggregate.droppedStale.map(fmt).join(", ")}`);
+  }
+  return parts.join("; ");
 }
 
 /**

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts
@@ -54,6 +54,14 @@ export interface EvidenceRow {
    * priority tie-breaker below. Tests can omit it for back-compat.
    */
   checkedAt?: Date | null;
+  /**
+   * QUA-991: when true, the row was written by an older checker model
+   * (or has no recorded model) and is excluded from the headline
+   * aggregation if at least one fresh row is available. NULL/undefined
+   * is treated as "not stale" so legacy callers and tests that don't
+   * supply the field keep their old behavior.
+   */
+  isStale?: boolean | null;
 }
 
 export interface ContributingVerdict {
@@ -95,6 +103,16 @@ export interface AggregationResult {
    * low-relevance row may both have `verdict = 'contradicted'`).
    */
   droppedLowRelevance: ContributingVerdict[];
+  /**
+   * QUA-991: per-verdict counts of rows that were excluded from the
+   * headline because they were stale (`isStale=true`) AND at least one
+   * fresh row was available. When all rows are stale, this is empty and
+   * the stale rows feed the headline as before — i.e. stale evidence is
+   * better than nothing. Surfaced for the QUA-792 explainer so a fresh
+   * `confirmed` aggregate can still say "1 stale partial source dissented
+   * (excluded)".
+   */
+  droppedStale: ContributingVerdict[];
   /** Count of `not_applicable` rows that were filtered out before aggregation. */
   droppedNotApplicable: number;
 }

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts
@@ -108,9 +108,14 @@ export interface AggregationResult {
    * headline because they were stale (`isStale=true`) AND at least one
    * fresh row was available. When all rows are stale, this is empty and
    * the stale rows feed the headline as before — i.e. stale evidence is
-   * better than nothing. Surfaced for the QUA-792 explainer so a fresh
-   * `confirmed` aggregate can still say "1 stale partial source dissented
-   * (excluded)".
+   * better than nothing.
+   *
+   * Currently consumed by `buildReasoning` (renders the `stale (excluded):
+   * N → verdict` clause that ships in `source_check_verdicts.reasoning`).
+   * The frontend `buildDisagreementExplainer` does NOT yet read this
+   * field — extending the explainer to surface stale dissent alongside
+   * low-relevance dissent is a deliberate follow-up; the persisted
+   * reasoning text is the operator-facing surface for now.
    */
   droppedStale: ContributingVerdict[];
   /** Count of `not_applicable` rows that were filtered out before aggregation. */

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
@@ -148,20 +148,7 @@ export function aggregateEvidence(
   let droppedStale: ContributingVerdict[];
   if (freshRows.length > 0 && freshRows.length < considered.length) {
     aggregable = freshRows;
-    const staleBuckets = new Map<AggregateVerdict, ContributingVerdict>();
-    for (const r of considered) {
-      if (r.isStale !== true) continue;
-      const v = r.verdict as AggregateVerdict;
-      const w = effectiveWeight(r);
-      const existing = staleBuckets.get(v);
-      if (existing) {
-        existing.weight += w;
-        existing.rowCount += 1;
-      } else {
-        staleBuckets.set(v, { verdict: v, weight: w, rowCount: 1 });
-      }
-    }
-    droppedStale = sortContributing([...staleBuckets.values()]);
+    droppedStale = bucketByVerdict(considered.filter((r) => r.isStale === true));
   } else {
     aggregable = considered;
     droppedStale = [];
@@ -173,23 +160,15 @@ export function aggregateEvidence(
   // dissent. Operates on `aggregable` so dropped-stale rows don't appear
   // in `droppedLowRelevance` (they're already in `droppedStale`).
   const aboveThreshold: EvidenceRow[] = [];
-  const belowThresholdBuckets = new Map<AggregateVerdict, ContributingVerdict>();
+  const belowThresholdRows: EvidenceRow[] = [];
   for (const r of aggregable) {
-    const w = effectiveWeight(r);
-    if (w >= minRelevance) {
+    if (effectiveWeight(r) >= minRelevance) {
       aboveThreshold.push(r);
-      continue;
-    }
-    const v = r.verdict as AggregateVerdict;
-    const existing = belowThresholdBuckets.get(v);
-    if (existing) {
-      existing.weight += w;
-      existing.rowCount += 1;
     } else {
-      belowThresholdBuckets.set(v, { verdict: v, weight: w, rowCount: 1 });
+      belowThresholdRows.push(r);
     }
   }
-  const droppedLowRelevance = sortContributing([...belowThresholdBuckets.values()]);
+  const droppedLowRelevance = bucketByVerdict(belowThresholdRows);
 
   if (aboveThreshold.length === 0) {
     return {
@@ -287,6 +266,42 @@ export function aggregateEvidence(
  * noise from typical `0.x + 0.y` sums.
  */
 const WEIGHT_EQUALITY_EPSILON = 1e-9;
+
+/**
+ * Group rows by verdict, summing weight, counting rows, and tracking the
+ * most-recent `checkedAt` per bucket. Returned list is sorted by
+ * `sortContributing` so callers can render dissent in the canonical order.
+ *
+ * Used for both `droppedStale` and `droppedLowRelevance` — both are
+ * "rows we excluded from the headline, surfaced for the dissent explainer."
+ * Same Map-bucketing idiom that the headline aggregator uses below.
+ */
+function bucketByVerdict(rows: Iterable<EvidenceRow>): ContributingVerdict[] {
+  const buckets = new Map<AggregateVerdict, ContributingVerdict>();
+  for (const r of rows) {
+    const v = r.verdict as AggregateVerdict;
+    const w = effectiveWeight(r);
+    const existing = buckets.get(v);
+    if (existing) {
+      existing.weight += w;
+      existing.rowCount += 1;
+      if (
+        r.checkedAt &&
+        (!existing.latestCheckedAt || r.checkedAt > existing.latestCheckedAt)
+      ) {
+        existing.latestCheckedAt = r.checkedAt;
+      }
+    } else {
+      buckets.set(v, {
+        verdict: v,
+        weight: w,
+        rowCount: 1,
+        latestCheckedAt: r.checkedAt ?? null,
+      });
+    }
+  }
+  return sortContributing([...buckets.values()]);
+}
 
 /**
  * Sort contributing buckets by weight desc, ties broken by recency desc

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
@@ -98,14 +98,19 @@ interface Bucket {
  *      from the QUA-426 relevance gate and signal "this source is not
  *      about the subject — don't even count it." They contribute nothing.
  *   2. If no rows remain after step 1, return `unchecked`.
- *   3. If every remaining row has `effectiveWeight < minRelevance`,
+ *   3. QUA-991: if at least one fresh row (`isStale != true`) is present,
+ *      drop stale rows from the headline aggregation entirely (surfaced
+ *      separately as `droppedStale` for the dissent explainer). When all
+ *      remaining rows are stale, fall through to current behavior — stale
+ *      evidence is better than nothing.
+ *   4. If every remaining row has `effectiveWeight < minRelevance`,
  *      return `unchecked` — we have looked but nothing is relevant
  *      enough to draw a conclusion.
- *   4. Compute a weighted score per non-`unchecked` verdict bucket.
+ *   5. Compute a weighted score per non-`unchecked` verdict bucket.
  *      Score for verdict V is `sum(effectiveWeight(row) for row.verdict = V)`.
- *   5. Pick the verdict with the highest weighted score. Ties broken by
+ *   6. Pick the verdict with the highest weighted score. Ties broken by
  *      `SOURCE_CHECK_VERDICT_PRIORITY` (more-actionable wins).
- *   6. Confidence: weighted average of `confidence × effectiveWeight`
+ *   7. Confidence: weighted average of `confidence × effectiveWeight`
  *      across all *contributing* rows (rows with the winning verdict),
  *      not the max. Reflects how strongly the contributors agreed, not
  *      just whether one source was certain.
@@ -126,19 +131,50 @@ export function aggregateEvidence(
       sourcesChecked: 0,
       contributing: [],
       droppedLowRelevance: [],
+      droppedStale: [],
       droppedNotApplicable: rows.length,
     };
   }
 
   const droppedNotApplicable = rows.length - considered.length;
 
-  // Step 3: split into above/below threshold. Below-threshold rows are
+  // QUA-991: if there is at least one fresh row, drop stale rows from
+  // headline aggregation. Stale rows still surface separately so the
+  // dissent explainer can say "1 stale partial source excluded". When
+  // every remaining row is stale, fall through to current behavior —
+  // an old reading is better than no reading at all.
+  const freshRows = considered.filter((r) => r.isStale !== true);
+  let aggregable: EvidenceRow[];
+  let droppedStale: ContributingVerdict[];
+  if (freshRows.length > 0 && freshRows.length < considered.length) {
+    aggregable = freshRows;
+    const staleBuckets = new Map<AggregateVerdict, ContributingVerdict>();
+    for (const r of considered) {
+      if (r.isStale !== true) continue;
+      const v = r.verdict as AggregateVerdict;
+      const w = effectiveWeight(r);
+      const existing = staleBuckets.get(v);
+      if (existing) {
+        existing.weight += w;
+        existing.rowCount += 1;
+      } else {
+        staleBuckets.set(v, { verdict: v, weight: w, rowCount: 1 });
+      }
+    }
+    droppedStale = sortContributing([...staleBuckets.values()]);
+  } else {
+    aggregable = considered;
+    droppedStale = [];
+  }
+
+  // Step 4: split into above/below threshold. Below-threshold rows are
   // filtered out from the headline but their per-verdict counts are
   // surfaced separately so QUA-792's explainer can mention low-relevance
-  // dissent.
+  // dissent. Operates on `aggregable` so dropped-stale rows don't appear
+  // in `droppedLowRelevance` (they're already in `droppedStale`).
   const aboveThreshold: EvidenceRow[] = [];
   const belowThresholdBuckets = new Map<AggregateVerdict, ContributingVerdict>();
-  for (const r of considered) {
+  for (const r of aggregable) {
     const w = effectiveWeight(r);
     if (w >= minRelevance) {
       aboveThreshold.push(r);
@@ -162,11 +198,12 @@ export function aggregateEvidence(
       sourcesChecked: considered.length,
       contributing: [],
       droppedLowRelevance,
+      droppedStale,
       droppedNotApplicable,
     };
   }
 
-  // Step 4: per-verdict aggregates in one pass. Only rows above the
+  // Step 5: per-verdict aggregates in one pass. Only rows above the
   // threshold get to vote — low-relevance noise shouldn't swing ties.
   // Rows with NULL confidence are skipped from the confidence average
   // (don't drag it down, don't elevate it).
@@ -204,11 +241,12 @@ export function aggregateEvidence(
       sourcesChecked: considered.length,
       contributing: [],
       droppedLowRelevance,
+      droppedStale,
       droppedNotApplicable,
     };
   }
 
-  // Step 5: pick winner. Score desc, then recency desc (QUA-992), then priority asc.
+  // Step 6: pick winner. Score desc, then recency desc (QUA-992), then priority asc.
   const contributing = sortContributing(
     [...buckets.entries()].map(([verdict, b]) => ({
       verdict,
@@ -220,8 +258,8 @@ export function aggregateEvidence(
   const winningVerdict = contributing[0].verdict;
   const winningBucket = buckets.get(winningVerdict)!;
 
-  // Step 6: confidence = weighted average of the winning bucket's rows
-  // that reported a confidence value (computed in step 4).
+  // Step 7: confidence = weighted average of the winning bucket's rows
+  // that reported a confidence value (computed in step 5).
   const confidence =
     winningBucket.confidenceWeightSum > 0
       ? winningBucket.confidenceWeightedSum / winningBucket.confidenceWeightSum
@@ -233,6 +271,7 @@ export function aggregateEvidence(
     sourcesChecked: considered.length,
     contributing,
     droppedLowRelevance,
+    droppedStale,
     droppedNotApplicable,
   };
 }

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -57,6 +57,7 @@ import {
   type AggregationResult,
   type EvidenceRow,
 } from "./sourcing-aggregation.js";
+import { CURRENT_CHECKER_MODEL, isStaleModel } from "./checker-model.js";
 
 // ---- Constants ----
 
@@ -100,11 +101,11 @@ const VALID_VERDICTS = [
 const VALID_VERDICT_TYPES = [...VALID_VERDICTS, "unchecked"] as const;
 
 /**
- * The current checker model used by the sourcing pipeline.
- * Evidence rows checked with a different model are flagged as stale.
- * Update this when the pipeline switches to a newer model.
+ * Re-export so existing import sites (`from "./sourcing.js"`) keep working
+ * while the canonical declaration lives in `./checker-model.ts`. Used by
+ * routes below in SQL filters and response envelopes.
  */
-export const CURRENT_CHECKER_MODEL = "claude-haiku-4-5-20251001";
+export { CURRENT_CHECKER_MODEL };
 export const DEAD_LINK_CHECKER_MODEL = "dead-link-detector";
 
 // ---- Coverage helpers (QUA-928) ----
@@ -426,12 +427,6 @@ const StaleQuery = z.object({
 });
 
 // ---- Helpers ----
-
-/** Check if a checker model is stale (different from the current model). */
-function isStaleModel(checkerModel: string | null): boolean {
-  if (!checkerModel) return true; // No model recorded = stale
-  return checkerModel !== CURRENT_CHECKER_MODEL;
-}
 
 /** Map an evidence DB row to the API response shape with isStale flag. */
 function mapEvidenceRow(e: {
@@ -828,6 +823,10 @@ const sourcingApp = new Hono()
         // QUA-992: aggregation tie-breaker prefers the bucket whose latest
         // evidence is most recent.
         checkedAt: e.checkedAt,
+        // QUA-991: drop stale rows from the headline when a fresh row exists,
+        // so the read-side aggregation on the detail page matches the write
+        // side recomputeVerdict's aggregation.
+        isStale: isStaleModel(e.checkerModel),
       });
     }
     for (const [key, rows] of evidenceByFieldKey) {

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -100,12 +100,6 @@ const VALID_VERDICTS = [
 
 const VALID_VERDICT_TYPES = [...VALID_VERDICTS, "unchecked"] as const;
 
-/**
- * Re-export so existing import sites (`from "./sourcing.js"`) keep working
- * while the canonical declaration lives in `./checker-model.ts`. Used by
- * routes below in SQL filters and response envelopes.
- */
-export { CURRENT_CHECKER_MODEL };
 export const DEAD_LINK_CHECKER_MODEL = "dead-link-detector";
 
 // ---- Coverage helpers (QUA-928) ----

--- a/crux/lib/sourcing-dedup.test.ts
+++ b/crux/lib/sourcing-dedup.test.ts
@@ -1,24 +1,17 @@
 import { describe, it, expect } from 'vitest';
+import {
+  CURRENT_CHECKER_MODEL,
+  isStaleModel,
+} from '@wiki-server/checker-model';
 
 /**
  * Tests for sourcing evidence deduplication and stale model detection.
  *
- * These test the logic from apps/wiki-server/src/routes/sourcing/sourcing.ts
- * without requiring a database connection. The functions are mirrored here since
- * the route file's helpers are not independently exported.
+ * QUA-991: previously this file inlined a copy of `isStaleModel` and
+ * `CURRENT_CHECKER_MODEL`. Both are now exported from
+ * `apps/wiki-server/src/routes/sourcing/checker-model.ts` and consumed
+ * directly here so the constant cannot drift.
  */
-
-// Current checker model — must match the constant in sourcing.ts
-const CURRENT_CHECKER_MODEL = 'claude-haiku-4-5-20251001';
-
-// ---------------------------------------------------------------------------
-// isStaleModel
-// ---------------------------------------------------------------------------
-
-function isStaleModel(checkerModel: string | null): boolean {
-  if (!checkerModel) return true;
-  return checkerModel !== CURRENT_CHECKER_MODEL;
-}
 
 describe('isStaleModel', () => {
   it('returns true for null checker model', () => {

--- a/crux/tsconfig.json
+++ b/crux/tsconfig.json
@@ -22,6 +22,7 @@
       "@wiki-server/api-response-types": ["../apps/wiki-server/src/api-response-types.ts"],
       "@wiki-server/facts-route": ["../apps/wiki-server/src/routes/factbase/facts.ts"],
       "@wiki-server/sourcing-route": ["../apps/wiki-server/src/routes/sourcing/sourcing.ts"],
+      "@wiki-server/checker-model": ["../apps/wiki-server/src/routes/sourcing/checker-model.ts"],
       "@wiki-server/grants-route": ["../apps/wiki-server/src/routes/tablebase/grants.ts"],
       "@wiki-server/divisions-route": ["../apps/wiki-server/src/routes/tablebase/divisions.ts"],
       "@wiki-server/funding-programs-route": ["../apps/wiki-server/src/routes/tablebase/funding-programs.ts"],

--- a/crux/vitest.config.ts
+++ b/crux/vitest.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from 'vitest/config';
+import path from 'node:path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@wiki-server/checker-model': path.resolve(
+        __dirname,
+        '../apps/wiki-server/src/routes/sourcing/checker-model.ts',
+      ),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
## Summary

Fix `aggregateEvidence()` so a fresh `confirmed` evidence row is no longer
blocked by a stale `partial` row from an older checker model (or a
QUA-650 retro-scan).

- When at least one fresh row (`isStale != true`) is present, stale rows
  are excluded from the headline aggregation and surfaced separately as
  `droppedStale` for the QUA-792 dissent explainer.
- When every row is stale, falls back to current behavior — old reading
  is better than no reading.
- Both aggregation sites updated: write-side `recompute-verdict.ts` and
  read-side `sourcing.ts:GET /verdicts/:recordType/:recordId` (detail-page
  re-aggregation). The persisted `reasoning` string gains a `stale
  (excluded): N → verdict` clause so an operator can audit why a
  previously-stuck-`partial` record now reads `confirmed`.
- `isStaleModel` + `CURRENT_CHECKER_MODEL` move to a new `checker-model.ts`
  to share between `sourcing.ts` (route) and `recompute-verdict.ts`
  (caller it imports) without re-introducing a cycle. `crux/lib/sourcing-dedup.test.ts`
  now imports those canonical symbols instead of an inline copy.

Sampled prod 2026-05-01 found ~500 records (~20% of the 2,546 partials)
stuck this way. Fix unblocks QUA-976 (investments) which is currently
78.7% green; expected post-deploy: ~88.5%.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/sourcing-aggregation.test.ts` —
      54 tests pass (12 new for QUA-991), including the 3 acceptance
      cases (fresh+stale → confirmed; only stale → unchanged; two fresh
      tied → priority unchanged) plus edge cases (NULL checker_model =
      stale; fresh-below-threshold does NOT fall back to stale; recency
      tie-break can't rescue a stale row when a fresh row exists).
- [x] `pnpm exec vitest run src/__tests__/recompute-verdict.test.ts` —
      14 tests pass (6 new), all three acceptance criteria covered at
      the integration layer plus the 3-clause reasoning format pin
      (`winner + dissent + droppedStale`).
- [x] `pnpm exec vitest run src/__tests__/sourcing-verdict-detail-stale.test.ts`
      — 3 new integration tests pinning the read-side aggregation in
      `GET /verdicts/:recordType/:recordId`. Catch the regression where a
      future refactor drops `isStale: isStaleModel(...)` from the
      read-side map-build (would silently re-display the stuck-`partial`
      symptom on the public detail page).
- [x] Full wiki-server suite: 1711 tests pass, 0 regressions.
- [x] Root `pnpm test`: 9778 tests pass, 0 regressions.
- [x] `pnpm crux w validate gate --fix` — all 73 checks pass.
- [x] `/agent-review-pr` ran; HIGH/MEDIUM findings (DRY duplication, drift
      between crux test and wiki-server helper, missing read-side
      coverage, missing `latestCheckedAt` on stale buckets, overstated
      docstring) all fixed in commit 2.
- [ ] After deploy: confirm `/api/sourcing/verdict-matrix` for
      `investment` shows green ≥80% (expected ~88%).
- [ ] After deploy: spot-check `fact`, `funding-program`, `personnel` —
      partial counts should drop, confirmed should rise.

Fixes QUA-991


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stale evidence detection to exclude outdated checks from verdict calculations when fresher evidence is available.
  * Enhanced verdict reasoning output to include information about excluded stale evidence.

* **Tests**
  * Added comprehensive test coverage for stale evidence handling and verdict aggregation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [~] `route` ~~New API route "checker-model"~~ — **false positive from auto-detector.** `apps/wiki-server/src/routes/sourcing/checker-model.ts` is a helper module (exports `CURRENT_CHECKER_MODEL` const + `isStaleModel()` fn) consumed by `sourcing.ts` and `recompute-verdict.ts`. There is no `/checker-model` endpoint.
- [ ] `manual` Confirm `/api/sourcing/verdict-matrix` for `investment` shows green ≥80% after deploy. Pre-deploy: 78.7% (48/61). Expected post-deploy: ~88.5% (54/61) once the 6 stuck-partial dissent rows promote — `curl -sf "$WIKI_SERVER_URL/api/sourcing/verdict-matrix?record_type=investment" -H "Authorization: Bearer $KEY" | jq '.totals'`
- [ ] `manual` Spot-check `fact`, `funding-program`, `personnel` verdict-matrix totals after deploy — partial counts should drop and confirmed should rise (~500 records flip across all types) — `for t in fact funding-program personnel; do echo "== $t ==" ; curl -sf "$WIKI_SERVER_URL/api/sourcing/verdict-matrix?record_type=$t" -H "Authorization: Bearer $KEY" | jq '.totals' ; done`
<!-- /deploy-tasks -->
