### PR TITLE
Integrate Plausible analytics in root layout

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -2,3 +2,9 @@
 # Copy to .env and fill in values for local development.
 # The workspace-root .env is loaded automatically by next.config.ts,
 # so you can also put these vars there.
+
+# Plausible analytics (hosted at plausible.io). When set, the layout injects
+# the Plausible tracker script with this domain. Leave unset locally so dev
+# builds don't render the tracker tag. In prod, set to the exact domain
+# registered in Plausible (e.g. www.longtermwiki.com).
+# NEXT_PUBLIC_PLAUSIBLE_DOMAIN=www.longtermwiki.com

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import Script from "next/script";
 import { DevModeToggle } from "@/components/DevModeToggle";
 import { SearchButton, SearchDialog } from "@/components/SearchDialog";
 import { MobileNav } from "@/components/MobileNav";
@@ -40,6 +41,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const plausibleDomain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -49,6 +51,13 @@ export default function RootLayout({
             __html: `(function(){if(localStorage.getItem('pageStatusDevMode')==='true'){document.documentElement.classList.add('page-status-dev-mode')}})()`,
           }}
         />
+        {plausibleDomain ? (
+          <Script
+            defer
+            data-domain={plausibleDomain}
+            src="https://plausible.io/js/script.js"
+          />
+        ) : null}
       </head>
       <body className="min-h-screen bg-background text-foreground overflow-x-clip">
         <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-card focus:border focus:border-border focus:rounded-md focus:text-sm focus:font-medium focus:text-foreground focus:shadow-lg">


### PR DESCRIPTION
## Summary

- Adds the Plausible tracker `<Script>` to `apps/web/src/app/layout.tsx`, gated on `NEXT_PUBLIC_PLAUSIBLE_DOMAIN`.
- When the env var is unset (local dev today), the tag isn't rendered. When set in prod, the tag injects `https://plausible.io/js/script.js` with `data-domain={env var}`.
- Documents the env var in `apps/web/.env.example`.

## Why this shape

Plausible's hosted `script.js` handles SPA navigation correctly and excludes `localhost` automatically. Using `next/script` keeps Next's loading-strategy semantics. No npm dependency added — `@plausible-analytics/tracker` is a one-step swap if/when we want a typed `track()` API for custom events.

## Bot filtering

Plausible is JS-based — server-side scrapers, curl/wget, and crawlers that don't execute JS are invisible to it from the start. Plausible also drops known-bot user agents. Headless-browser scrapers (Playwright/Puppeteer) that execute JS *can* slip through unless they hit the known-headless UA list. Numbers should be much closer to real humans than server-log analytics suggest, but not perfect.

## Deploy steps

1. In Plausible (plausible.io), add `www.longtermwiki.com` (or chosen canonical) as a site.
2. In Vercel, set project env var `NEXT_PUBLIC_PLAUSIBLE_DOMAIN=www.longtermwiki.com` (production environment).
3. Redeploy — `NEXT_PUBLIC_*` is build-time inlined, so a re-deploy is required.
4. View-source the homepage and confirm `<script ... data-domain="..." src="https://plausible.io/js/script.js">` is present, then check the Plausible dashboard for incoming pageviews.

## Test plan

- [x] Typecheck: `cd apps/web && npx tsc --noEmit` — passed locally
- [x] Gate: `pnpm crux w validate gate` — passed locally (also re-run by pre-push hook)
- [ ] Post-deploy: Plausible dashboard receives pageviews from `www.longtermwiki.com`
- [ ] Post-deploy: view-source shows the Plausible script tag

## Session checklist

| # | Item | State | Note |
|---|------|-------|------|
| 1 | fix-escaping | N/A | No MDX/content edits |
| 2 | lockfile-fresh | N/A | No `package.json` changes |
| 3 | gate-passes | done | Content-scope gate green; full gate green via pre-push hook |
| 4 | pr-description | done | This PR body |
| 5 | ids-server-allocated | N/A | No entities created |
| 6 | duplicate-check | done | Grepped for plausible/analytics/gtag/posthog/umami — no existing integration |
| 7 | tests-written | N/A | Trivial conditional render of one `<Script>` tag based on a string env var; no functions/logic to unit-test. Verified by typecheck + manual inspection |
| 8 | red-team | done | Empty/missing env var → no script tag; React auto-escapes `data-domain` value (no XSS via env var); env var is intentionally `NEXT_PUBLIC_` |
| 9 | retry-safety | N/A | No async/job/retry code |
| 10 | prompt-security | N/A | No LLM prompts |
| 11 | contract-alignment | N/A | No API calls |
| 12 | scope-complete | done | Acceptance: integrate Plausible — done |
| 13 | security | done | No secrets committed; env var is public by design; React escapes the data-domain attribute |
| 14 | issue-tracking | N/A | No GitHub/Linear issue for this session |
| 15 | push-ci-green | pending | Pushed; CI now starting |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional analytics integration, activatable via environment configuration.

* **Documentation**
  * Added setup guidance for analytics configuration in environment settings, with recommendations for local vs. production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->