### PR TITLE
fix(QUA-1082): filter cancelled runs in checkDeployHealth

### DIFF
--- a/crux/lib/pr-analysis/deploy-status.test.ts
+++ b/crux/lib/pr-analysis/deploy-status.test.ts
@@ -78,4 +78,62 @@ describe('checkDeployHealth', () => {
     // failingSince should be the earliest consecutive failure
     expect(result.failingSince).toBe('2026-03-06T12:00:00Z');
   });
+
+  it('ignores cancelled runs and uses next-most-recent successful run', async () => {
+    mockApi.mockResolvedValueOnce({
+      workflow_runs: [
+        makeRun({ id: 2, conclusion: 'cancelled', created_at: '2026-03-06T12:00:17Z', head_sha: 'abc123' }),
+        makeRun({ id: 1, conclusion: 'success', created_at: '2026-03-06T12:00:00Z', head_sha: 'abc123' }),
+      ],
+      total_count: 2,
+    });
+    const result = await checkDeployHealth('test/repo');
+    expect(result.healthy).toBe(true);
+    expect(result.lastDeploy?.status).toBe('success');
+  });
+
+  it('ignores cancelled runs and surfaces underlying failure', async () => {
+    mockApi.mockResolvedValueOnce({
+      workflow_runs: [
+        makeRun({ id: 3, conclusion: 'cancelled', created_at: '2026-03-06T14:00:00Z', head_sha: 'ghi789' }),
+        makeRun({ id: 2, conclusion: 'failure', created_at: '2026-03-06T12:00:00Z', head_sha: 'def456' }),
+        makeRun({ id: 1, conclusion: 'success', created_at: '2026-03-06T10:00:00Z' }),
+      ],
+      total_count: 3,
+    });
+    const result = await checkDeployHealth('test/repo');
+    expect(result.healthy).toBe(false);
+    expect(result.lastDeploy?.status).toBe('failure');
+    expect(result.failingSince).toBe('2026-03-06T12:00:00Z');
+  });
+
+  it('returns notAvailable when all runs are cancelled', async () => {
+    mockApi.mockResolvedValueOnce({
+      workflow_runs: [
+        makeRun({ id: 2, conclusion: 'cancelled', created_at: '2026-03-06T12:00:00Z', head_sha: 'abc123' }),
+        makeRun({ id: 1, conclusion: 'cancelled', created_at: '2026-03-06T10:00:00Z', head_sha: 'xyz000' }),
+      ],
+      total_count: 2,
+    });
+    const result = await checkDeployHealth('test/repo');
+    expect(result.healthy).toBe(true);
+    expect(result.lastDeploy).toBeNull();
+  });
+
+  it('failingSince walk skips intervening cancelled runs', async () => {
+    mockApi.mockResolvedValueOnce({
+      workflow_runs: [
+        makeRun({ id: 4, conclusion: 'failure', created_at: '2026-03-06T16:00:00Z', head_sha: 'jkl012' }),
+        makeRun({ id: 3, conclusion: 'cancelled', created_at: '2026-03-06T14:00:00Z', head_sha: 'ghi789' }),
+        makeRun({ id: 2, conclusion: 'failure', created_at: '2026-03-06T12:00:00Z', head_sha: 'def456' }),
+        makeRun({ id: 1, conclusion: 'success', created_at: '2026-03-06T10:00:00Z' }),
+      ],
+      total_count: 4,
+    });
+    const result = await checkDeployHealth('test/repo');
+    expect(result.healthy).toBe(false);
+    // The cancelled run is ignored; consecutive failures are id=4 and id=2,
+    // so failingSince should be the earlier failure's timestamp
+    expect(result.failingSince).toBe('2026-03-06T12:00:00Z');
+  });
 });

--- a/crux/lib/pr-analysis/deploy-status.ts
+++ b/crux/lib/pr-analysis/deploy-status.ts
@@ -54,9 +54,12 @@ export async function checkDeployHealth(repo?: string): Promise<DeployHealthStat
     );
 
     const runs = resp.workflow_runs ?? [];
-    if (runs.length === 0) return notAvailable;
+    // Cancelled runs did not produce a deployment (concurrency-cancelled, manually
+    // cancelled, or skipped). Skip them — only completed non-cancelled runs matter.
+    const meaningful = runs.filter((r) => r.conclusion !== 'cancelled');
+    if (meaningful.length === 0) return notAvailable;
 
-    const latest = runs[0];
+    const latest = meaningful[0];
     const lastDeploy = {
       status: latest.conclusion ?? 'unknown',
       sha: latest.head_sha,
@@ -68,9 +71,9 @@ export async function checkDeployHealth(repo?: string): Promise<DeployHealthStat
       return { healthy: true, lastDeploy, failingSince: null };
     }
 
-    // Find when consecutive failures started (walk backward through runs)
+    // Find when consecutive failures started (walk backward through meaningful runs)
     let failingSince = latest.created_at;
-    for (const run of runs) {
+    for (const run of meaningful) {
       if (run.conclusion === 'success') break;
       failingSince = run.created_at;
     }


### PR DESCRIPTION
## Summary

Fixes QUA-1082. `checkDeployHealth()` was returning `unhealthy` because a redundant `workflow_dispatch` run (concurrency-cancelled by GitHub Actions) had a newer `created_at` than the actual `push`-triggered deploy that succeeded. The cancelled run never produced a deployment but was treated as the latest deploy state. This blocks `crux release create` (preflight) and produces false alarms in `crux health`.

## Root cause

Timeline from the 2026-05-03 release attempt (https://github.com/quantified-uncertainty/longterm-wiki/actions/runs/25287142507):

| Run | Event | SHA | Conclusion | Created |
|---|---|---|---|---|
| 25271223664 | `workflow_dispatch` | 9a9b322 | **cancelled** | 05:47:10Z |
| 25271218476 | `push` | 9a9b322 | **success** | 05:46:53Z |

PR #4850 merged at 05:46:53Z; the `push` deploy succeeded. 17s later a redundant `workflow_dispatch` was triggered on the same SHA — GitHub concurrency cancelled it. Same `head_sha`, no new image — the cancelled run is meaningless. But `checkDeployHealth` sorted runs by `created_at` and picked `runs[0]`, so the preflight reported the cancelled run as the latest deploy and blocked the next release PR.

## Fix

`crux/lib/pr-analysis/deploy-status.ts`: filter out runs with `conclusion === 'cancelled'` before evaluating health. A cancelled run is not a meaningful health signal — what matters is the most recent run that actually completed (success or failure). The `failingSince` walk now iterates the filtered list so an intervening cancelled run doesn't break a streak of failures.

If filtering leaves zero runs, fall through to `notAvailable` (fail-open, same as the existing zero-runs path).

## Tests

Added 4 cases to `crux/lib/pr-analysis/deploy-status.test.ts`:
- `cancelled` → `success`: returns healthy with the success run
- `cancelled` → `failure` → `success`: returns unhealthy with the failure surfaced
- All `cancelled`: returns `notAvailable` (fail-open)
- `failure` → `cancelled` → `failure` → `success`: `failingSince` is the earlier failure (cancelled doesn't break the streak)

All 9 tests in `deploy-status.test.ts` pass. The existing `evaluateReleasePreflight` test ("blocks when last deploy was cancelled") in `release.test.ts` still passes — that's defensive logic in the evaluator, validly tested in isolation; in practice the evaluator no longer sees a `cancelled` status because `checkDeployHealth` filters it out first.

## Unblocks

- `crux release create` preflight (the immediate blocker)
- `crux health` "Wiki-server deploy: cancelled" false alarm (original QUA-1082 symptom)

## Test plan

- [x] `pnpm vitest run crux/lib/pr-analysis/deploy-status.test.ts` — 9/9 pass (5 existing + 4 new)
- [x] `pnpm vitest run crux/commands/release.test.ts` — `evaluateReleasePreflight` "blocks when last deploy was cancelled" still passes (defensive logic preserved)
- [x] `pnpm crux w validate gate --scope=content --fix` — clean
- [x] Manual diagnosis verified against real data: GitHub API returns the cancelled `workflow_dispatch` (25271223664) with `created_at` 17s after the `push` success (25271218476) on the same SHA — confirms the misordering this PR fixes

Fixes QUA-1082
