### PR TITLE
qua-1078: inline 50k input-token cap on spawnClaude (stream-json)

### DIFF
--- a/crux/commands/pr-patrol.ts
+++ b/crux/commands/pr-patrol.ts
@@ -327,6 +327,8 @@ Daemon Options:
   --interval=N      Seconds between checks (default: 300)
   --max-turns=N     Max Claude turns per fix (default: 120)
   --timeout=N       Hard timeout in minutes per fix (default: 60)
+  --input-token-cap=N
+                    Inline kill if cumulative input_tokens exceed N (default: 50000, 0 disables)
   --cooldown=N      Skip recently-processed PRs for N seconds (default: 1800)
   --stale-hours=N   Hours before a PR is considered stale (default: 48)
   --model=MODEL     Claude model (default: sonnet)
@@ -337,6 +339,7 @@ Environment:
   PR_PATROL_INTERVAL              Seconds between checks
   PR_PATROL_MAX_TURNS             Max Claude turns per fix
   PR_PATROL_TIMEOUT_MINUTES       Hard timeout per fix in minutes (default: 60)
+  PR_PATROL_INPUT_TOKEN_CAP       Inline kill if cumulative input_tokens exceed N (default: 50000, 0 disables)
   PR_PATROL_COOLDOWN              Cooldown per PR (seconds)
   PR_PATROL_STALE_HOURS           Hours before a PR is stale (default: 48)
   PR_PATROL_MODEL                 Claude model

--- a/crux/pr-patrol/branch-agent.ts
+++ b/crux/pr-patrol/branch-agent.ts
@@ -283,7 +283,7 @@ export async function runBranchAgent(config: BranchAgentConfig): Promise<void> {
         ...config,
         maxTurns: effectiveMaxTurns,
         timeoutMinutes: effectiveTimeout,
-      });
+      }, { context: { prNumber, label: 'branch-agent' } });
       const elapsedS = Math.floor((Date.now() - startTime) / 1000);
 
       if (result.timedOut) {

--- a/crux/pr-patrol/execution.ts
+++ b/crux/pr-patrol/execution.ts
@@ -63,6 +63,17 @@ import {
 } from './state.ts';
 import { buildMainBranchPrompt, buildPrompt } from './prompts.ts';
 import { computeEffectiveBudget } from './scoring.ts';
+import {
+  buildOutput,
+  newStreamJsonState,
+  processStreamJsonLine,
+} from './stream-json.ts';
+
+/**
+ * Default inline input-token cap for spawnClaude when PatrolConfig doesn't
+ * supply one explicitly. Set to QUA-1071 AC#5's 50k threshold.
+ */
+export const DEFAULT_INPUT_TOKEN_CAP = 50_000;
 
 // ── No-op detection ─────────────────────────────────────────────────────────
 
@@ -287,7 +298,10 @@ export async function fixMainBranch(status: MainBranchStatus, config: PatrolConf
   let reason = '';
 
   try {
-    const result = await spawnClaude(prompt, config, { cwd: worktreePath });
+    const result = await spawnClaude(prompt, config, {
+      cwd: worktreePath,
+      context: { label: `main-branch:${status.runId ?? '?'}` },
+    });
     const elapsedS = Math.floor((Date.now() - startTime) / 1000);
 
     if (result.timedOut) {
@@ -349,11 +363,40 @@ export async function fixMainBranch(status: MainBranchStatus, config: PatrolConf
 
 // ── Claude spawning ─────────────────────────────────────────────────────────
 
+export interface SpawnClaudeResult {
+  exitCode: number;
+  /**
+   * Reconstructed agent output. Built from joined `assistant` text content +
+   * `result.result` text + `tool_result` content (and any unparseable
+   * passthrough lines), so the existing regex-based callers
+   * (`looksLikeNoOp`, `looksLikeMainRootCause`, `extractFixPrNumber`,
+   * fix-complete tail comments) keep matching without changes.
+   */
+  output: string;
+  hitMaxTurns: boolean;
+  timedOut: boolean;
+  /** True if the subprocess was SIGTERM'd because cumulative input_tokens hit the cap. */
+  budgetExceeded: boolean;
+  /** Cumulative `input_tokens` summed across stream-json `assistant` events. */
+  inputTokens: number;
+}
+
+export interface SpawnClaudeOpts {
+  cwd?: string;
+  extraEnv?: Record<string, string>;
+  /**
+   * Optional context attached to the `cycle_budget_exceeded` JSONL event
+   * when the input-token cap fires. Lets fixPr / fixMainBranch / branch-agent
+   * tag the entry without each caller having to log separately.
+   */
+  context?: { prNumber?: number | null; label?: string };
+}
+
 export function spawnClaude(
   prompt: string,
   config: PatrolConfig,
-  opts?: { cwd?: string; extraEnv?: Record<string, string> },
-): Promise<{ exitCode: number; output: string; hitMaxTurns: boolean; timedOut: boolean }> {
+  opts?: SpawnClaudeOpts,
+): Promise<SpawnClaudeResult> {
   return new Promise((resolve, reject) => {
     const args = [
       '--print',
@@ -361,6 +404,8 @@ export function spawnClaude(
       config.model,
       '--max-turns',
       String(config.maxTurns),
+      '--output-format',
+      'stream-json',
       '--verbose',
     ];
     if (config.skipPerms) args.push('--dangerously-skip-permissions');
@@ -395,9 +440,13 @@ export function spawnClaude(
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
-    let output = '';
+    const state = newStreamJsonState();
+    const cap = config.inputTokenCap ?? DEFAULT_INPUT_TOKEN_CAP;
     let timedOut = false;
+    let budgetExceeded = false;
+    let killedReason: 'timeout' | 'budget' | null = null;
     let forceKillTimer: ReturnType<typeof setTimeout> | null = null;
+    let stdoutBuffer = '';
 
     const clearTimers = () => {
       clearTimeout(timer);
@@ -407,29 +456,56 @@ export function spawnClaude(
       }
     };
 
-    // Hard timeout — kill subprocess if it runs too long
-    const timeoutMs = config.timeoutMinutes * 60 * 1000;
-    const timer = setTimeout(() => {
-      timedOut = true;
-      log(`  ${cl.yellow}⚠ Claude subprocess timed out after ${config.timeoutMinutes}m — killing${cl.reset}`);
+    // Single kill path — used by both timeout and budget. Idempotent so a
+    // concurrent budget-cross + timeout doesn't double-fire SIGTERM.
+    const triggerKill = (reason: 'timeout' | 'budget') => {
+      if (killedReason) return;
+      killedReason = reason;
       child.kill('SIGTERM');
-      // Force kill if SIGTERM doesn't exit within 10s.
-      // Note: child.killed is true as soon as kill() is called, so we check
-      // exitCode/signalCode instead to know if the process actually exited.
       forceKillTimer = setTimeout(() => {
         if (child.exitCode === null && child.signalCode === null) {
           child.kill('SIGKILL');
         }
       }, 10_000);
+    };
+
+    // Hard timeout — kill subprocess if it runs too long
+    const timeoutMs = config.timeoutMinutes * 60 * 1000;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      log(
+        `  ${cl.yellow}⚠ Claude subprocess timed out after ${config.timeoutMinutes}m — killing${cl.reset}`,
+      );
+      triggerKill('timeout');
     }, timeoutMs);
 
+    const handleLine = (line: string) => {
+      const effect = processStreamJsonLine(line, state, cap);
+      if (effect.stderrText) process.stderr.write(effect.stderrText + '\n');
+      if (effect.budgetCrossedNow && !budgetExceeded) {
+        budgetExceeded = true;
+        log(
+          `  ${cl.red}⚠ Input-token budget exceeded (observed ${state.cumulativeInputTokens} ≥ cap ${cap}) — killing claude subprocess${cl.reset}`,
+        );
+        triggerKill('budget');
+      }
+    };
+
     child.stdout.on('data', (chunk: Buffer) => {
-      const text = chunk.toString();
-      output += text;
-      process.stderr.write(text);
+      stdoutBuffer += chunk.toString();
+      let nlIdx;
+      while ((nlIdx = stdoutBuffer.indexOf('\n')) !== -1) {
+        const line = stdoutBuffer.slice(0, nlIdx);
+        stdoutBuffer = stdoutBuffer.slice(nlIdx + 1);
+        handleLine(line);
+      }
     });
     child.stderr.on('data', (chunk: Buffer) => {
-      output += chunk.toString();
+      const text = chunk.toString();
+      // Surface stderr to the operator (claude warnings live here) and append
+      // to output so existing substring matchers still see error wording.
+      process.stderr.write(text);
+      state.outputParts.push(text);
     });
 
     child.stdin.write(prompt);
@@ -437,11 +513,50 @@ export function spawnClaude(
 
     child.on('close', (code) => {
       clearTimers();
+      // Drain any final partial line so we don't lose the result event.
+      if (stdoutBuffer.trim()) handleLine(stdoutBuffer);
+      stdoutBuffer = '';
+
+      const output = buildOutput(state);
+      // Backward-compat fallback: in the previous text-mode the `Reached max
+      // turns` substring was the canonical signal. Keep it as a safety net in
+      // case stop_reason / subtype don't carry the cue on a future CLI build.
+      const hitMaxTurns = state.hitMaxTurns || output.includes('Reached max turns');
+
+      if (budgetExceeded) {
+        // The kill-signal landed; verify whether the process actually exited
+        // versus still hanging at SIGKILL deadline (close is firing now, so
+        // it did exit — but record the signal source for forensics).
+        const killSucceeded = child.exitCode !== null || child.signalCode !== null;
+        try {
+          appendJsonl(JSONL_FILE, {
+            type: 'cycle_budget_exceeded',
+            pr_num: opts?.context?.prNumber ?? null,
+            label: opts?.context?.label ?? null,
+            threshold: cap,
+            observed_input_tokens: state.cumulativeInputTokens,
+            kill_succeeded: killSucceeded,
+            exit_code: code,
+            signal: child.signalCode,
+          });
+        } catch (e) {
+          // Don't let a disk-full error stall the promise; the kill itself
+          // succeeded and the operator already has the live stderr warning.
+          log(
+            `  ${cl.yellow}Warning: could not append cycle_budget_exceeded JSONL: ${
+              e instanceof Error ? e.message : String(e)
+            }${cl.reset}`,
+          );
+        }
+      }
+
       resolve({
         exitCode: code ?? 1,
         output,
-        hitMaxTurns: output.includes('Reached max turns'),
+        hitMaxTurns,
         timedOut,
+        budgetExceeded,
+        inputTokens: state.cumulativeInputTokens,
       });
     });
     child.on('error', (err) => {
@@ -742,7 +857,7 @@ export async function fixPr(pr: ScoredPr, config: PatrolConfig): Promise<FixPrRe
       ...config,
       maxTurns: effectiveMaxTurns,
       timeoutMinutes: effectiveTimeout,
-    }, { cwd: worktreePath });
+    }, { cwd: worktreePath, context: { prNumber: pr.number } });
     const elapsedS = Math.floor((Date.now() - startTime) / 1000);
 
     if (result.timedOut) {

--- a/crux/pr-patrol/execution.ts
+++ b/crux/pr-patrol/execution.ts
@@ -304,14 +304,23 @@ export async function fixMainBranch(status: MainBranchStatus, config: PatrolConf
     });
     const elapsedS = Math.floor((Date.now() - startTime) / 1000);
 
-    if (result.timedOut) {
+    if (result.timedOut || result.budgetExceeded) {
       const failCount = recordFailure(MAIN_BRANCH_KEY);
       outcome = 'timeout';
-      reason = `Killed after ${config.timeoutMinutes}m timeout — attempt ${failCount}`;
-      log(`${cl.red}✗ Main branch fix timed out after ${config.timeoutMinutes}m${cl.reset} (attempt ${failCount})`);
+      // QUA-1078: a budget kill is shaped like a timeout (daemon-initiated
+      // SIGTERM, partial work) — fold into the same branch but emit a clearer
+      // reason so operators don't see a meaningless "Exit code: null".
+      reason = result.budgetExceeded
+        ? `Killed after exceeding ${config.inputTokenCap ?? 0} cumulative input_tokens (observed ${result.inputTokens}) — attempt ${failCount}`
+        : `Killed after ${config.timeoutMinutes}m timeout — attempt ${failCount}`;
+      log(
+        result.budgetExceeded
+          ? `${cl.red}✗ Main branch fix killed for input-token budget (${result.inputTokens})${cl.reset} (attempt ${failCount})`
+          : `${cl.red}✗ Main branch fix timed out after ${config.timeoutMinutes}m${cl.reset} (attempt ${failCount})`,
+      );
 
       if (failCount >= MAIN_BRANCH_ABANDON_THRESHOLD) {
-        reason = `Abandoned after ${failCount} failures (timeout)`;
+        reason = `Abandoned after ${failCount} failures (${result.budgetExceeded ? 'budget' : 'timeout'})`;
         log(`${cl.red}✗ Main branch fix abandoned after ${failCount} failures${cl.reset}`);
       }
     } else if (result.exitCode === 0 && !result.hitMaxTurns) {
@@ -461,6 +470,11 @@ export function spawnClaude(
     const triggerKill = (reason: 'timeout' | 'budget') => {
       if (killedReason) return;
       killedReason = reason;
+      // If we got here from a close-handler drain (the partial-line buffer
+      // crossing the cap *after* the child has already exited), the child
+      // is gone — calling kill() is harmless but the SIGKILL fallback timer
+      // would leak for 10s and delay clean shutdown. Skip it.
+      if (child.exitCode !== null || child.signalCode !== null) return;
       child.kill('SIGTERM');
       forceKillTimer = setTimeout(() => {
         if (child.exitCode === null && child.signalCode === null) {
@@ -501,11 +515,13 @@ export function spawnClaude(
       }
     });
     child.stderr.on('data', (chunk: Buffer) => {
-      const text = chunk.toString();
-      // Surface stderr to the operator (claude warnings live here) and append
-      // to output so existing substring matchers still see error wording.
-      process.stderr.write(text);
-      state.outputParts.push(text);
+      // Surface stderr to the operator (claude warnings live here) but DO
+      // NOT append to output: stderr can include partial credentials on auth
+      // failure (e.g. truncated `sk-ant-...` echoes), and `output.slice(-500)`
+      // is posted as a public PR comment via buildFixCompleteComment. The
+      // pre-stream-json text mode concatenated stderr too — that was a
+      // pre-existing leak risk we're tightening up here.
+      process.stderr.write(chunk);
     });
 
     child.stdin.write(prompt);
@@ -518,10 +534,11 @@ export function spawnClaude(
       stdoutBuffer = '';
 
       const output = buildOutput(state);
-      // Backward-compat fallback: in the previous text-mode the `Reached max
-      // turns` substring was the canonical signal. Keep it as a safety net in
-      // case stop_reason / subtype don't carry the cue on a future CLI build.
-      const hitMaxTurns = state.hitMaxTurns || output.includes('Reached max turns');
+      // hitMaxTurns is already OR'd from three signals in `handleResult`
+      // (subtype, stop_reason, regex against resultText). No need for a
+      // redundant outer substring check — if the result event carried the
+      // phrase, handleResult set the flag.
+      const hitMaxTurns = state.hitMaxTurns;
 
       if (budgetExceeded) {
         // The kill-signal landed; verify whether the process actually exited
@@ -860,17 +877,26 @@ export async function fixPr(pr: ScoredPr, config: PatrolConfig): Promise<FixPrRe
     }, { cwd: worktreePath, context: { prNumber: pr.number } });
     const elapsedS = Math.floor((Date.now() - startTime) / 1000);
 
-    if (result.timedOut) {
-      // Timeouts count toward abandonment — a PR that times out repeatedly
-      // is likely unfixable and should not keep burning compute.
+    if (result.timedOut || result.budgetExceeded) {
+      // Timeouts AND budget kills count toward abandonment — a PR that
+      // repeatedly times out or repeatedly blows the input-token cap is
+      // likely unfixable and shouldn't keep burning compute. QUA-1078: fold
+      // budget kills into this branch so the reason string doesn't read
+      // "Exit code: null" — operators need to see what actually happened.
       const failCount = recordFailure(pr.number);
       outcome = 'timeout';
-      reason = `Killed after ${effectiveTimeout}m timeout — attempt ${failCount}`;
-      log(`${cl.red}✗ PR #${pr.number} timed out after ${effectiveTimeout}m${cl.reset} (attempt ${failCount})`);
+      reason = result.budgetExceeded
+        ? `Killed after exceeding ${config.inputTokenCap ?? 0} cumulative input_tokens (observed ${result.inputTokens}) — attempt ${failCount}`
+        : `Killed after ${effectiveTimeout}m timeout — attempt ${failCount}`;
+      log(
+        result.budgetExceeded
+          ? `${cl.red}✗ PR #${pr.number} killed for input-token budget (${result.inputTokens})${cl.reset} (attempt ${failCount})`
+          : `${cl.red}✗ PR #${pr.number} timed out after ${effectiveTimeout}m${cl.reset} (attempt ${failCount})`,
+      );
 
       if (failCount >= 2) {
         markAbandoned(pr.number);
-        reason = `Abandoned after ${failCount} failures (timeout)`;
+        reason = `Abandoned after ${failCount} failures (${result.budgetExceeded ? 'budget' : 'timeout'})`;
         log(`${cl.red}✗ PR #${pr.number} abandoned after ${failCount} consecutive failures${cl.reset}`);
         await postEventComment(pr.number, config.repo, buildAbandonmentComment(failCount, pr.issues))
           .catch((e: unknown) => log(`  Warning: could not post abandonment comment: ${e instanceof Error ? e.message : String(e)}`));

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -273,6 +273,11 @@ export function buildConfig(
       options.timeout ?? process.env.PR_PATROL_TIMEOUT_MINUTES,
       60,
     ),
+    // QUA-1078: inline 50k input-token cap on spawnClaude. 0 disables.
+    inputTokenCap: parseIntOpt(
+      options.inputTokenCap ?? process.env.PR_PATROL_INPUT_TOKEN_CAP,
+      50_000,
+    ),
   };
 }
 

--- a/crux/pr-patrol/parallel.ts
+++ b/crux/pr-patrol/parallel.ts
@@ -201,6 +201,9 @@ interface ClaudeResult {
   output: string;
   hitMaxTurns: boolean;
   timedOut: boolean;
+  /** QUA-1078: optional fields from spawnClaude's stream-json mode. */
+  budgetExceeded?: boolean;
+  inputTokens?: number;
 }
 
 interface ClassifiedOutcome {
@@ -219,11 +222,17 @@ export function classifyFixOutcome(
   effectiveTimeout: number,
   effectiveMaxTurns: number,
 ): ClassifiedOutcome {
-  if (result.timedOut) {
+  if (result.timedOut || result.budgetExceeded) {
     const failCount = recordFailure(prNumber);
+    // QUA-1078: budget kills are shaped like timeouts (daemon-initiated,
+    // partial work) — fold both into the same branch but emit a clearer
+    // reason so the JSONL/PR-comment isn't a meaningless "Exit code: null".
+    const cause = result.budgetExceeded ? 'budget' : 'timeout';
     const reason = failCount >= 2
-      ? `Abandoned after ${failCount} failures (timeout)`
-      : `Killed after ${effectiveTimeout}m timeout — attempt ${failCount}`;
+      ? `Abandoned after ${failCount} failures (${cause})`
+      : result.budgetExceeded
+        ? `Killed after exceeding cumulative input_tokens (observed ${result.inputTokens ?? '?'}) — attempt ${failCount}`
+        : `Killed after ${effectiveTimeout}m timeout — attempt ${failCount}`;
     return { outcome: 'timeout', reason, mainIsRootCause: false };
   }
 

--- a/crux/pr-patrol/parallel.ts
+++ b/crux/pr-patrol/parallel.ts
@@ -376,7 +376,7 @@ async function fixPrInWorktree(
             ...config,
             maxTurns: 60,
             timeoutMinutes: 30,
-          }, { cwd: worktreePath });
+          }, { cwd: worktreePath, context: { prNumber: pr.number, label: 'rebase-only' } });
           const elapsedS = Math.floor((Date.now() - startTime) / 1000);
           const claudeOutcome: FixOutcome = rebaseResult2.exitCode === 0 && !rebaseResult2.hitMaxTurns ? 'fixed' : 'error';
           if (claudeOutcome === 'fixed') {
@@ -420,7 +420,7 @@ async function fixPrInWorktree(
       ...config,
       maxTurns: effectiveMaxTurns,
       timeoutMinutes: effectiveTimeout,
-    }, { cwd: worktreePath });
+    }, { cwd: worktreePath, context: { prNumber: pr.number } });
 
     const elapsedS = Math.floor((Date.now() - startTime) / 1000);
 
@@ -833,6 +833,11 @@ export function buildParallelConfig(
     timeoutMinutes: parseIntOpt(
       options.timeout ?? process.env.PR_PATROL_TIMEOUT_MINUTES,
       60,
+    ),
+    // QUA-1078: inline 50k input-token cap on spawnClaude. 0 disables.
+    inputTokenCap: parseIntOpt(
+      options.inputTokenCap ?? process.env.PR_PATROL_INPUT_TOKEN_CAP,
+      50_000,
     ),
   };
 

--- a/crux/pr-patrol/reflection.ts
+++ b/crux/pr-patrol/reflection.ts
@@ -64,7 +64,7 @@ ${recentEntries}
       maxTurns: 10, // Reflection needs fewer turns
       model: 'haiku', // Reflection is log analysis — doesn't need sonnet
       timeoutMinutes: 5, // Should complete quickly
-    });
+    }, { context: { label: `reflection:cycle-${cycleCount}` } });
     const elapsedS = Math.floor((Date.now() - startTime) / 1000);
 
     if (result.timedOut || result.hitMaxTurns) {

--- a/crux/pr-patrol/spawn-claude.test.ts
+++ b/crux/pr-patrol/spawn-claude.test.ts
@@ -14,16 +14,37 @@
  */
 
 import { EventEmitter } from 'events';
-import { mkdtempSync, readFileSync, existsSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { Readable, Writable } from 'stream';
+import { spawn as nodeSpawn } from 'child_process';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Override HOME *before* importing modules that compute JSONL_FILE at load,
-// so writes land in a per-test temp dir we can clean up.
-const tmpHome = mkdtempSync(join(tmpdir(), 'spawn-claude-test-'));
-process.env.HOME = tmpHome;
+// Override JSONL_FILE via vi.mock so writes land in a per-test temp dir.
+// Plain `process.env.HOME = ...` at the top of the file is **not** sufficient
+// because ESM imports are statically hoisted: by the time the assignment
+// runs, `state.ts` has already evaluated `JSONL_FILE = join(HOME, ...)` using
+// the real HOME. Without this mock the integration tests truncate the
+// operator's actual ~/.cache/pr-patrol/runs.jsonl.
+const { TEST_JSONL_FILE } = vi.hoisted(() => {
+  // CJS APIs only — vi.hoisted runs before any ESM imports resolve.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const fs = require('fs') as typeof import('fs');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const os = require('os') as typeof import('os');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require('path') as typeof import('path');
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-claude-test-'));
+  const cacheDir = path.join(tmpHome, '.cache', 'pr-patrol');
+  fs.mkdirSync(cacheDir, { recursive: true });
+  return { TEST_JSONL_FILE: path.join(cacheDir, 'runs.jsonl') };
+});
+
+vi.mock('./state.ts', async () => {
+  const actual = await vi.importActual<typeof import('./state.ts')>('./state.ts');
+  return { ...actual, JSONL_FILE: TEST_JSONL_FILE };
+});
 
 interface FakeChild extends EventEmitter {
   stdout: Readable;
@@ -112,9 +133,9 @@ function readJsonlEntries(): Array<Record<string, unknown>> {
 
 beforeEach(() => {
   // Truncate the JSONL between tests so assertions are scoped per-test.
-  if (existsSync(JSONL_FILE)) {
-    require('fs').writeFileSync(JSONL_FILE, '');
-  }
+  // JSONL_FILE here is the mocked path (TEST_JSONL_FILE), guaranteed by the
+  // vi.mock above to point inside our temp dir.
+  if (existsSync(JSONL_FILE)) writeFileSync(JSONL_FILE, '');
 });
 
 afterEach(() => {
@@ -223,6 +244,77 @@ describe('spawnClaude (stream-json + token cap)', () => {
     const result = await promise;
     expect(result.hitMaxTurns).toBe(true);
     expect(result.budgetExceeded).toBe(false);
+  });
+
+  it('passes --output-format stream-json --verbose to claude (regression guard for arg ordering)', async () => {
+    const promise = spawnClaude('test', baseConfig, undefined);
+    queueMicrotask(() => {
+      lastChild.stdout.push(RESULT_OK);
+      setImmediate(() => {
+        lastChild.exitCode = 0;
+        lastChild.emit('close', 0);
+      });
+    });
+    await promise;
+    const spawnMock = vi.mocked(nodeSpawn);
+    const args = spawnMock.mock.calls.at(-1)![1] as string[];
+    expect(args).toContain('--output-format');
+    expect(args[args.indexOf('--output-format') + 1]).toBe('stream-json');
+    expect(args).toContain('--verbose');
+    expect(args).toContain('--print');
+  });
+
+  it('does NOT leak the SIGKILL fallback timer when budget cross fires from the close-handler drain', async () => {
+    // The close handler drains a partial line; if that drain crosses the cap,
+    // triggerKill is called *after* the child has already exited. The
+    // SIGKILL fallback timer would otherwise leak for 10s and delay shutdown.
+    const promise = spawnClaude('test', baseConfig, { context: { prNumber: 1 } });
+    queueMicrotask(() => {
+      // Push a complete event under cap, then a partial line that crosses
+      // the cap with NO trailing newline (drained at close).
+      lastChild.stdout.push(ASSISTANT('part1', 30_000));
+      const partial = JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          usage: { input_tokens: 25_000, output_tokens: 1 },
+          content: [{ type: 'text', text: 'crossing now' }],
+        },
+      });
+      lastChild.stdout.push(partial);
+      setImmediate(() => {
+        // Child has already exited cleanly (close fires here). triggerKill
+        // should detect this and NOT schedule the SIGKILL timer.
+        lastChild.exitCode = 0;
+        lastChild.signalCode = null;
+        lastChild.emit('close', 0);
+      });
+    });
+    const result = await promise;
+    expect(result.budgetExceeded).toBe(true);
+    // kill was NOT invoked — child had exited before triggerKill ran, so the
+    // early-return guard fires and avoids the leaked SIGKILL timer.
+    expect(lastChild.kill).not.toHaveBeenCalled();
+  });
+
+  it('does NOT bleed claude stderr into result.output (avoids credential-leak in PR comments)', async () => {
+    const promise = spawnClaude('test', baseConfig, undefined);
+    queueMicrotask(() => {
+      // Simulate claude writing a partial credential string to stderr (auth
+      // failure echoes the bad token). This must NOT show up in `output`,
+      // since callers post `output.slice(-500)` as a public PR comment.
+      lastChild.stderr.push('Bad token: sk-ant-api03-LEAK-DO-NOT-PUBLISH\n');
+      lastChild.stdout.push(ASSISTANT('I will look at this', 100));
+      lastChild.stdout.push(RESULT_OK);
+      setImmediate(() => {
+        lastChild.exitCode = 0;
+        lastChild.emit('close', 0);
+      });
+    });
+    const result = await promise;
+    expect(result.output).not.toContain('sk-ant-api03');
+    expect(result.output).not.toContain('Bad token');
+    expect(result.output).toContain('I will look at this');
   });
 
   it('emits the budget event even if a partial final line lacks a trailing newline', async () => {

--- a/crux/pr-patrol/spawn-claude.test.ts
+++ b/crux/pr-patrol/spawn-claude.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Integration tests for `spawnClaude` covering the QUA-1078 stream-json + 50k
+ * input-token cap migration.
+ *
+ * Strategy: mock `child_process.spawn` to return a fake child process whose
+ * stdout/stderr we drive manually. Tests assert on the final result shape, on
+ * whether `child.kill('SIGTERM')` was invoked when the budget was exceeded,
+ * and on the `cycle_budget_exceeded` event being appended to runs.jsonl.
+ *
+ * The real concern of the migration — backward-compat output reconstruction
+ * and stream-json parsing — is covered exhaustively by stream-json.test.ts.
+ * This file focuses on the spawn lifecycle: child events, timer interactions,
+ * kill signalling, JSONL emission.
+ */
+
+import { EventEmitter } from 'events';
+import { mkdtempSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Readable, Writable } from 'stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Override HOME *before* importing modules that compute JSONL_FILE at load,
+// so writes land in a per-test temp dir we can clean up.
+const tmpHome = mkdtempSync(join(tmpdir(), 'spawn-claude-test-'));
+process.env.HOME = tmpHome;
+
+interface FakeChild extends EventEmitter {
+  stdout: Readable;
+  stderr: Readable;
+  stdin: Writable;
+  kill: ReturnType<typeof vi.fn>;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+}
+
+let lastChild: FakeChild;
+
+function makeFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new Readable({ read() {} });
+  child.stderr = new Readable({ read() {} });
+  child.stdin = new Writable({ write(_chunk, _enc, cb) { cb(); } });
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = vi.fn((signal?: NodeJS.Signals | number) => {
+    // Track the signal so the test can assert SIGTERM was sent. Don't
+    // auto-exit the child — tests script the close event explicitly.
+    if (signal === 'SIGTERM' || signal === undefined) child.signalCode = 'SIGTERM';
+    if (signal === 'SIGKILL') child.signalCode = 'SIGKILL';
+    return true;
+  });
+  return child;
+}
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    spawn: vi.fn(() => {
+      lastChild = makeFakeChild();
+      return lastChild;
+    }),
+  };
+});
+
+import type { PatrolConfig } from './types.ts';
+import { spawnClaude } from './execution.ts';
+import { JSONL_FILE } from './state.ts';
+
+const baseConfig: PatrolConfig = {
+  repo: 'q/r',
+  intervalSeconds: 60,
+  maxTurns: 5,
+  cooldownSeconds: 0,
+  staleHours: 48,
+  model: 'sonnet',
+  skipPerms: true,
+  once: true,
+  dryRun: false,
+  verbose: false,
+  reflectionInterval: 10,
+  timeoutMinutes: 60,
+  inputTokenCap: 50_000,
+};
+
+const ASSISTANT = (text: string, inputTokens: number) =>
+  JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      usage: { input_tokens: inputTokens, output_tokens: 10 },
+      content: [{ type: 'text', text }],
+    },
+  }) + '\n';
+
+const RESULT_OK = JSON.stringify({
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  stop_reason: 'end_turn',
+  result: 'all done',
+}) + '\n';
+
+function readJsonlEntries(): Array<Record<string, unknown>> {
+  if (!existsSync(JSONL_FILE)) return [];
+  return readFileSync(JSONL_FILE, 'utf-8')
+    .split('\n')
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+beforeEach(() => {
+  // Truncate the JSONL between tests so assertions are scoped per-test.
+  if (existsSync(JSONL_FILE)) {
+    require('fs').writeFileSync(JSONL_FILE, '');
+  }
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('spawnClaude (stream-json + token cap)', () => {
+  it('returns normally and reconstructs output for under-cap runs', async () => {
+    const promise = spawnClaude('test prompt', baseConfig, { context: { prNumber: 99 } });
+
+    // Drive the fake child: emit a few assistant events under the cap, then a clean result.
+    queueMicrotask(() => {
+      lastChild.stdout.push(ASSISTANT('looking at failing test', 5_000));
+      lastChild.stdout.push(ASSISTANT('found root cause; pushing fix', 5_000));
+      lastChild.stdout.push(RESULT_OK);
+      // Defer close so the Readable's internal 'data' emissions drain into
+      // our parser before we tell spawnClaude the process exited.
+      setImmediate(() => {
+        lastChild.exitCode = 0;
+        lastChild.emit('close', 0);
+      });
+    });
+
+    const result = await promise;
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+    expect(result.budgetExceeded).toBe(false);
+    expect(result.hitMaxTurns).toBe(false);
+    expect(result.inputTokens).toBe(10_000);
+    expect(result.output).toContain('looking at failing test');
+    expect(result.output).toContain('found root cause');
+    expect(result.output).toContain('all done');
+  });
+
+  it('SIGTERMs the child and emits cycle_budget_exceeded when input_tokens crosses the cap', async () => {
+    const promise = spawnClaude('test prompt', baseConfig, {
+      context: { prNumber: 4242, label: 'unit-test' },
+    });
+
+    queueMicrotask(() => {
+      lastChild.stdout.push(ASSISTANT('thinking...', 25_000));
+      lastChild.stdout.push(ASSISTANT('still thinking — really deep tree', 30_000));
+      // Caller (spawnClaude) should call kill() right here. We script close
+      // shortly after to emulate the child responding to SIGTERM.
+      setImmediate(() => {
+        lastChild.exitCode = null;
+        lastChild.signalCode = 'SIGTERM';
+        lastChild.emit('close', null);
+      });
+    });
+
+    const result = await promise;
+    expect(lastChild.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(result.budgetExceeded).toBe(true);
+    expect(result.inputTokens).toBe(55_000);
+
+    const entries = readJsonlEntries();
+    const budgetEntry = entries.find((e) => e.type === 'cycle_budget_exceeded');
+    expect(budgetEntry).toBeDefined();
+    expect(budgetEntry?.pr_num).toBe(4242);
+    expect(budgetEntry?.label).toBe('unit-test');
+    expect(budgetEntry?.threshold).toBe(50_000);
+    expect(budgetEntry?.observed_input_tokens).toBe(55_000);
+    expect(budgetEntry?.kill_succeeded).toBe(true);
+  });
+
+  it('does NOT fire the budget kill when cap is 0 (disabled)', async () => {
+    const promise = spawnClaude('test', { ...baseConfig, inputTokenCap: 0 }, undefined);
+
+    queueMicrotask(() => {
+      lastChild.stdout.push(ASSISTANT('huge', 100_000));
+      lastChild.stdout.push(RESULT_OK);
+      setImmediate(() => {
+        lastChild.exitCode = 0;
+        lastChild.emit('close', 0);
+      });
+    });
+
+    const result = await promise;
+    expect(lastChild.kill).not.toHaveBeenCalled();
+    expect(result.budgetExceeded).toBe(false);
+    expect(result.inputTokens).toBe(100_000);
+
+    const entries = readJsonlEntries();
+    expect(entries.find((e) => e.type === 'cycle_budget_exceeded')).toBeUndefined();
+  });
+
+  it('detects hitMaxTurns from a max-turns result event', async () => {
+    const promise = spawnClaude('test', baseConfig, undefined);
+
+    queueMicrotask(() => {
+      lastChild.stdout.push(ASSISTANT('working', 1_000));
+      lastChild.stdout.push(JSON.stringify({
+        type: 'result',
+        subtype: 'error_max_turns',
+        is_error: true,
+        stop_reason: 'max_turns',
+        result: 'Reached max turns. Stopping.',
+      }) + '\n');
+      setImmediate(() => {
+        lastChild.exitCode = 0;
+        lastChild.emit('close', 0);
+      });
+    });
+
+    const result = await promise;
+    expect(result.hitMaxTurns).toBe(true);
+    expect(result.budgetExceeded).toBe(false);
+  });
+
+  it('emits the budget event even if a partial final line lacks a trailing newline', async () => {
+    const promise = spawnClaude('test', baseConfig, { context: { prNumber: 7 } });
+
+    queueMicrotask(() => {
+      // Push without trailing newline — close should drain the buffer.
+      lastChild.stdout.push(ASSISTANT('part1', 30_000).trimEnd());  // valid line
+      lastChild.stdout.push('\n');
+      // Now a partial line that crosses the cap, never terminated:
+      const partial = JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          usage: { input_tokens: 25_000, output_tokens: 1 },
+          content: [{ type: 'text', text: 'crossing now' }],
+        },
+      });
+      lastChild.stdout.push(partial);
+      // Don't push '\n' — verify the close handler drains the partial.
+      setImmediate(() => {
+        lastChild.exitCode = null;
+        lastChild.signalCode = 'SIGTERM';
+        lastChild.emit('close', null);
+      });
+    });
+
+    const result = await promise;
+    expect(result.budgetExceeded).toBe(true);
+    expect(result.inputTokens).toBe(55_000);
+  });
+});

--- a/crux/pr-patrol/stream-json.test.ts
+++ b/crux/pr-patrol/stream-json.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildOutput,
+  newStreamJsonState,
+  processStreamJsonLine,
+} from './stream-json.ts';
+
+const ASSISTANT_50K = JSON.stringify({
+  type: 'assistant',
+  message: {
+    role: 'assistant',
+    usage: {
+      input_tokens: 50_000,
+      output_tokens: 100,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+    content: [{ type: 'text', text: 'I will look at the failing test now.' }],
+  },
+});
+
+const ASSISTANT_TEXT = (text: string, inputTokens = 1_000) =>
+  JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      usage: { input_tokens: inputTokens, output_tokens: 50 },
+      content: [{ type: 'text', text }],
+    },
+  });
+
+const ASSISTANT_TOOL_USE = JSON.stringify({
+  type: 'assistant',
+  message: {
+    role: 'assistant',
+    usage: { input_tokens: 200, output_tokens: 5 },
+    content: [
+      {
+        type: 'tool_use',
+        name: 'Bash',
+        input: { command: 'pnpm test --run' },
+      },
+    ],
+  },
+});
+
+const TOOL_RESULT = (text: string) =>
+  JSON.stringify({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', content: text }],
+    },
+  });
+
+const SYSTEM_INIT = JSON.stringify({
+  type: 'system',
+  subtype: 'init',
+  model: 'claude-sonnet-4-6',
+  cwd: '/tmp/wt',
+  session_id: 'abc',
+});
+
+const RESULT_OK = JSON.stringify({
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  stop_reason: 'end_turn',
+  num_turns: 3,
+  duration_ms: 1234,
+  total_cost_usd: 0.05,
+  result: 'Done — pushed fix to claude/fix-1234. See https://github.com/x/y/pull/1234',
+});
+
+const RESULT_MAX_TURNS = JSON.stringify({
+  type: 'result',
+  subtype: 'error_max_turns',
+  is_error: true,
+  stop_reason: 'max_turns',
+  num_turns: 60,
+  duration_ms: 5_000,
+  total_cost_usd: 0.5,
+  result: 'Reached max turns. Stopping.',
+});
+
+describe('processStreamJsonLine', () => {
+  it('accumulates input_tokens across assistant events', () => {
+    const state = newStreamJsonState();
+    processStreamJsonLine(ASSISTANT_TEXT('first', 1000), state, 50_000);
+    processStreamJsonLine(ASSISTANT_TEXT('second', 2000), state, 50_000);
+    processStreamJsonLine(ASSISTANT_TEXT('third', 3000), state, 50_000);
+    expect(state.cumulativeInputTokens).toBe(6000);
+  });
+
+  it('appends assistant text to outputParts in order', () => {
+    const state = newStreamJsonState();
+    processStreamJsonLine(ASSISTANT_TEXT('first message'), state, 0);
+    processStreamJsonLine(ASSISTANT_TEXT('second message'), state, 0);
+    expect(buildOutput(state)).toBe('first message\nsecond message');
+  });
+
+  it('ignores empty / whitespace-only lines', () => {
+    const state = newStreamJsonState();
+    const a = processStreamJsonLine('', state, 0);
+    const b = processStreamJsonLine('   ', state, 0);
+    expect(a.stderrText).toBeNull();
+    expect(b.stderrText).toBeNull();
+    expect(state.outputParts).toEqual([]);
+  });
+
+  it('passes unparseable lines through (they may be claude warnings)', () => {
+    const state = newStreamJsonState();
+    const garbage = 'WARN: rate limit approaching';
+    const effect = processStreamJsonLine(garbage, state, 0);
+    expect(effect.stderrText).toBe(garbage);
+    expect(state.outputParts).toEqual([garbage]);
+  });
+
+  it('flags budgetCrossedNow exactly once on the crossing event', () => {
+    const state = newStreamJsonState();
+    // Two assistant events of 25k each with cap 50k — second one crosses.
+    const first = processStreamJsonLine(
+      ASSISTANT_TEXT('a', 25_000),
+      state,
+      50_000,
+    );
+    const second = processStreamJsonLine(
+      ASSISTANT_TEXT('b', 25_000),
+      state,
+      50_000,
+    );
+    expect(first.budgetCrossedNow).toBe(false);
+    expect(second.budgetCrossedNow).toBe(true);
+    expect(state.cumulativeInputTokens).toBe(50_000);
+
+    // Subsequent events do NOT re-flag the cross — caller already killed.
+    const third = processStreamJsonLine(
+      ASSISTANT_TEXT('c', 10_000),
+      state,
+      50_000,
+    );
+    expect(third.budgetCrossedNow).toBe(false);
+    expect(state.cumulativeInputTokens).toBe(60_000);
+  });
+
+  it('flags budgetCrossedNow when a single event crosses the cap', () => {
+    const state = newStreamJsonState();
+    const effect = processStreamJsonLine(ASSISTANT_50K, state, 50_000);
+    expect(effect.budgetCrossedNow).toBe(true);
+    expect(state.cumulativeInputTokens).toBe(50_000);
+  });
+
+  it('cap=0 disables the budget check', () => {
+    const state = newStreamJsonState();
+    const effect = processStreamJsonLine(ASSISTANT_TEXT('massive', 1_000_000), state, 0);
+    expect(effect.budgetCrossedNow).toBe(false);
+  });
+
+  it('renders tool_use as a single-line preview to stderr', () => {
+    const state = newStreamJsonState();
+    const effect = processStreamJsonLine(ASSISTANT_TOOL_USE, state, 0);
+    expect(effect.stderrText).toBe('[tool] Bash: pnpm test --run');
+    // Tool calls do NOT contribute to backward-compat output.
+    expect(buildOutput(state)).toBe('');
+  });
+
+  it('captures tool_result text into output for substring matching', () => {
+    const state = newStreamJsonState();
+    processStreamJsonLine(TOOL_RESULT('PR url: github.com/foo/bar/pull/9876'), state, 0);
+    expect(buildOutput(state)).toContain('pull/9876');
+  });
+
+  it('detects max-turns via subtype error_max_turns', () => {
+    const state = newStreamJsonState();
+    processStreamJsonLine(RESULT_MAX_TURNS, state, 0);
+    expect(state.hitMaxTurns).toBe(true);
+  });
+
+  it('detects max-turns via stop_reason=max_turns even without subtype', () => {
+    const state = newStreamJsonState();
+    const evt = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      stop_reason: 'max_turns',
+      result: '',
+    });
+    processStreamJsonLine(evt, state, 0);
+    expect(state.hitMaxTurns).toBe(true);
+  });
+
+  it('does not flag max-turns on a clean end_turn result', () => {
+    const state = newStreamJsonState();
+    processStreamJsonLine(RESULT_OK, state, 0);
+    expect(state.hitMaxTurns).toBe(false);
+  });
+
+  it('preserves agent text in the output for legacy regex callers', () => {
+    const state = newStreamJsonState();
+    processStreamJsonLine(SYSTEM_INIT, state, 0);
+    processStreamJsonLine(
+      ASSISTANT_TEXT('No code changes needed — this is a pre-existing failure on main'),
+      state,
+      0,
+    );
+    processStreamJsonLine(RESULT_OK, state, 0);
+
+    const output = buildOutput(state);
+    // looksLikeNoOp pattern
+    expect(/no code changes needed/i.test(output)).toBe(true);
+    // looksLikeMainRootCause pattern
+    expect(/pre-existing.*failure/i.test(output)).toBe(true);
+    // extractFixPrNumber pattern
+    expect(/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/.exec(output)?.[1]).toBe('1234');
+  });
+
+  it('emits a stderr line for system/init carrying the model', () => {
+    const state = newStreamJsonState();
+    const effect = processStreamJsonLine(SYSTEM_INIT, state, 0);
+    expect(effect.stderrText).toContain('claude-sonnet-4-6');
+  });
+
+  it('handles a missing usage block defensively', () => {
+    const state = newStreamJsonState();
+    const evt = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'no usage' }] },
+    });
+    const effect = processStreamJsonLine(evt, state, 50_000);
+    expect(effect.budgetCrossedNow).toBe(false);
+    expect(state.cumulativeInputTokens).toBe(0);
+    expect(buildOutput(state)).toBe('no usage');
+  });
+
+  it('tolerates unknown event types without error', () => {
+    const state = newStreamJsonState();
+    const evt = JSON.stringify({ type: 'rate_limit_event', rate_limit_info: {} });
+    const effect = processStreamJsonLine(evt, state, 0);
+    expect(effect.stderrText).toBeNull();
+  });
+});

--- a/crux/pr-patrol/stream-json.test.ts
+++ b/crux/pr-patrol/stream-json.test.ts
@@ -165,10 +165,14 @@ describe('processStreamJsonLine', () => {
     expect(buildOutput(state)).toBe('');
   });
 
-  it('captures tool_result text into output for substring matching', () => {
+  it('does NOT capture tool_result text into output (avoids extractFixPrNumber misfires)', () => {
+    // A `gh api /search/issues` tool_result can spray sibling PR URLs into
+    // the buffer; tail-slicing for `extractFixPrNumber` would then match the
+    // wrong PR. Tool_result is intentionally excluded — only the agent's own
+    // prose + result text feed the classifier.
     const state = newStreamJsonState();
     processStreamJsonLine(TOOL_RESULT('PR url: github.com/foo/bar/pull/9876'), state, 0);
-    expect(buildOutput(state)).toContain('pull/9876');
+    expect(buildOutput(state)).toBe('');
   });
 
   it('detects max-turns via subtype error_max_turns', () => {
@@ -238,5 +242,41 @@ describe('processStreamJsonLine', () => {
     const evt = JSON.stringify({ type: 'rate_limit_event', rate_limit_info: {} });
     const effect = processStreamJsonLine(evt, state, 0);
     expect(effect.stderrText).toBeNull();
+  });
+
+  it('tolerates negative or weird input_tokens defensively (no NaN, no crash)', () => {
+    // claude shouldn't emit a negative input_tokens, but if it ever did, the
+    // cap math should still terminate cleanly — not produce NaN or trip the
+    // crossed flag in an undefined way.
+    const state = newStreamJsonState();
+    const evt = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        usage: { input_tokens: -1000, output_tokens: 5 },
+        content: [{ type: 'text', text: 'weird' }],
+      },
+    });
+    const effect = processStreamJsonLine(evt, state, 50_000);
+    expect(effect.budgetCrossedNow).toBe(false);
+    expect(state.cumulativeInputTokens).toBe(-1000);
+    expect(Number.isNaN(state.cumulativeInputTokens)).toBe(false);
+  });
+
+  it('truncates a >160-char tool_use preview to keep stderr lines bounded', () => {
+    const state = newStreamJsonState();
+    const longCmd = 'a'.repeat(500);
+    const evt = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        usage: { input_tokens: 10, output_tokens: 1 },
+        content: [{ type: 'tool_use', name: 'Bash', input: { command: longCmd } }],
+      },
+    });
+    const effect = processStreamJsonLine(evt, state, 0);
+    expect(effect.stderrText).toBeTruthy();
+    expect(effect.stderrText!.length).toBeLessThan(200);
+    expect(effect.stderrText).toContain('…');
   });
 });

--- a/crux/pr-patrol/stream-json.ts
+++ b/crux/pr-patrol/stream-json.ts
@@ -1,0 +1,201 @@
+/**
+ * PR Patrol — stream-json event processing for spawnClaude
+ *
+ * The patrol daemon spawns `claude --print --output-format stream-json
+ * --verbose` (QUA-1078). Each stdout line is one JSON event. This module
+ * accumulates the agent's textual output into a backward-compatible
+ * `result.output` string (so the existing `looksLikeNoOp` /
+ * `looksLikeMainRootCause` / `extractFixPrNumber` regexes keep working) and
+ * tracks cumulative `input_tokens` so spawnClaude can SIGTERM a runaway
+ * agent before it burns the budget.
+ *
+ * Kept as a pure module — no spawn/IO — so the parser is unit-testable
+ * without standing up a real subprocess.
+ */
+
+export interface StreamJsonState {
+  /** Captured assistant/result text in arrival order. Joined for backward-compat output. */
+  outputParts: string[];
+  /** Sum of `message.usage.input_tokens` across every assistant event. */
+  cumulativeInputTokens: number;
+  /** True once a `result` event signalled max-turns (CLI-side). */
+  hitMaxTurns: boolean;
+}
+
+export interface LineEffect {
+  /** Text to render to the operator (preserves the live `tail -f run.log` UX). */
+  stderrText: string | null;
+  /** True iff cumulative input_tokens crossed the cap on this line. */
+  budgetCrossedNow: boolean;
+}
+
+export function newStreamJsonState(): StreamJsonState {
+  return {
+    outputParts: [],
+    cumulativeInputTokens: 0,
+    hitMaxTurns: false,
+  };
+}
+
+/**
+ * Apply a single stream-json line to `state`. Tolerant of malformed input —
+ * unparseable lines are appended to outputParts and surfaced verbatim to the
+ * operator (claude warnings/errors sometimes come through as plain text).
+ *
+ * `cap` of 0 disables the budget check.
+ */
+export function processStreamJsonLine(
+  line: string,
+  state: StreamJsonState,
+  cap: number,
+): LineEffect {
+  const trimmed = line.trim();
+  if (!trimmed) return { stderrText: null, budgetCrossedNow: false };
+
+  let evt: Record<string, unknown>;
+  try {
+    evt = JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    // Pass non-JSON lines straight through — claude's pre-stream stderr
+    // sometimes interleaves into stdout on auth/credit errors. Keep them
+    // visible AND searchable in `output` so existing regexes still fire.
+    state.outputParts.push(trimmed);
+    return { stderrText: trimmed, budgetCrossedNow: false };
+  }
+
+  const type = typeof evt.type === 'string' ? evt.type : '';
+
+  if (type === 'assistant') {
+    return handleAssistant(evt, state, cap);
+  }
+  if (type === 'result') {
+    return handleResult(evt, state);
+  }
+  if (type === 'user') {
+    return handleUserToolResult(evt, state);
+  }
+  if (type === 'system') {
+    return handleSystem(evt);
+  }
+  // Unknown event types (rate_limit_event, etc.) — silently track raw type for debugging.
+  return { stderrText: null, budgetCrossedNow: false };
+}
+
+function handleAssistant(
+  evt: Record<string, unknown>,
+  state: StreamJsonState,
+  cap: number,
+): LineEffect {
+  const msg = (evt.message ?? {}) as Record<string, unknown>;
+  const usage = (msg.usage ?? {}) as Record<string, unknown>;
+  const inputTokens = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
+
+  const wasUnderCap = cap > 0 ? state.cumulativeInputTokens < cap : false;
+  state.cumulativeInputTokens += inputTokens;
+  const budgetCrossedNow = cap > 0 && wasUnderCap && state.cumulativeInputTokens >= cap;
+
+  const content = Array.isArray(msg.content) ? (msg.content as Array<Record<string, unknown>>) : [];
+  const lines: string[] = [];
+  for (const part of content) {
+    const partType = typeof part.type === 'string' ? part.type : '';
+    if (partType === 'text' && typeof part.text === 'string') {
+      const text = part.text.trim();
+      if (text) {
+        state.outputParts.push(text);
+        lines.push(text);
+      }
+    } else if (partType === 'tool_use') {
+      const name = typeof part.name === 'string' ? part.name : '?';
+      const input = part.input;
+      let preview = '';
+      if (input && typeof input === 'object') {
+        const io = input as Record<string, unknown>;
+        if (typeof io.command === 'string') preview = io.command;
+        else if (typeof io.file_path === 'string') preview = io.file_path;
+        else if (typeof io.pattern === 'string') preview = io.pattern;
+        else if (typeof io.path === 'string') preview = io.path;
+        else if (typeof io.url === 'string') preview = io.url;
+      }
+      // Tool calls don't contribute to backward-compat output — they were
+      // never in text mode either (text mode only echoed the agent's own
+      // prose). But render them to stderr so the operator sees progress.
+      const truncated = preview.length > 160 ? preview.slice(0, 159) + '…' : preview;
+      lines.push(`[tool] ${name}${truncated ? ': ' + truncated : ''}`);
+    }
+  }
+
+  return {
+    stderrText: lines.length > 0 ? lines.join('\n') : null,
+    budgetCrossedNow,
+  };
+}
+
+function handleResult(
+  evt: Record<string, unknown>,
+  state: StreamJsonState,
+): LineEffect {
+  const resultText = typeof evt.result === 'string' ? evt.result : '';
+  const stopReason = typeof evt.stop_reason === 'string' ? evt.stop_reason : '';
+  const subtype = typeof evt.subtype === 'string' ? evt.subtype : '';
+  const isError = evt.is_error === true;
+
+  if (resultText) {
+    state.outputParts.push(resultText);
+  }
+  // CLI-side max-turns signal:
+  //   - subtype === 'error_max_turns' (newer claude builds)
+  //   - stop_reason === 'max_turns'
+  //   - "max turns" in result text
+  // We OR them together so a future CLI rename doesn't silently break the gate.
+  if (
+    subtype === 'error_max_turns' ||
+    stopReason === 'max_turns' ||
+    /max[ _-]?turns/i.test(resultText)
+  ) {
+    state.hitMaxTurns = true;
+  }
+
+  let stderrText: string | null = null;
+  if (resultText) stderrText = resultText;
+  else if (isError && subtype) stderrText = `[result error] ${subtype}`;
+
+  return { stderrText, budgetCrossedNow: false };
+}
+
+function handleUserToolResult(
+  evt: Record<string, unknown>,
+  state: StreamJsonState,
+): LineEffect {
+  const msg = (evt.message ?? {}) as Record<string, unknown>;
+  const content = Array.isArray(msg.content) ? (msg.content as Array<Record<string, unknown>>) : [];
+  for (const part of content) {
+    if (typeof part.type === 'string' && part.type === 'tool_result') {
+      let text = '';
+      if (typeof part.content === 'string') {
+        text = part.content;
+      } else if (Array.isArray(part.content)) {
+        const first = (part.content as Array<Record<string, unknown>>)[0];
+        if (first && typeof first.text === 'string') text = first.text;
+      }
+      if (text) state.outputParts.push(text);
+      // Tool results aren't echoed to stderr — keep the live tail focused on
+      // the agent's own prose + tool invocations. (Text mode never showed
+      // tool stdout either — claude only printed assistant turns.)
+    }
+  }
+  return { stderrText: null, budgetCrossedNow: false };
+}
+
+function handleSystem(evt: Record<string, unknown>): LineEffect {
+  const subtype = typeof evt.subtype === 'string' ? evt.subtype : '';
+  if (subtype === 'init') {
+    const model = typeof evt.model === 'string' ? evt.model : 'unknown';
+    return { stderrText: `[claude] init model=${model}`, budgetCrossedNow: false };
+  }
+  return { stderrText: null, budgetCrossedNow: false };
+}
+
+/** Build the backward-compatible `output` string consumed by the existing regexes. */
+export function buildOutput(state: StreamJsonState): string {
+  return state.outputParts.join('\n');
+}

--- a/crux/pr-patrol/stream-json.ts
+++ b/crux/pr-patrol/stream-json.ts
@@ -163,26 +163,19 @@ function handleResult(
 }
 
 function handleUserToolResult(
-  evt: Record<string, unknown>,
-  state: StreamJsonState,
+  _evt: Record<string, unknown>,
+  _state: StreamJsonState,
 ): LineEffect {
-  const msg = (evt.message ?? {}) as Record<string, unknown>;
-  const content = Array.isArray(msg.content) ? (msg.content as Array<Record<string, unknown>>) : [];
-  for (const part of content) {
-    if (typeof part.type === 'string' && part.type === 'tool_result') {
-      let text = '';
-      if (typeof part.content === 'string') {
-        text = part.content;
-      } else if (Array.isArray(part.content)) {
-        const first = (part.content as Array<Record<string, unknown>>)[0];
-        if (first && typeof first.text === 'string') text = first.text;
-      }
-      if (text) state.outputParts.push(text);
-      // Tool results aren't echoed to stderr — keep the live tail focused on
-      // the agent's own prose + tool invocations. (Text mode never showed
-      // tool stdout either — claude only printed assistant turns.)
-    }
-  }
+  // Deliberately a no-op: tool_result content is NOT pushed into outputParts.
+  // The regex classifiers (`looksLikeNoOp`, `looksLikeMainRootCause`,
+  // `extractFixPrNumber`, fix-complete tail) are calibrated against the
+  // agent's own prose only. A `gh api /search/issues` tool_result can dump
+  // dozens of github.com/.../pull/N URLs into the buffer and trick
+  // `extractFixPrNumber` into matching a sibling PR instead of the agent's
+  // actual fix-PR. tool_result was never user-visible in text mode either
+  // (claude only emitted assistant turns to stdout), so omitting it here
+  // preserves the prior contract. We also don't render to stderr — keeps the
+  // live `tail -f run.log` focused on the agent's own thinking + tool calls.
   return { stderrText: null, budgetCrossedNow: false };
 }
 

--- a/crux/pr-patrol/types.ts
+++ b/crux/pr-patrol/types.ts
@@ -51,4 +51,13 @@ export interface PatrolConfig {
   verbose: boolean;
   reflectionInterval: number;
   timeoutMinutes: number;
+  /**
+   * Inline cap on cumulative `input_tokens` reported by the spawned `claude`
+   * stream-json events. When the spawn exceeds this threshold the daemon
+   * SIGTERMs the child (10s SIGKILL fallback) and appends a
+   * `cycle_budget_exceeded` event to runs.jsonl. Defense-in-depth on top of
+   * `--max-turns` and `timeoutMinutes`. Set to 0 (or omit) to disable.
+   * Default in buildConfig: 50_000 (QUA-1071 AC#5 / QUA-1078).
+   */
+  inputTokenCap?: number;
 }


### PR DESCRIPTION
## Summary

Migrates `crux/pr-patrol/execution.ts:spawnClaude` from text-mode `claude --print --verbose` to `--output-format stream-json --verbose`, then adds an inline cumulative-`input_tokens` kill (default 50_000, configurable via `--input-token-cap=N` / `PR_PATROL_INPUT_TOKEN_CAP` / `PatrolConfig.inputTokenCap`).

When the cap is crossed:
- The child is sent SIGTERM with a 10s SIGKILL fallback.
- A `cycle_budget_exceeded` event is appended to `~/.cache/pr-patrol/runs.jsonl` with `pr_num`, `label`, `threshold`, `observed_input_tokens`, `kill_succeeded`, `exit_code`, `signal`.
- Main callers (`fixPr`, `fixMainBranch`, `parallel.classifyFixOutcome`) fold budget kills into the existing timeout branch with a clear reason — operators see `"Killed after exceeding 50000 cumulative input_tokens (observed 55000)"`, not `"Exit code: null"`.

Backward-compat is preserved by reconstructing `result.output` from joined `assistant` text + `result.result` text only — `tool_result` content and child stderr are intentionally NOT included (the regex classifiers were calibrated against agent prose only; including tool output would trick `extractFixPrNumber` into matching sibling URLs and risk leaking partial credentials from auth-failure stderr into public PR comments). The live `tail -f run.log` UX is preserved by re-rendering each `assistant` text event back to stderr.

## Why this is defense-in-depth

The Apr 2026 $1,877 incident traced to the in-Claude-session `/loop maintain-pr-patrol` pattern, which QUA-1071 already deprecated. The daemon's existing `--max-turns` + `timeoutMinutes` controls bound runaway cost in practice. This PR adds the deferred AC#5 from QUA-1071 — a third independent safeguard. Marginal value is genuinely diminishing.

## What changed

- **New module** `crux/pr-patrol/stream-json.ts` — pure, no-IO stream-json line parser. Tracks `cumulativeInputTokens`, accumulates `outputParts` for backward-compat output, detects `hitMaxTurns` from `subtype` / `stop_reason` / regex on `result.result`.
- **`spawnClaude`** rewritten around line-buffered stdout parsing + a single idempotent `triggerKill(reason)` helper used by both timeout and budget paths. Skips the SIGKILL fallback timer when the child has already exited (avoids leaking a 10s timer when the close-handler partial-line drain trips the cap).
- **`PatrolConfig.inputTokenCap`** added (optional). Both `buildConfig` (index.ts) and `buildParallelConfig` (parallel.ts) read it from `--input-token-cap` / `PR_PATROL_INPUT_TOKEN_CAP` (0 disables; default 50_000). Help text + env list updated in `pnpm crux gh pr-patrol --help`.
- **All 4 spawnClaude callsites** pass `context: { prNumber, label }` so the JSONL row carries useful identity (fixMainBranch → `main-branch:<runId>`, fixPr → `prNumber`, parallel rebase-only → `prNumber + 'rebase-only'`, branch-agent → `prNumber + 'branch-agent'`, reflection → `reflection:cycle-N`).
- **Caller awareness:** `fixPr`, `fixMainBranch`, `classifyFixOutcome` each branch on `result.budgetExceeded` so a budget kill produces a meaningful operator-facing reason and increments the PR's failure counter (so abandonment after 2 failures still kicks in).

## Tests

- `crux/pr-patrol/stream-json.test.ts` — 18 unit tests for the pure parser (cumulative tokens, single-event vs multi-event cap cross, `cap=0` disabled, unparseable lines, missing usage block, max-turns detection variants, tool_use rendering + 160-char truncation, tool_result EXCLUSION from output, defensive negative-input_tokens, unknown event types).
- `crux/pr-patrol/spawn-claude.test.ts` — 8 integration tests against a mocked `child_process.spawn`: under-cap normal return, budget kill + JSONL emission with PR identity, `cap=0` disabled, max-turns from result event, partial final line drained on close, **arg-ordering regression guard**, **leaked-timer guard for close-handler drain**, **stderr-credential-leak guard**.

Full pr-patrol suite: 514/514 ✅. Gate: 71/71 ✅ locally. tsc clean.

## Hostile review

Ran `/agent-review-pr` after the initial commit; it caught a CRITICAL test-isolation bug (HOME-override-at-top-of-file pattern doesn't work with ESM static imports — tests were truncating the operator's real `~/.cache/pr-patrol/runs.jsonl`) plus four HIGH-severity issues (leaked SIGKILL timer, callers not consuming `budgetExceeded`, tool_result corrupting the regex classifiers, stderr leaking into public PR comments). All addressed in commit `9e54edc72`.

## Test plan

- [x] Unit tests pass (`pnpm vitest run crux/pr-patrol/stream-json.test.ts crux/pr-patrol/spawn-claude.test.ts`)
- [x] Full pr-patrol suite passes (`pnpm vitest run crux/pr-patrol`)
- [x] `pnpm crux w validate gate --fix` passes
- [x] `pnpm crux gh pr-patrol --help` lists the new flag + env var
- [ ] CI green
- [ ] Manual smoke (operator's call, post-merge): launch the patrol daemon at home, watch one cycle's events.jsonl for the new shape; `tail -f run.log` should still show prose

Closes QUA-1078.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --input-token-cap (default 50,000; 0 disables) and PR_PATROL_INPUT_TOKEN_CAP to cap cumulative input tokens and produce a budget event when exceeded.
  * Stream-json parsing now reconstructs assistant output more reliably and tags events with PR/context.

* **Bug Fixes / Behavior**
  * Budget-exceeded terminations are handled like timeouts and logged distinctly; stderr is no longer merged into reconstructed output.

* **Tests**
  * Added integration and unit tests for budget enforcement and stream-json parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->