### PR TITLE
Cleanup: move Plausible <Script> out of <head>; drop redundant defer

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -51,15 +51,14 @@ export default function RootLayout({
             __html: `(function(){if(localStorage.getItem('pageStatusDevMode')==='true'){document.documentElement.classList.add('page-status-dev-mode')}})()`,
           }}
         />
+      </head>
+      <body className="min-h-screen bg-background text-foreground overflow-x-clip">
         {plausibleDomain ? (
           <Script
-            defer
             data-domain={plausibleDomain}
             src="https://plausible.io/js/script.js"
           />
         ) : null}
-      </head>
-      <body className="min-h-screen bg-background text-foreground overflow-x-clip">
         <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-card focus:border focus:border-border focus:rounded-md focus:text-sm focus:font-medium focus:text-foreground focus:shadow-lg">
           Skip to content
         </a>


### PR DESCRIPTION
## Summary

Cleanup follow-up to #4861. CodeRabbit reviewed the original PR and suggested moving the Plausible `<Script>` component out of `<head>` and dropping the redundant `defer` attribute. I committed the fix while #4861 was still open, but the merge happened during the pre-push gate run (~5–10 min) and the hook's stale "PR is OPEN" check let the push through *after* the merge. The cleanup commit ended up orphaned on `origin/claude/plausible-analytics-integration`. This PR cherry-picks it onto a fresh branch from `main`.

Filed [QUA-1106](https://linear.app/quantifieduncertainty/issue/QUA-1106) for the underlying pre-push hook race.

## What changed

- `<Script>` moves from `<head>` to inside `<body>`. `next/script` handles injection regardless of placement, so this is purely structural cleanup.
- `defer` attribute removed. Redundant when `next/script` controls loading via `strategy` (default `afterInteractive`).
- No functional behavior change: the script still loads when `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` is set, on the same `afterInteractive` strategy.

## What was rejected

CodeRabbit also suggested `strategy="lazyOnload"`. Declined: `lazyOnload` defers until browser idle, which means fast bounces (the pageviews most likely to be inflated by scrapers — the use case driving this integration) wouldn't fire. `afterInteractive` runs after hydration, before idle, which is the right tradeoff for analytics accuracy. Plausible's `script.js` is ~1KB; the LCP cost over `lazyOnload` is negligible.

## Test plan

- [x] Typecheck: `cd apps/web && npx tsc --noEmit` — passed locally
- [x] Pre-push gate: passed locally (cached from prior push of identical content)
- [ ] Post-merge: confirm Plausible dashboard still receives pageviews from `www.longtermwiki.com`
- [ ] Post-merge: view-source still shows the Plausible script tag (now in body, not head)
