### PR TITLE
QUA-1090: consolidate /agent-end orchestration into 'crux sys agent-end'

### DIFF
--- a/.claude/commands/agent-end.md
+++ b/.claude/commands/agent-end.md
@@ -8,9 +8,24 @@ effort: low
 Close out a session that does not need `/agent-ship` (research, abandoned work,
 maintenance, or a quick fix already pushed by hand).
 
-**Read `docs/agent-workflows/agent-end.md` and execute every step in order.**
-That file is the single source of truth and is shared across agent runtimes.
+The fastest path is to run the consolidated TS command, which executes every
+step in `docs/agent-workflows/agent-end.md` in one process:
 
-Claude-specific final step: after the workflow finishes, tell the user to run
+```bash
+pnpm crux sys agent-end                 # default
+pnpm crux sys agent-end --pr=<URL>      # if you created a PR
+pnpm crux sys agent-end --dry-run       # print actions, take none
+```
+
+If that bails (exit 2) on unexpected dirty state — uncommitted edits to a
+non-`.claude/` path or unpushed commits on the feature branch — read what it
+lists, decide whether to commit/push/discard, then re-run. Last-resort:
+`--dirty=force` discards everything.
+
+For runtimes without `pnpm`, or to debug a step in isolation, follow
+`docs/agent-workflows/agent-end.md` step by step — it is the cross-runtime
+source of truth and stays in sync with the TS command.
+
+Claude-specific final step: after the close-out finishes, tell the user to run
 `/clear` (wipe context) and `/rename` (clear the Claude Code session name).
 Both are Claude Code built-ins and cannot be invoked from this command file.

--- a/crux/commands/agent-end.test.ts
+++ b/crux/commands/agent-end.test.ts
@@ -569,6 +569,34 @@ describe('agent-end execute (non-dry-run)', () => {
     expect(agentsCloseMock).toHaveBeenCalled();
   });
 
+  it('bails (exit 2) on a detached HEAD without invoking any step', async () => {
+    // Per CodeRabbit finding on PR #4878: `git rev-parse --abbrev-ref HEAD`
+    // returns the literal string 'HEAD' for a detached worktree (not the
+    // commit hash). Without an upfront guard, the parallel side-effects
+    // (Linear close, agents close, file unlinks) would run before
+    // stepBranchReset's downstream guard caught the bad state.
+    installFs({
+      [join(PROJECT_ROOT, '.claude/wip-checklist.md')]: '> Linear: QUA-1090\n',
+      [join(PROJECT_ROOT, '.env')]: '',
+      [join(PROJECT_ROOT, '.agent-slot')]: '7\n',
+    });
+    setExec([
+      { match: /rev-parse --abbrev-ref/, out: 'HEAD' }, // ← detached
+      { match: /status --porcelain/, out: '' },
+      { match: /rev-list --count/, out: '0' },
+    ]);
+
+    const result = await commands.default([], { ci: true });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.output).toMatch(/detached or unknown git HEAD/);
+    // Crucially: no step was invoked.
+    expect(checklistCompleteMock).not.toHaveBeenCalled();
+    expect(linearDoneMock).not.toHaveBeenCalled();
+    expect(agentsCloseMock).not.toHaveBeenCalled();
+    expect(unlinkSyncMock).not.toHaveBeenCalled();
+  });
+
   it('skips dev-server kill cleanly when no DEV_PORT is configured', async () => {
     installFs({
       [join(PROJECT_ROOT, '.claude/wip-checklist.md')]: '> Linear: QUA-1090\n',

--- a/crux/commands/agent-end.test.ts
+++ b/crux/commands/agent-end.test.ts
@@ -271,15 +271,19 @@ describe('inspectDirtyState', () => {
 
   it('does not query unpushed commits on main', () => {
     let revListCalls = 0;
-    execSyncMock.mockImplementation((cmd: string) => {
-      if (/status --porcelain/.test(cmd)) return '';
-      if (/rev-parse --abbrev-ref/.test(cmd)) return 'main';
-      if (/rev-list --count/.test(cmd)) {
+    const impl = (rendered: string) => {
+      if (/status --porcelain/.test(rendered)) return '';
+      if (/rev-parse --abbrev-ref/.test(rendered)) return 'main';
+      if (/rev-list --count/.test(rendered)) {
         revListCalls++;
         return '5';
       }
       return '';
-    });
+    };
+    execSyncMock.mockImplementation((cmd: string) => impl(cmd));
+    execFileSyncMock.mockImplementation((file: string, args: string[] = []) =>
+      impl(`${file} ${args.join(' ')}`),
+    );
     expect(inspectDirtyState().unpushedCommits).toBe(0);
     expect(revListCalls).toBe(0);
   });

--- a/crux/commands/agent-end.test.ts
+++ b/crux/commands/agent-end.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Tests for crux/commands/agent-end.ts
+ *
+ * Two layers:
+ *   1. Pure helpers (parseDirtyMode, resolveLinearId, readDevPort,
+ *      readSlotNumber, inspectDirtyState) — straightforward fs/child_process
+ *      mocks.
+ *   2. Dry-run smoke test — drives the default command with --dry-run and
+ *      asserts the printed plan reflects the mocked slot state. Verifies
+ *      that no destructive subcommand is invoked when --dry-run is set.
+ *
+ * Side-effect-heavy steps (linear done, agents close, git checkout, tmux)
+ * are exercised separately via the orchestrator paths once the bash skill
+ * lands. Here we focus on the gates and dry-run wiring per QUA-1090.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---- Hoisted mocks --------------------------------------------------------
+
+const { existsSyncMock, readFileSyncMock, unlinkSyncMock, execSyncMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn<(p: string) => boolean>(() => false),
+  readFileSyncMock: vi.fn<(p: string, enc: string) => string>(() => ''),
+  unlinkSyncMock: vi.fn<(p: string) => void>(() => undefined),
+  execSyncMock: vi.fn<(cmd: string, opts?: unknown) => string | Buffer>(() => ''),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: existsSyncMock,
+  readFileSync: readFileSyncMock,
+  unlinkSync: unlinkSyncMock,
+}));
+
+vi.mock('child_process', () => ({
+  execSync: execSyncMock,
+}));
+
+// Stub the orchestrated command modules so dry-run never invokes them and
+// non-dry-run paths return predictable results.
+const {
+  checklistCompleteMock,
+  leakCheckMock,
+  linearDoneMock,
+  patrolStopMock,
+  agentsCloseMock,
+} = vi.hoisted(() => ({
+  checklistCompleteMock: vi.fn(async () => ({ output: '', exitCode: 0 })),
+  leakCheckMock: vi.fn(async () => ({ output: '', exitCode: 0 })),
+  linearDoneMock: vi.fn(async () => ({ output: '', exitCode: 0 })),
+  patrolStopMock: vi.fn(async () => ({ output: 'No patrol daemon running.', exitCode: 0 })),
+  agentsCloseMock: vi.fn(async () => ({ output: '', exitCode: 0 })),
+}));
+
+vi.mock('./agent-checklist.ts', () => ({
+  commands: { complete: checklistCompleteMock },
+}));
+vi.mock('./linear.ts', () => ({
+  commands: { 'leak-check': leakCheckMock, done: linearDoneMock },
+}));
+vi.mock('./pr-patrol.ts', () => ({
+  commands: { stop: patrolStopMock },
+}));
+vi.mock('./agents.ts', () => ({
+  commands: { close: agentsCloseMock },
+}));
+
+// ---- Imports (after mocks) ------------------------------------------------
+
+import {
+  parseDirtyMode,
+  resolveLinearId,
+  readDevPort,
+  readSlotNumber,
+  inspectDirtyState,
+  findPortListeners,
+  commands,
+} from './agent-end.ts';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { join } from 'path';
+
+// ---- Helper: install a virtual filesystem ---------------------------------
+
+function installFs(files: Record<string, string>) {
+  existsSyncMock.mockImplementation((p: string) => Object.prototype.hasOwnProperty.call(files, p));
+  readFileSyncMock.mockImplementation((p: string) => {
+    if (Object.prototype.hasOwnProperty.call(files, p)) return files[p];
+    throw new Error(`ENOENT: ${p}`);
+  });
+}
+
+function setExec(mapping: Array<{ match: RegExp; out: string | Error }>) {
+  execSyncMock.mockImplementation((cmd: string) => {
+    for (const { match, out } of mapping) {
+      if (match.test(cmd)) {
+        if (out instanceof Error) throw out;
+        return out;
+      }
+    }
+    return '';
+  });
+}
+
+beforeEach(() => {
+  existsSyncMock.mockReset();
+  readFileSyncMock.mockReset();
+  unlinkSyncMock.mockReset();
+  execSyncMock.mockReset();
+  checklistCompleteMock.mockClear();
+  leakCheckMock.mockClear();
+  linearDoneMock.mockClear();
+  patrolStopMock.mockClear();
+  agentsCloseMock.mockClear();
+});
+
+// ---- parseDirtyMode -------------------------------------------------------
+
+describe('parseDirtyMode', () => {
+  it('returns "fail" by default', () => {
+    expect(parseDirtyMode(undefined)).toBe('fail');
+    expect(parseDirtyMode(null)).toBe('fail');
+    expect(parseDirtyMode('')).toBe('fail');
+    expect(parseDirtyMode('garbage')).toBe('fail');
+  });
+  it('accepts the three valid modes', () => {
+    expect(parseDirtyMode('ask')).toBe('ask');
+    expect(parseDirtyMode('fail')).toBe('fail');
+    expect(parseDirtyMode('force')).toBe('force');
+  });
+});
+
+// ---- resolveLinearId ------------------------------------------------------
+
+describe('resolveLinearId', () => {
+  it('reads `> Linear: QUA-NNN` from the wip checklist', () => {
+    installFs({
+      [join(PROJECT_ROOT, '.claude/wip-checklist.md')]:
+        '# Session\n\n> Linear: QUA-1090\n> Branch: claude/qua-1090\n',
+    });
+    setExec([{ match: /rev-parse --abbrev-ref/, out: 'main' }]);
+    expect(resolveLinearId()).toBe('QUA-1090');
+  });
+
+  it('falls back to the branch name when no checklist is present', () => {
+    installFs({});
+    setExec([{ match: /rev-parse --abbrev-ref/, out: 'claude/qua-9999-some-feature' }]);
+    expect(resolveLinearId()).toBe('QUA-9999');
+  });
+
+  it('returns null when neither source has an ID', () => {
+    installFs({});
+    setExec([{ match: /rev-parse --abbrev-ref/, out: 'main' }]);
+    expect(resolveLinearId()).toBeNull();
+  });
+
+  it('handles checklist without a Linear marker by falling through to branch', () => {
+    installFs({
+      [join(PROJECT_ROOT, '.claude/wip-checklist.md')]: '# Session\n\nno linear marker here\n',
+    });
+    setExec([{ match: /rev-parse --abbrev-ref/, out: 'claude/qua-555-x' }]);
+    expect(resolveLinearId()).toBe('QUA-555');
+  });
+});
+
+// ---- readDevPort ----------------------------------------------------------
+
+describe('readDevPort', () => {
+  it('reads DEV_PORT from .env', () => {
+    installFs({
+      [join(PROJECT_ROOT, '.env')]: 'FOO=bar\nDEV_PORT=3017\nBAZ=qux\n',
+    });
+    expect(readDevPort()).toBe(3017);
+  });
+
+  it('returns null when .env is missing', () => {
+    installFs({});
+    expect(readDevPort()).toBeNull();
+  });
+
+  it('returns null when DEV_PORT is not set', () => {
+    installFs({ [join(PROJECT_ROOT, '.env')]: 'FOO=bar\nBAZ=qux\n' });
+    expect(readDevPort()).toBeNull();
+  });
+
+  it('rejects non-numeric values', () => {
+    installFs({ [join(PROJECT_ROOT, '.env')]: 'DEV_PORT=banana\n' });
+    expect(readDevPort()).toBeNull();
+  });
+});
+
+// ---- readSlotNumber -------------------------------------------------------
+
+describe('readSlotNumber', () => {
+  it('reads digits from .agent-slot', () => {
+    installFs({ [join(PROJECT_ROOT, '.agent-slot')]: '7\n' });
+    expect(readSlotNumber()).toBe('7');
+  });
+
+  it('returns null for missing file', () => {
+    installFs({});
+    expect(readSlotNumber()).toBeNull();
+  });
+
+  it('returns null for non-numeric content', () => {
+    installFs({ [join(PROJECT_ROOT, '.agent-slot')]: 'main\n' });
+    expect(readSlotNumber()).toBeNull();
+  });
+});
+
+// ---- inspectDirtyState ----------------------------------------------------
+
+describe('inspectDirtyState', () => {
+  it('categorises expected paths separately from unexpected ones', () => {
+    setExec([
+      { match: /status --porcelain/, out:
+        ' M .claude/wip-checklist.md\n' +     // expected
+        '?? .claude/wip-context.md\n' +        // expected (untracked)
+        ' M .claude/hooks/pre-commit.sh\n' +   // expected (under .claude/hooks/)
+        ' M apps/web/src/app/page.tsx\n' +     // unexpected
+        '?? scratch.md\n'                      // unexpected
+      },
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1090-foo' },
+      { match: /rev-list --count/, out: '0' },
+    ]);
+    const r = inspectDirtyState();
+    expect(r.expectedFiles).toHaveLength(3);
+    expect(r.unexpectedFiles).toHaveLength(2);
+    const unexpectedJoined = r.unexpectedFiles.join('\n');
+    expect(unexpectedJoined).toContain('apps/web/src/app/page.tsx');
+    expect(unexpectedJoined).toContain('scratch.md');
+  });
+
+  it('reports unpushed commits on a non-main branch', () => {
+    setExec([
+      { match: /status --porcelain/, out: '' },
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1090-foo' },
+      { match: /rev-list --count/, out: '3' },
+    ]);
+    expect(inspectDirtyState().unpushedCommits).toBe(3);
+  });
+
+  it('does not query unpushed commits on main', () => {
+    let revListCalls = 0;
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (/status --porcelain/.test(cmd)) return '';
+      if (/rev-parse --abbrev-ref/.test(cmd)) return 'main';
+      if (/rev-list --count/.test(cmd)) {
+        revListCalls++;
+        return '5';
+      }
+      return '';
+    });
+    expect(inspectDirtyState().unpushedCommits).toBe(0);
+    expect(revListCalls).toBe(0);
+  });
+
+  it('treats branches with no upstream as 0 unpushed commits (no upstream → execSafe returns null)', () => {
+    setExec([
+      { match: /status --porcelain/, out: '' },
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-9999-fresh' },
+      { match: /rev-list --count/, out: new Error('no upstream') },
+    ]);
+    expect(inspectDirtyState().unpushedCommits).toBe(0);
+  });
+});
+
+// ---- findPortListeners ----------------------------------------------------
+
+describe('findPortListeners', () => {
+  it('parses one PID per line', () => {
+    setExec([{ match: /lsof -ti:3017/, out: '12345\n67890' }]);
+    expect(findPortListeners(3017)).toEqual([12345, 67890]);
+  });
+
+  it('returns [] when nothing listens', () => {
+    setExec([{ match: /lsof/, out: new Error('no match') }]);
+    expect(findPortListeners(3017)).toEqual([]);
+  });
+});
+
+// ---- Dry-run smoke --------------------------------------------------------
+
+describe('agent-end --dry-run', () => {
+  it('prints the plan and does not invoke any side-effect commands', async () => {
+    installFs({
+      [join(PROJECT_ROOT, '.claude/wip-checklist.md')]:
+        '# Session\n\n> Linear: QUA-1090\n',
+      [join(PROJECT_ROOT, '.env')]: 'DEV_PORT=3017\n',
+      [join(PROJECT_ROOT, '.agent-slot')]: '7\n',
+    });
+    setExec([
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1090-foo' },
+      { match: /status --porcelain/, out: ' M .claude/wip-checklist.md\n' }, // expected only
+      { match: /rev-list --count/, out: '0' },
+      { match: /lsof -ti:3017/, out: '4567' },
+      { match: /pgrep/, out: '' },
+    ]);
+
+    const result = await commands.default([], { dryRun: true, ci: true });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/dry-run/);
+    expect(result.output).toMatch(/linear:\s+QUA-1090/);
+    expect(result.output).toMatch(/branch:\s+claude\/qua-1090-foo/);
+    expect(result.output).toMatch(/dev port:\s+3017/);
+    expect(result.output).toMatch(/PIDs 4567/);
+    expect(result.output).toMatch(/Re-run without --dry-run to execute/);
+
+    // Must NOT have called any side-effect command.
+    expect(checklistCompleteMock).not.toHaveBeenCalled();
+    expect(leakCheckMock).not.toHaveBeenCalled();
+    expect(linearDoneMock).not.toHaveBeenCalled();
+    expect(patrolStopMock).not.toHaveBeenCalled();
+    expect(agentsCloseMock).not.toHaveBeenCalled();
+  });
+
+  it('shows "Linear → Done" when no PR URL is supplied', async () => {
+    installFs({
+      [join(PROJECT_ROOT, '.claude/wip-checklist.md')]: '> Linear: QUA-1\n',
+      [join(PROJECT_ROOT, '.env')]: '',
+      [join(PROJECT_ROOT, '.agent-slot')]: '7\n',
+    });
+    setExec([
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1-x' },
+      { match: /status --porcelain/, out: '' },
+      { match: /rev-list --count/, out: '0' },
+    ]);
+    const result = await commands.default([], { dryRun: true, ci: true });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/QUA-1 → Done/);
+  });
+
+  it('shows "Linear → In Review" when --pr is supplied', async () => {
+    installFs({
+      [join(PROJECT_ROOT, '.claude/wip-checklist.md')]: '> Linear: QUA-1\n',
+      [join(PROJECT_ROOT, '.env')]: '',
+      [join(PROJECT_ROOT, '.agent-slot')]: '7\n',
+    });
+    setExec([
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1-x' },
+      { match: /status --porcelain/, out: '' },
+      { match: /rev-list --count/, out: '0' },
+    ]);
+    const result = await commands.default(
+      [],
+      { dryRun: true, ci: true, pr: 'https://example/pr/1' },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/QUA-1 → In Review/);
+    expect(result.output).toMatch(/PR https:\/\/example\/pr\/1/);
+  });
+});
+
+// ---- Dirty-state gate -----------------------------------------------------
+
+describe('agent-end dirty-state gate', () => {
+  it('exits 2 when unexpected files are present and --dirty=fail (default)', async () => {
+    installFs({});
+    setExec([
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1090-foo' },
+      { match: /status --porcelain/, out: ' M apps/web/src/app/page.tsx\n' },
+      { match: /rev-list --count/, out: '0' },
+    ]);
+    const result = await commands.default([], { ci: true });
+    expect(result.exitCode).toBe(2);
+    expect(result.output).toMatch(/Dirty state requires attention/);
+    expect(result.output).toMatch(/apps\/web\/src\/app\/page\.tsx/);
+    expect(result.output).toMatch(/--dirty=force/);
+  });
+
+  it('exits 2 when there are unpushed commits on a non-main branch', async () => {
+    installFs({});
+    setExec([
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1090-foo' },
+      { match: /status --porcelain/, out: '' },
+      { match: /rev-list --count/, out: '2' },
+    ]);
+    const result = await commands.default([], { ci: true });
+    expect(result.exitCode).toBe(2);
+    expect(result.output).toMatch(/2 unpushed commit/);
+  });
+
+  it('passes through to dry-run when --dirty=force overrides unexpected paths', async () => {
+    installFs({
+      [join(PROJECT_ROOT, '.env')]: '',
+      [join(PROJECT_ROOT, '.agent-slot')]: '7\n',
+    });
+    setExec([
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1090-foo' },
+      { match: /status --porcelain/, out: ' M apps/web/src/app/page.tsx\n' },
+      { match: /rev-list --count/, out: '0' },
+    ]);
+    const result = await commands.default(
+      [],
+      { ci: true, dryRun: true, dirty: 'force' },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/Would execute/);
+  });
+});

--- a/crux/commands/agent-end.test.ts
+++ b/crux/commands/agent-end.test.ts
@@ -121,10 +121,11 @@ describe('parseDirtyMode', () => {
     expect(parseDirtyMode('')).toBe('fail');
     expect(parseDirtyMode('garbage')).toBe('fail');
   });
-  it('accepts the three valid modes', () => {
-    expect(parseDirtyMode('ask')).toBe('ask');
-    expect(parseDirtyMode('fail')).toBe('fail');
+  it('returns "force" only for the literal "force"', () => {
     expect(parseDirtyMode('force')).toBe('force');
+    expect(parseDirtyMode('fail')).toBe('fail');
+    // "ask" was dropped from v1 because it was indistinguishable from "fail".
+    expect(parseDirtyMode('ask')).toBe('fail');
   });
 });
 
@@ -261,6 +262,31 @@ describe('inspectDirtyState', () => {
     ]);
     expect(inspectDirtyState().unpushedCommits).toBe(0);
   });
+
+  it('treats a rename row that maps an expected file to another expected path as expected', () => {
+    setExec([
+      // Rename of .claude/wip-checklist.md → .claude/wip-context.md (both expected)
+      { match: /status --porcelain/, out: 'R  .claude/wip-checklist.md -> .claude/wip-context.md\n' },
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1090-foo' },
+      { match: /rev-list --count/, out: '0' },
+    ]);
+    const r = inspectDirtyState();
+    expect(r.expectedFiles).toHaveLength(1);
+    expect(r.unexpectedFiles).toHaveLength(0);
+  });
+
+  it('treats a rename row that touches an unexpected path as unexpected', () => {
+    setExec([
+      // Rename of an expected wip file → an unexpected app source path
+      { match: /status --porcelain/, out: 'R  .claude/wip-checklist.md -> apps/web/leak.md\n' },
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1090-foo' },
+      { match: /rev-list --count/, out: '0' },
+    ]);
+    const r = inspectDirtyState();
+    expect(r.expectedFiles).toHaveLength(0);
+    expect(r.unexpectedFiles).toHaveLength(1);
+    expect(r.unexpectedFiles[0]).toContain('apps/web/leak.md');
+  });
 });
 
 // ---- findPortListeners ----------------------------------------------------
@@ -394,5 +420,139 @@ describe('agent-end dirty-state gate', () => {
     );
     expect(result.exitCode).toBe(0);
     expect(result.output).toMatch(/Would execute/);
+  });
+});
+
+// ---- Destructive execution path ------------------------------------------
+
+describe('agent-end execute (non-dry-run)', () => {
+  it('runs every step and reports them in the summary', async () => {
+    installFs({
+      [join(PROJECT_ROOT, '.claude/wip-checklist.md')]: '> Linear: QUA-1090\n',
+      [join(PROJECT_ROOT, '.env')]: 'DEV_PORT=3017\n',
+      [join(PROJECT_ROOT, '.agent-slot')]: '7\n',
+    });
+    setExec([
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1090-foo' },
+      // Clean working tree → no dirty bail.
+      { match: /status --porcelain/, out: '' },
+      { match: /rev-list --count @\{u\}\.\.HEAD/, out: '0' },
+      { match: /rev-list --count origin\/main\.\.main/, out: '0' },
+      // No dev-server listener.
+      { match: /lsof -ti:3017/, out: '' },
+      { match: /pgrep/, out: '' },
+      // git plumbing — succeed silently.
+      { match: /git checkout -- \./, out: '' },
+      { match: /git clean -fd/, out: '' },
+      { match: /git checkout main/, out: '' },
+      { match: /git fetch origin main/, out: '' },
+      { match: /git pull --ff-only/, out: '' },
+      { match: /git branch -D/, out: '' },
+      { match: /git checkout -- /, out: '' },
+    ]);
+
+    const result = await commands.default([], { ci: true });
+
+    // Mocked sub-commands all succeeded → exit 0
+    expect(result.exitCode).toBe(0);
+
+    // Each step contributed a line
+    expect(result.output).toMatch(/Checklist/);
+    expect(result.output).toMatch(/Linear leak-check/);
+    expect(result.output).toMatch(/Linear done/);
+    expect(result.output).toMatch(/Patrol daemon/);
+    expect(result.output).toMatch(/Dev server/);
+    expect(result.output).toMatch(/WIP artifacts/);
+    expect(result.output).toMatch(/Review artifacts/);
+    expect(result.output).toMatch(/Agent session/);
+    expect(result.output).toMatch(/Branch reset/);
+    expect(result.output).toMatch(/Tmux rename/);
+
+    // Side-effect mocks were called
+    expect(checklistCompleteMock).toHaveBeenCalledOnce();
+    expect(leakCheckMock).toHaveBeenCalledOnce();
+    expect(linearDoneMock).toHaveBeenCalledOnce();
+    expect(patrolStopMock).toHaveBeenCalledOnce();
+    expect(agentsCloseMock).toHaveBeenCalledOnce();
+
+    // Summary footer
+    expect(result.output).toMatch(/Done\./);
+  });
+
+  it('REFUSES to reset main when local main has commits not in origin/main', async () => {
+    // This is the QUA-1090 review-found data-loss guard. Without it, an
+    // accidental local commit on main would be silently discarded by
+    // `git reset --hard origin/main`.
+    installFs({
+      [join(PROJECT_ROOT, '.claude/wip-checklist.md')]: '> Linear: QUA-1090\n',
+      [join(PROJECT_ROOT, '.env')]: '',
+      [join(PROJECT_ROOT, '.agent-slot')]: '7\n',
+    });
+    setExec([
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1090-foo' },
+      { match: /status --porcelain/, out: '' },
+      { match: /rev-list --count @\{u\}\.\.HEAD/, out: '0' },
+      // 2 local-only commits on main → safety guard fires.
+      { match: /rev-list --count origin\/main\.\.main/, out: '2' },
+      { match: /git checkout -- \./, out: '' },
+      { match: /git clean -fd/, out: '' },
+      { match: /git checkout main/, out: '' },
+      { match: /git fetch origin main/, out: '' },
+      // git pull / reset --hard / branch -D should NOT fire if guard works.
+      { match: /git pull --ff-only/, out: new Error('would not be called') },
+      { match: /git reset --hard/, out: new Error('would not be called') },
+      { match: /git branch -D/, out: new Error('would not be called') },
+    ]);
+
+    const result = await commands.default([], { ci: true });
+
+    expect(result.exitCode).toBe(1); // at least one step failed
+    expect(result.output).toMatch(/2 local commit\(s\) on main not in origin\/main/);
+    expect(result.output).toMatch(/refusing to reset/);
+  });
+
+  it('reports failure when checklist has unchecked items but still runs the rest', async () => {
+    installFs({
+      [join(PROJECT_ROOT, '.claude/wip-checklist.md')]: '> Linear: QUA-1090\n[ ] item-a\n[ ] item-b\n',
+      [join(PROJECT_ROOT, '.env')]: '',
+      [join(PROJECT_ROOT, '.agent-slot')]: '7\n',
+    });
+    setExec([
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1090-foo' },
+      { match: /status --porcelain/, out: '' },
+      { match: /rev-list --count/, out: '0' },
+      { match: /lsof/, out: '' },
+      { match: /pgrep/, out: '' },
+    ]);
+    // checklist complete returns exit 1 with output containing two `[ ]` markers
+    checklistCompleteMock.mockResolvedValueOnce({
+      output: '✗ 2 unchecked item(s):\n  [ ] item-a\n  [ ] item-b\n',
+      exitCode: 1,
+    });
+
+    const result = await commands.default([], { ci: true });
+    // checklist failure surfaces in the per-step report, but the rest of the
+    // session-close still runs to completion — the slot would otherwise leak.
+    expect(result.output).toMatch(/Checklist/);
+    expect(result.output).toMatch(/2 item\(s\) unchecked/);
+    expect(linearDoneMock).toHaveBeenCalled();
+    expect(agentsCloseMock).toHaveBeenCalled();
+  });
+
+  it('skips dev-server kill cleanly when no DEV_PORT is configured', async () => {
+    installFs({
+      [join(PROJECT_ROOT, '.claude/wip-checklist.md')]: '> Linear: QUA-1090\n',
+      [join(PROJECT_ROOT, '.env')]: 'FOO=bar\n', // no DEV_PORT
+      [join(PROJECT_ROOT, '.agent-slot')]: '7\n',
+    });
+    setExec([
+      { match: /rev-parse --abbrev-ref/, out: 'claude/qua-1090-foo' },
+      { match: /status --porcelain/, out: '' },
+      { match: /rev-list --count/, out: '0' },
+      { match: /pgrep/, out: '' },
+      { match: /git/, out: '' },
+    ]);
+    const result = await commands.default([], { ci: true });
+    expect(result.output).toMatch(/Dev server.*no DEV_PORT in \.env/);
   });
 });

--- a/crux/commands/agent-end.test.ts
+++ b/crux/commands/agent-end.test.ts
@@ -18,11 +18,22 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ---- Hoisted mocks --------------------------------------------------------
 
-const { existsSyncMock, readFileSyncMock, unlinkSyncMock, execSyncMock } = vi.hoisted(() => ({
+const {
+  existsSyncMock,
+  readFileSyncMock,
+  unlinkSyncMock,
+  execSyncMock,
+  execFileSyncMock,
+  findSlotFromAncestorsMock,
+} = vi.hoisted(() => ({
   existsSyncMock: vi.fn<(p: string) => boolean>(() => false),
   readFileSyncMock: vi.fn<(p: string, enc: string) => string>(() => ''),
   unlinkSyncMock: vi.fn<(p: string) => void>(() => undefined),
   execSyncMock: vi.fn<(cmd: string, opts?: unknown) => string | Buffer>(() => ''),
+  execFileSyncMock: vi.fn<(file: string, args?: string[], opts?: unknown) => string | Buffer>(
+    () => '',
+  ),
+  findSlotFromAncestorsMock: vi.fn<(cwd: string) => number | null>(() => null),
 }));
 
 vi.mock('fs', () => ({
@@ -33,6 +44,13 @@ vi.mock('fs', () => ({
 
 vi.mock('child_process', () => ({
   execSync: execSyncMock,
+  execFileSync: execFileSyncMock,
+}));
+
+// Mock the slot-ancestor walker so tests run from any cwd without surprises.
+// Tests that need the walker to find a slot can override per-test.
+vi.mock('../lib/session/session-context.ts', () => ({
+  findSlotFromAncestors: findSlotFromAncestorsMock,
 }));
 
 // Stub the orchestrated command modules so dry-run never invokes them and
@@ -88,16 +106,26 @@ function installFs(files: Record<string, string>) {
   });
 }
 
+/**
+ * Route both shell-style (execSync) and arg-style (execFileSync) calls
+ * through one regex-mapping table. `git status --porcelain` and
+ * `execFileSync('git', ['status', '--porcelain'])` both match `/status --porcelain/`,
+ * so existing tests written against the old shell pipeline keep working.
+ */
 function setExec(mapping: Array<{ match: RegExp; out: string | Error }>) {
-  execSyncMock.mockImplementation((cmd: string) => {
+  const dispatch = (rendered: string) => {
     for (const { match, out } of mapping) {
-      if (match.test(cmd)) {
+      if (match.test(rendered)) {
         if (out instanceof Error) throw out;
         return out;
       }
     }
     return '';
-  });
+  };
+  execSyncMock.mockImplementation((cmd: string) => dispatch(cmd));
+  execFileSyncMock.mockImplementation((file: string, args: string[] = []) =>
+    dispatch(`${file} ${args.join(' ')}`),
+  );
 }
 
 beforeEach(() => {
@@ -105,6 +133,8 @@ beforeEach(() => {
   readFileSyncMock.mockReset();
   unlinkSyncMock.mockReset();
   execSyncMock.mockReset();
+  execFileSyncMock.mockReset();
+  findSlotFromAncestorsMock.mockReset();
   checklistCompleteMock.mockClear();
   leakCheckMock.mockClear();
   linearDoneMock.mockClear();
@@ -327,7 +357,7 @@ describe('agent-end --dry-run', () => {
     expect(result.output).toMatch(/linear:\s+QUA-1090/);
     expect(result.output).toMatch(/branch:\s+claude\/qua-1090-foo/);
     expect(result.output).toMatch(/dev port:\s+3017/);
-    expect(result.output).toMatch(/PIDs 4567/);
+    expect(result.output).toMatch(/PIDs: 4567/);
     expect(result.output).toMatch(/Re-run without --dry-run to execute/);
 
     // Must NOT have called any side-effect command.

--- a/crux/commands/agent-end.ts
+++ b/crux/commands/agent-end.ts
@@ -17,6 +17,9 @@ import { join } from 'path';
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import { createLogger } from '../lib/output.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { gitSafe } from '../lib/git.ts';
+import { findSlotFromAncestors } from '../lib/session/session-context.ts';
+import { resolveLinearId as resolveLinearIdFromSources } from '../lib/linear/parse-id.ts';
 import * as agentChecklistCommands from './agent-checklist.ts';
 import * as agentsCommands from './agents.ts';
 import * as linearCommands from './linear.ts';
@@ -62,24 +65,24 @@ function isExpectedPath(path: string): boolean {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function exec(cmd: string, timeoutMs = 30000): string {
-  return execSync(cmd, { encoding: 'utf-8', timeout: timeoutMs, cwd: PROJECT_ROOT }).trim();
-}
-
-function execSafe(cmd: string, timeoutMs = 30000): string | null {
+/**
+ * Run a non-git shell command. Returns null on failure. Uses execSync (with a
+ * shell) intentionally for things like `lsof | tmux | pgrep` that aren't in
+ * lib/git.ts. For git commands, prefer gitSafe (no shell, injection-safe).
+ */
+function shellSafe(cmd: string, timeoutMs = 30000): string | null {
   try {
-    return exec(cmd, timeoutMs);
+    return execSync(cmd, { encoding: 'utf-8', timeout: timeoutMs, cwd: PROJECT_ROOT }).trim();
   } catch {
     return null;
   }
 }
 
 /**
- * Like execSafe but preserves whitespace. Use for command output where leading
- * whitespace is semantic — notably `git status --porcelain` (a leading space in
- * column 0 means "no staged change", and `.trim()` would corrupt the layout).
+ * Like shellSafe but preserves leading whitespace. Used for `git status
+ * --porcelain` whose column-0 space (" M file" = unstaged modify) is semantic.
  */
-function execRawSafe(cmd: string, timeoutMs = 30000): string | null {
+function shellRawSafe(cmd: string, timeoutMs = 30000): string | null {
   try {
     return execSync(cmd, { encoding: 'utf-8', timeout: timeoutMs, cwd: PROJECT_ROOT });
   } catch {
@@ -89,21 +92,32 @@ function execRawSafe(cmd: string, timeoutMs = 30000): string | null {
 
 /**
  * Read the Linear ID from the wip checklist (`> Linear: QUA-NNN`) first,
- * then fall back to parsing the current branch (`claude/qua-NNN-...`).
+ * then fall back to parsing the current branch via the shared parse-id helper
+ * (which enforces the team-key allowlist — see crux/lib/linear/parse-id.ts).
+ *
+ * Exported for tests; pass the branch in to avoid a redundant rev-parse.
  */
-export function resolveLinearId(): string | null {
+export function resolveLinearId(branch?: string | null): string | null {
+  const sources: Array<string | null> = [];
   const checklistPath = join(PROJECT_ROOT, '.claude/wip-checklist.md');
   if (existsSync(checklistPath)) {
     const md = readFileSync(checklistPath, 'utf-8');
     const m = md.match(/^>\s*Linear:\s*([A-Z]+-\d+)/m);
-    if (m) return m[1];
+    if (m) sources.push(m[0]);
   }
-  const branch = execSafe('git rev-parse --abbrev-ref HEAD');
-  if (branch) {
-    const m = branch.match(/claude\/(qua-\d+)/i);
-    if (m) return m[1].toUpperCase();
-  }
-  return null;
+  // Caller passes branch when known to avoid a duplicate rev-parse.
+  const branchValue = branch ?? readCurrentBranch();
+  if (branchValue) sources.push(branchValue);
+  return resolveLinearIdFromSources(sources);
+}
+
+/**
+ * Current branch name, or null on failure. Wraps `gitSafe` so we don't need to
+ * decide between throwing/non-throwing variants at every call site.
+ */
+function readCurrentBranch(): string | null {
+  const r = gitSafe('rev-parse', '--abbrev-ref', 'HEAD');
+  return r.ok ? r.output : null;
 }
 
 /**
@@ -120,9 +134,15 @@ export function readDevPort(): number | null {
 }
 
 /**
- * Read .agent-slot (e.g. "7" → 7). Returns null if missing or unparsable.
+ * Slot number for the current cwd, or null. Walks ancestors for `a<N>`
+ * (canonical) and falls back to `.agent-slot` for legacy layouts. Returns the
+ * value as a string for tmux/output use; callers needing a number should
+ * import findSlotFromAncestors directly.
  */
 export function readSlotNumber(): string | null {
+  const n = findSlotFromAncestors(process.cwd());
+  if (n !== null) return String(n);
+  // Legacy fallback — pre-a<N> layouts and worktrees that override .agent-slot.
   const slotPath = join(PROJECT_ROOT, '.agent-slot');
   if (!existsSync(slotPath)) return null;
   const raw = readFileSync(slotPath, 'utf-8').trim();
@@ -135,7 +155,7 @@ export function readSlotNumber(): string | null {
  * `feedback_kill_port_safely.md`).
  */
 export function findPortListeners(port: number): number[] {
-  const out = execSafe(`lsof -ti:${port} -sTCP:LISTEN`);
+  const out = shellSafe(`lsof -ti:${port} -sTCP:LISTEN`);
   if (!out) return [];
   return out
     .split('\n')
@@ -157,12 +177,12 @@ interface DirtyStatus {
  * Unpushed commits are reported only on non-main branches (on main any unpushed
  * work is a separate issue the user owns; agent-end does not amend that).
  */
-export function inspectDirtyState(): DirtyStatus {
-  // execRawSafe (no trim): porcelain output uses two columns where column 0
+export function inspectDirtyState(branch?: string | null): DirtyStatus {
+  // shellRawSafe (no trim): porcelain output uses two columns where column 0
   // can legitimately be a space (" M file" = unstaged modify). Trim would
   // corrupt the slice(3).
-  const status = execRawSafe('git status --porcelain') ?? '';
-  const branch = execSafe('git rev-parse --abbrev-ref HEAD') ?? '(unknown)';
+  const status = shellRawSafe('git status --porcelain') ?? '';
+  const branchValue = branch ?? readCurrentBranch() ?? '(unknown)';
 
   const expectedFiles: string[] = [];
   const unexpectedFiles: string[] = [];
@@ -180,11 +200,11 @@ export function inspectDirtyState(): DirtyStatus {
   }
 
   let unpushedCommits = 0;
-  if (branch !== 'main' && branch !== '(unknown)') {
-    // 2>/dev/null swallows the "no upstream configured" error that fires for
-    // branches that were never pushed (research/abandoned sessions).
-    const counted = execSafe('git rev-list --count @{u}..HEAD 2>/dev/null');
-    if (counted) unpushedCommits = Number(counted) || 0;
+  if (branchValue !== 'main' && branchValue !== '(unknown)') {
+    // gitSafe handles the "no upstream configured" error cleanly without
+    // shell stderr redirection (returns ok:false → unpushedCommits stays 0).
+    const counted = gitSafe('rev-list', '--count', '@{u}..HEAD');
+    if (counted.ok) unpushedCommits = Number(counted.output) || 0;
   }
 
   return { unexpectedFiles, unpushedCommits, expectedFiles };
@@ -211,65 +231,92 @@ interface Plan {
   branch: string;
   slot: string | null;
   devPort: number | null;
-  devPids: number[];
-  patrolPid: number | null;
-  isMain: boolean;
 }
 
-function buildPlan(options: CommandOptions): Plan {
-  const branch = execSafe('git rev-parse --abbrev-ref HEAD') ?? '(unknown)';
-  const linearId = resolveLinearId();
-  const slot = readSlotNumber();
-  const devPort = readDevPort();
-  const devPids = devPort ? findPortListeners(devPort) : [];
-  const patrolPid = (() => {
-    try {
-      // Reuse pr-patrol's daemon registry — same source the `stop` command uses.
-      // Falling back to null if anything throws.
-      const out = execSafe('pgrep -f "crux gh pr-patrol run" 2>/dev/null') ?? '';
-      const first = out.split('\n').find(Boolean);
-      return first ? Number(first) : null;
-    } catch {
-      return null;
-    }
-  })();
-
+function buildPlan(options: CommandOptions, branch: string): Plan {
   return {
-    linearId,
+    linearId: resolveLinearId(branch),
     prUrl: typeof options.pr === 'string' ? options.pr : null,
     branch,
-    slot,
-    devPort,
-    devPids,
-    patrolPid,
-    isMain: branch === 'main',
+    slot: readSlotNumber(),
+    devPort: readDevPort(),
   };
 }
 
-async function stepCompleteChecklist(_opts: CommandOptions): Promise<StepResult> {
+/**
+ * Look up a running pr-patrol daemon's PID, for dry-run reporting only.
+ * `stepPatrolStop` calls into the daemon's own registry directly — we don't
+ * pass the PID in.
+ */
+function patrolPid(): number | null {
+  const out = shellSafe('pgrep -f "crux gh pr-patrol run"');
+  if (!out) return null;
+  const first = out.split('\n').find(Boolean);
+  const n = first ? Number(first) : null;
+  return Number.isInteger(n) && n! > 0 ? n : null;
+}
+
+/**
+ * Execute a delegated command (Linear/agents/patrol/checklist) and shape the
+ * result into a StepResult. Three orchestration steps share this exact shape;
+ * inlining was 3x copy-paste.
+ *
+ * `onSuccess` interprets a 0-exit result. `onNonZero` (optional) interprets a
+ * non-zero exit with the captured output — defaults to truncating the first
+ * line to 200 chars. Caught exceptions always become `error: <msg>`.
+ */
+async function runDelegate(
+  label: string,
+  invoke: () => Promise<CommandResult>,
+  onSuccess: (result: CommandResult) => string,
+  onNonZero?: (result: CommandResult) => StepResult,
+): Promise<StepResult> {
+  try {
+    const result = await invoke();
+    if (result.exitCode === 0) {
+      return { label, ok: true, detail: onSuccess(result) };
+    }
+    if (onNonZero) return onNonZero(result);
+    const firstLine = result.output.trim().split('\n')[0]?.slice(0, 200) ?? 'unknown error';
+    return { label, ok: false, detail: firstLine };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { label, ok: false, detail: `error: ${msg}` };
+  }
+}
+
+async function stepCompleteChecklist(): Promise<StepResult> {
   // The checklist file may not exist (quick-fix sessions) — that's a no-op.
   const checklistPath = join(PROJECT_ROOT, '.claude/wip-checklist.md');
   if (!existsSync(checklistPath)) {
     return { label: 'Checklist', ok: true, detail: 'no checklist (skipped)' };
   }
-  const result = await agentChecklistCommands.commands.complete([], { ci: true });
-  // exitCode 0 = complete, 1 = unchecked items remain. Either way we proceed
-  // (the checklist command surfaces the warning; agent-end is meant to close
-  // the slot regardless of checklist state).
-  if (result.exitCode === 0) {
-    return { label: 'Checklist', ok: true, detail: 'all items complete' };
-  }
-  const unchecked = (result.output.match(/\[ \]/g) ?? []).length;
-  return { label: 'Checklist', ok: false, detail: `${unchecked} item(s) unchecked` };
+  return runDelegate(
+    'Checklist',
+    () => agentChecklistCommands.commands.complete([], { ci: true }),
+    () => 'all items complete',
+    // Exit 1 = unchecked items remain. Surface the count, but agent-end still
+    // proceeds — closing the slot regardless of checklist state is by design.
+    (result) => {
+      const unchecked = (result.output.match(/\[ \]/g) ?? []).length;
+      return { label: 'Checklist', ok: false, detail: `${unchecked} item(s) unchecked` };
+    },
+  );
 }
 
-async function stepLeakCheck(_opts: CommandOptions): Promise<StepResult> {
-  const result = await linearCommands.commands['leak-check']([], { ci: true });
-  // leakCheck is advisory and returns exit 0 even when leaks exist — the
-  // command's printed output names any leaked refs.
-  const leaks = (result.output.match(/QUA-\d+/g) ?? []).filter((v, i, a) => a.indexOf(v) === i);
-  if (leaks.length === 0) return { label: 'Linear leak-check', ok: true, detail: 'no extra refs' };
-  return { label: 'Linear leak-check', ok: true, detail: `flagged: ${leaks.join(', ')}` };
+async function stepLeakCheck(): Promise<StepResult> {
+  return runDelegate(
+    'Linear leak-check',
+    () => linearCommands.commands['leak-check']([], { ci: true }),
+    // leakCheck is advisory: exit 0 even when leaks exist. Surface any
+    // mentioned QUA-NNN refs in the detail line.
+    (result) => {
+      const leaks = (result.output.match(/QUA-\d+/g) ?? []).filter(
+        (v, i, a) => a.indexOf(v) === i,
+      );
+      return leaks.length === 0 ? 'no extra refs' : `flagged: ${leaks.join(', ')}`;
+    },
+  );
 }
 
 async function stepLinearDone(plan: Plan): Promise<StepResult> {
@@ -278,45 +325,40 @@ async function stepLinearDone(plan: Plan): Promise<StepResult> {
   }
   const opts: CommandOptions = { ci: true };
   if (plan.prUrl) opts.pr = plan.prUrl;
-  try {
-    const result = await linearCommands.commands.done([plan.linearId], opts);
-    if (result.exitCode === 0) {
+  return runDelegate(
+    'Linear done',
+    () => linearCommands.commands.done([plan.linearId!], opts),
+    () => {
       const target = plan.prUrl ? 'In Review' : 'Done';
       const suffix = plan.prUrl ? ` (PR ${plan.prUrl})` : '';
-      return { label: 'Linear done', ok: true, detail: `${plan.linearId} → ${target}${suffix}` };
-    }
-    return { label: 'Linear done', ok: false, detail: result.output.trim().slice(0, 200) };
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return { label: 'Linear done', ok: false, detail: `error: ${msg}` };
-  }
+      return `${plan.linearId} → ${target}${suffix}`;
+    },
+  );
 }
 
-async function stepPatrolStop(_opts: CommandOptions): Promise<StepResult> {
-  try {
-    const result = await prPatrolCommands.commands.stop([], { ci: true });
-    if (result.output.toLowerCase().includes('no patrol daemon')) {
-      return { label: 'Patrol daemon', ok: true, detail: 'not running (skipped)' };
-    }
-    if (result.exitCode === 0) {
-      return { label: 'Patrol daemon', ok: true, detail: 'stopped' };
-    }
-    return { label: 'Patrol daemon', ok: false, detail: result.output.trim().slice(0, 200) };
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return { label: 'Patrol daemon', ok: false, detail: `error: ${msg}` };
-  }
+async function stepPatrolStop(): Promise<StepResult> {
+  return runDelegate(
+    'Patrol daemon',
+    () => prPatrolCommands.commands.stop([], { ci: true }),
+    (result) =>
+      result.output.toLowerCase().includes('no patrol daemon')
+        ? 'not running (skipped)'
+        : 'stopped',
+  );
 }
 
 function stepKillDevServer(plan: Plan): StepResult {
   if (!plan.devPort) {
     return { label: 'Dev server', ok: true, detail: 'no DEV_PORT in .env (skipped)' };
   }
-  if (plan.devPids.length === 0) {
+  // Look up listeners at execute time (not at buildPlan), so dry-run can
+  // print plan-time PIDs but the kill step always operates on fresh data.
+  const pids = findPortListeners(plan.devPort);
+  if (pids.length === 0) {
     return { label: 'Dev server', ok: true, detail: `port ${plan.devPort} has no listener` };
   }
   const failed: number[] = [];
-  for (const pid of plan.devPids) {
+  for (const pid of pids) {
     try {
       process.kill(pid, 'SIGTERM');
     } catch (e: unknown) {
@@ -329,7 +371,7 @@ function stepKillDevServer(plan: Plan): StepResult {
     return {
       label: 'Dev server',
       ok: true,
-      detail: `killed port ${plan.devPort} (PIDs: ${plan.devPids.join(', ')})`,
+      detail: `killed port ${plan.devPort} (PIDs: ${pids.join(', ')})`,
     };
   }
   return {
@@ -390,7 +432,7 @@ function stepCleanReviewArtifacts(): StepResult {
 
   // Restore tracked review artifacts
   for (const rel of TRACKED_RESTORE_TARGETS) {
-    if (execSafe(`git checkout -- "${rel}"`) !== null) actions++;
+    if (gitSafe('checkout', '--', rel).ok) actions++;
   }
 
   return {
@@ -400,39 +442,34 @@ function stepCleanReviewArtifacts(): StepResult {
   };
 }
 
-async function stepCloseAgentSession(_opts: CommandOptions): Promise<StepResult> {
-  try {
-    const result = await agentsCommands.commands.close([], { ci: true });
-    if (result.exitCode === 0) {
-      return { label: 'Agent session', ok: true, detail: 'closed in DB' };
-    }
-    return {
-      label: 'Agent session',
-      ok: false,
-      detail: result.output.trim().split('\n')[0]?.slice(0, 200) ?? 'unknown error',
-    };
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return { label: 'Agent session', ok: false, detail: `error: ${msg}` };
-  }
+async function stepCloseAgentSession(): Promise<StepResult> {
+  return runDelegate(
+    'Agent session',
+    () => agentsCommands.commands.close([], { ci: true }),
+    () => 'closed in DB',
+  );
 }
 
 function stepBranchReset(plan: Plan): StepResult {
+  const isMain = plan.branch === 'main';
+
   // Always run the discard pair — even on main this just reverts any session
   // hook tweaks.
-  const discardOk = execSafe('git checkout -- .') !== null;
-  const cleanOk =
-    execSafe('git clean -fd --exclude=.agent-slot --exclude=.envrc --exclude=.env') !== null;
+  const discardOk = gitSafe('checkout', '--', '.').ok;
+  const cleanOk = gitSafe(
+    'clean', '-fd',
+    '--exclude=.agent-slot', '--exclude=.envrc', '--exclude=.env',
+  ).ok;
 
-  if (plan.isMain) {
+  if (isMain) {
     if (!discardOk || !cleanOk) {
       return { label: 'Branch reset', ok: false, detail: 'on main; discard/clean failed' };
     }
     return { label: 'Branch reset', ok: true, detail: 'already on main; cleaned' };
   }
 
-  // Guard against pathological branch states. These shouldn't happen in a
-  // healthy slot, but we'd rather no-op than `git branch -D "(unknown)"`.
+  // Guard against pathological branch states. Shouldn't happen in a healthy
+  // slot, but we'd rather no-op than `git branch -D "(unknown)"`.
   if (!plan.branch || plan.branch === '(unknown)') {
     return { label: 'Branch reset', ok: false, detail: `cannot reset: branch=${plan.branch}` };
   }
@@ -440,18 +477,19 @@ function stepBranchReset(plan: Plan): StepResult {
   // The PreToolUse hook for branch switching is bypassed here because we are
   // running outside the Bash tool (TS execSync is a child process, not a tool
   // call). No `AGENT_RESET=1` needed.
-  if (execSafe('git checkout main') === null) {
+  if (!gitSafe('checkout', 'main').ok) {
     return { label: 'Branch reset', ok: false, detail: `failed to checkout main from ${plan.branch}` };
   }
 
   // Refresh origin so the divergence check below uses up-to-date refs.
-  execSafe('git fetch origin main', 30000);
+  gitSafe('fetch', 'origin', 'main');
 
   // Detect local commits on main that origin/main doesn't have. If any exist,
   // bail rather than risk discarding them via `git reset --hard origin/main`.
   // Healthy slots never accumulate local commits on main, but if a prior
   // session committed accidentally we want a loud error, not silent loss.
-  const localAhead = Number(execSafe('git rev-list --count origin/main..main 2>/dev/null') ?? '0');
+  const localAheadResult = gitSafe('rev-list', '--count', 'origin/main..main');
+  const localAhead = localAheadResult.ok ? Number(localAheadResult.output) || 0 : 0;
   if (localAhead > 0) {
     return {
       label: 'Branch reset',
@@ -461,14 +499,14 @@ function stepBranchReset(plan: Plan): StepResult {
   }
 
   // Local main is either even with or behind origin — safe to fast-forward.
-  if (execSafe('git pull --ff-only origin main', 30000) === null) {
+  if (!gitSafe('pull', '--ff-only', 'origin', 'main').ok) {
     return { label: 'Branch reset', ok: false, detail: 'pull --ff-only failed (network?); main is unchanged' };
   }
 
   // Delete the spent feature branch (best-effort — may already be gone). `-D`
   // is force-delete; safe because the branch is presumed merged or abandoned
   // by the operator running /agent-end.
-  execSafe(`git branch -D "${plan.branch}"`);
+  gitSafe('branch', '-D', plan.branch);
 
   return { label: 'Branch reset', ok: true, detail: `switched main; deleted ${plan.branch}` };
 }
@@ -477,7 +515,7 @@ function stepRenameTmux(plan: Plan): StepResult {
   if (!plan.slot) return { label: 'Tmux rename', ok: true, detail: 'no .agent-slot (skipped)' };
   if (!process.env.TMUX) return { label: 'Tmux rename', ok: true, detail: 'not in tmux (skipped)' };
   const target = `A${plan.slot}`;
-  if (execSafe(`tmux rename-window "${target}"`) === null) {
+  if (shellSafe(`tmux rename-window "${target}"`) === null) {
     return { label: 'Tmux rename', ok: false, detail: `failed to rename to ${target}` };
   }
   return { label: 'Tmux rename', ok: true, detail: `renamed to ${target}` };
@@ -488,15 +526,15 @@ function stepRenameTmux(plan: Plan): StepResult {
 // ---------------------------------------------------------------------------
 
 function planLines(plan: Plan, dirtyMode: DirtyMode): string[] {
-  const out: string[] = [];
-  out.push(`branch:    ${plan.branch}${plan.isMain ? ' (already main — no delete)' : ''}`);
-  out.push(`slot:      ${plan.slot ?? '(none)'}`);
-  out.push(`linear:    ${plan.linearId ?? '(none — skip linear done)'}`);
-  out.push(`pr:        ${plan.prUrl ?? '(none — Linear → Done)'}`);
-  out.push(`dev port:  ${plan.devPort ?? '(none)'}${plan.devPids.length ? ` PIDs ${plan.devPids.join(', ')}` : ''}`);
-  out.push(`patrol:    ${plan.patrolPid ?? '(not running)'}`);
-  out.push(`dirty:     ${dirtyMode}`);
-  return out;
+  const isMain = plan.branch === 'main';
+  return [
+    `branch:    ${plan.branch}${isMain ? ' (already main — no delete)' : ''}`,
+    `slot:      ${plan.slot ?? '(none)'}`,
+    `linear:    ${plan.linearId ?? '(none — skip linear done)'}`,
+    `pr:        ${plan.prUrl ?? '(none — Linear → Done)'}`,
+    `dev port:  ${plan.devPort ?? '(none)'}`,
+    `dirty:     ${dirtyMode}`,
+  ];
 }
 
 async function agentEndCommand(
@@ -508,14 +546,15 @@ async function agentEndCommand(
   const dirtyMode = parseDirtyMode(options.dirty);
   const isDryRun = Boolean(options.dryRun);
 
-  const plan = buildPlan(options);
+  const branch = readCurrentBranch() ?? '(unknown)';
+  const plan = buildPlan(options, branch);
 
   let output = '';
   output += `${c.bold}Agent End${c.reset} — ${plan.slot ? `slot ${plan.slot}` : 'no slot marker'}${isDryRun ? ` ${c.dim}(dry-run)${c.reset}` : ''}\n`;
   output += `${c.dim}${'─'.repeat(50)}${c.reset}\n`;
 
   // ── 1. Dirty-state gate ────────────────────────────────────────────────
-  const dirty = inspectDirtyState();
+  const dirty = inspectDirtyState(branch);
   const hasUnexpectedDirty = dirty.unexpectedFiles.length > 0 || dirty.unpushedCommits > 0;
   if (hasUnexpectedDirty && dirtyMode !== 'force') {
     output += `${c.red}✗${c.reset} Dirty state requires attention (--dirty=${dirtyMode}):\n`;
@@ -544,6 +583,12 @@ async function agentEndCommand(
 
   // ── 3. Dry-run: print and exit ─────────────────────────────────────────
   if (isDryRun) {
+    // patrolPid + dev-port listeners are looked up only for dry-run reporting.
+    // The real steps re-resolve at execute time, so a stale snapshot is fine.
+    const patrol = patrolPid();
+    const devPids = plan.devPort ? findPortListeners(plan.devPort) : [];
+    const isMain = plan.branch === 'main';
+
     output += `${c.bold}Would execute:${c.reset}\n`;
     output += `  • agent-checklist complete\n`;
     output += `  • linear leak-check\n`;
@@ -553,16 +598,16 @@ async function agentEndCommand(
     } else {
       output += `  • linear done — skipped (no Linear ID)\n`;
     }
-    output += `  • pr-patrol stop ${plan.patrolPid ? `(PID ${plan.patrolPid})` : '(not running)'}\n`;
+    output += `  • pr-patrol stop ${patrol ? `(PID ${patrol})` : '(not running)'}\n`;
     if (plan.devPort) {
-      output += `  • kill dev server on port ${plan.devPort} ${plan.devPids.length ? `(PIDs: ${plan.devPids.join(', ')})` : '(no listener)'}\n`;
+      output += `  • kill dev server on port ${plan.devPort} ${devPids.length ? `(PIDs: ${devPids.join(', ')})` : '(no listener)'}\n`;
     } else {
       output += `  • dev server — no DEV_PORT in .env\n`;
     }
     output += `  • rm .claude/wip-checklist.md, .claude/wip-context.md\n`;
     output += `  • rm gitignored markers (review-phases-done, simplify-done) + git checkout -- .claude/review-done .claude/hooks/\n`;
     output += `  • agents close (DB session)\n`;
-    if (plan.isMain) {
+    if (isMain) {
       output += `  • git checkout -- . && git clean -fd (already on main)\n`;
     } else {
       output += `  • git checkout -- . && git clean -fd && git checkout main && git pull && git branch -D ${plan.branch}\n`;
@@ -574,19 +619,27 @@ async function agentEndCommand(
     return { output, exitCode: 0 };
   }
 
-  // ── 4. Execute steps in order ──────────────────────────────────────────
-  const steps: StepResult[] = [];
+  // ── 4. Independent steps run in parallel ───────────────────────────────
+  // Linear and agents-close hit the wiki-server (200–800ms each); patrol,
+  // dev-server, wip-cleanup, review-artifacts are local. Running them
+  // concurrently saves 1–2s per session-end. Promise.all preserves input
+  // order, so the printed summary still reads sequentially.
+  const parallel = await Promise.all([
+    stepCompleteChecklist(),
+    stepLeakCheck(),
+    stepLinearDone(plan),
+    stepPatrolStop(),
+    Promise.resolve(stepKillDevServer(plan)),
+    Promise.resolve(stepCleanWipArtifacts()),
+    Promise.resolve(stepCleanReviewArtifacts()),
+    stepCloseAgentSession(),
+  ]);
 
-  steps.push(await stepCompleteChecklist(options));
-  steps.push(await stepLeakCheck(options));
-  steps.push(await stepLinearDone(plan));
-  steps.push(await stepPatrolStop(options));
-  steps.push(stepKillDevServer(plan));
-  steps.push(stepCleanWipArtifacts());
-  steps.push(stepCleanReviewArtifacts());
-  steps.push(await stepCloseAgentSession(options));
-  steps.push(stepBranchReset(plan));
-  steps.push(stepRenameTmux(plan));
+  // ── 5. Sequential steps that mutate branch / window state ──────────────
+  // Branch-reset must run after the cleanups (the discard pair expects the
+  // working tree to be in its post-cleanup state). Tmux-rename is last
+  // because it changes the visible window title.
+  const steps = [...parallel, stepBranchReset(plan), stepRenameTmux(plan)];
 
   for (const s of steps) {
     const icon = s.ok ? `${c.green}✓${c.reset}` : `${c.red}✗${c.reset}`;

--- a/crux/commands/agent-end.ts
+++ b/crux/commands/agent-end.ts
@@ -8,7 +8,6 @@
  *   crux sys agent-end                            Close & reset (defaults)
  *   crux sys agent-end --pr=URL                   Pass PR URL to Linear `done`
  *   crux sys agent-end --dirty=force              Discard unexpected dirty state
- *   crux sys agent-end --dirty=ask                Bail with dirty details (LLM triages)
  *   crux sys agent-end --dry-run                  Print actions only
  */
 
@@ -25,16 +24,20 @@ import * as prPatrolCommands from './pr-patrol.ts';
 
 interface CommandOptions extends BaseOptions {
   pr?: string;
-  dirty?: string; // 'ask' | 'fail' | 'force'
+  dirty?: string; // 'fail' | 'force'
   dryRun?: boolean;
   ci?: boolean;
 }
 
-type DirtyMode = 'ask' | 'fail' | 'force';
+type DirtyMode = 'fail' | 'force';
 
-// Files/directories that may legitimately be modified or untracked at session
-// end — they are session-scoped scaffolding we are about to clean. Anything
-// else dirty triggers the --dirty bail (unless --dirty=force).
+// Files / directory prefixes that may legitimately be modified or untracked at
+// session end — they are session-scoped scaffolding we are about to clean.
+// Anything else dirty triggers the --dirty bail (unless --dirty=force).
+//
+// Trailing-slash entries are directory prefixes; the matcher checks
+// `path.startsWith(prefix)` for those. Non-slash entries match exactly OR with
+// `path === entry + '/' + ...`. See `isExpectedPath` below.
 const EXPECTED_DIRTY_PATHS = [
   '.claude/wip-checklist.md',
   '.claude/wip-context.md',
@@ -47,6 +50,13 @@ const EXPECTED_DIRTY_PATHS = [
   '.claude/sessions/',
   '.agent-task',
 ];
+
+function isExpectedPath(path: string): boolean {
+  return EXPECTED_DIRTY_PATHS.some((p) => {
+    if (p.endsWith('/')) return path.startsWith(p);
+    return path === p || path.startsWith(p + '/');
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -158,11 +168,13 @@ export function inspectDirtyState(): DirtyStatus {
   const unexpectedFiles: string[] = [];
 
   for (const line of status.split('\n').filter(Boolean)) {
-    // Format: "XY <path>"  (X = staged, Y = unstaged; both single chars)
-    const path = line.slice(3);
-    const isExpected = EXPECTED_DIRTY_PATHS.some(
-      (p) => path === p || path.startsWith(p + '/') || (p.endsWith('/') && path.startsWith(p)),
-    );
+    // Format: "XY <path>" (X = staged, Y = unstaged; both single chars).
+    // Renames have the form "R<flag> old -> new" — both old and new must be
+    // checked, since a session might rename an expected scaffolding file.
+    const slice = line.slice(3);
+    const renameSplit = ' -> ';
+    const paths = slice.includes(renameSplit) ? slice.split(renameSplit) : [slice];
+    const isExpected = paths.every(isExpectedPath);
     if (isExpected) expectedFiles.push(line);
     else unexpectedFiles.push(line);
   }
@@ -179,7 +191,7 @@ export function inspectDirtyState(): DirtyStatus {
 }
 
 export function parseDirtyMode(raw: unknown): DirtyMode {
-  if (raw === 'ask' || raw === 'fail' || raw === 'force') return raw;
+  if (raw === 'force') return 'force';
   return 'fail';
 }
 
@@ -350,44 +362,42 @@ function stepCleanWipArtifacts(): StepResult {
   return { label: 'WIP artifacts', ok: true, detail: `removed ${removed.length}` };
 }
 
-function stepRestoreTrackedFiles(): StepResult {
-  // Tracked files / dirs that get touched mid-session and must be returned to
-  // their committed state. `git checkout --` for tracked, plain rm for untracked.
-  const restored: string[] = [];
-  const cleared: string[] = [];
+// Gitignored review markers — agent-end always unlinks if present (no
+// git-checkout needed since git doesn't track them).
+const GITIGNORED_MARKERS = ['.claude/review-phases-done', '.claude/simplify-done'];
 
-  const trackedTargets = [
-    '.claude/review-done',
-    '.claude/review-phases-done',
-    '.claude/simplify-done',
-    '.claude/hooks/',
-  ];
-  for (const rel of trackedTargets) {
+// Tracked paths that may be modified mid-session (review-done is committed
+// when the marker file exists in git history; .claude/hooks/ is the live
+// session-hook scaffolding) — restore to HEAD with git checkout.
+const TRACKED_RESTORE_TARGETS = ['.claude/review-done', '.claude/hooks/'];
+
+function stepCleanReviewArtifacts(): StepResult {
+  let actions = 0;
+
+  // Unlink gitignored markers
+  for (const rel of GITIGNORED_MARKERS) {
     const abs = join(PROJECT_ROOT, rel);
-    if (execSafe(`git ls-files --error-unmatch -- "${rel}"`) !== null) {
-      // Tracked: discard local modifications
-      if (execSafe(`git checkout -- "${rel}"`) !== null) restored.push(rel);
-    } else if (existsSync(abs)) {
-      // Untracked: best-effort remove
+    if (existsSync(abs)) {
       try {
-        if (rel.endsWith('/')) {
-          // Directory: leave to `git clean -fd` later, since rm -rf is risky
-          cleared.push(rel + '(via clean)');
-        } else {
-          unlinkSync(abs);
-          cleared.push(rel);
-        }
+        unlinkSync(abs);
+        actions++;
       } catch {
-        // Non-fatal
+        // Non-fatal — the branch reset below will catch any leftovers via
+        // `git clean -fd`. We don't fail the step on a single unlink miss.
       }
     }
   }
 
-  const all = [...restored, ...cleared];
-  if (all.length === 0) {
-    return { label: 'Tracked-file restore', ok: true, detail: 'nothing to restore' };
+  // Restore tracked review artifacts
+  for (const rel of TRACKED_RESTORE_TARGETS) {
+    if (execSafe(`git checkout -- "${rel}"`) !== null) actions++;
   }
-  return { label: 'Tracked-file restore', ok: true, detail: `${all.length} target(s)` };
+
+  return {
+    label: 'Review artifacts',
+    ok: true,
+    detail: actions === 0 ? 'nothing to restore' : `${actions} target(s)`,
+  };
 }
 
 async function stepCloseAgentSession(_opts: CommandOptions): Promise<StepResult> {
@@ -421,17 +431,43 @@ function stepBranchReset(plan: Plan): StepResult {
     return { label: 'Branch reset', ok: true, detail: 'already on main; cleaned' };
   }
 
+  // Guard against pathological branch states. These shouldn't happen in a
+  // healthy slot, but we'd rather no-op than `git branch -D "(unknown)"`.
+  if (!plan.branch || plan.branch === '(unknown)') {
+    return { label: 'Branch reset', ok: false, detail: `cannot reset: branch=${plan.branch}` };
+  }
+
   // The PreToolUse hook for branch switching is bypassed here because we are
   // running outside the Bash tool (TS execSync is a child process, not a tool
   // call). No `AGENT_RESET=1` needed.
   if (execSafe('git checkout main') === null) {
     return { label: 'Branch reset', ok: false, detail: `failed to checkout main from ${plan.branch}` };
   }
-  // Pull latest; on conflict force to origin/main (the slot has no work to keep)
-  if (execSafe('git pull --ff-only origin main', 30000) === null) {
-    execSafe('git reset --hard origin/main');
+
+  // Refresh origin so the divergence check below uses up-to-date refs.
+  execSafe('git fetch origin main', 30000);
+
+  // Detect local commits on main that origin/main doesn't have. If any exist,
+  // bail rather than risk discarding them via `git reset --hard origin/main`.
+  // Healthy slots never accumulate local commits on main, but if a prior
+  // session committed accidentally we want a loud error, not silent loss.
+  const localAhead = Number(execSafe('git rev-list --count origin/main..main 2>/dev/null') ?? '0');
+  if (localAhead > 0) {
+    return {
+      label: 'Branch reset',
+      ok: false,
+      detail: `${localAhead} local commit(s) on main not in origin/main — refusing to reset; investigate by hand`,
+    };
   }
-  // Delete the spent feature branch (best-effort — may already be gone)
+
+  // Local main is either even with or behind origin — safe to fast-forward.
+  if (execSafe('git pull --ff-only origin main', 30000) === null) {
+    return { label: 'Branch reset', ok: false, detail: 'pull --ff-only failed (network?); main is unchanged' };
+  }
+
+  // Delete the spent feature branch (best-effort — may already be gone). `-D`
+  // is force-delete; safe because the branch is presumed merged or abandoned
+  // by the operator running /agent-end.
   execSafe(`git branch -D "${plan.branch}"`);
 
   return { label: 'Branch reset', ok: true, detail: `switched main; deleted ${plan.branch}` };
@@ -524,7 +560,7 @@ async function agentEndCommand(
       output += `  • dev server — no DEV_PORT in .env\n`;
     }
     output += `  • rm .claude/wip-checklist.md, .claude/wip-context.md\n`;
-    output += `  • git checkout -- .claude/review-done .claude/review-phases-done .claude/simplify-done .claude/hooks/\n`;
+    output += `  • rm gitignored markers (review-phases-done, simplify-done) + git checkout -- .claude/review-done .claude/hooks/\n`;
     output += `  • agents close (DB session)\n`;
     if (plan.isMain) {
       output += `  • git checkout -- . && git clean -fd (already on main)\n`;
@@ -547,7 +583,7 @@ async function agentEndCommand(
   steps.push(await stepPatrolStop(options));
   steps.push(stepKillDevServer(plan));
   steps.push(stepCleanWipArtifacts());
-  steps.push(stepRestoreTrackedFiles());
+  steps.push(stepCleanReviewArtifacts());
   steps.push(await stepCloseAgentSession(options));
   steps.push(stepBranchReset(plan));
   steps.push(stepRenameTmux(plan));
@@ -588,19 +624,18 @@ Usage:
   crux sys agent-end                    Close & reset (defaults)
   crux sys agent-end --pr=URL           Pass PR URL to Linear \`done\`
   crux sys agent-end --dirty=force      Discard unexpected dirty state
-  crux sys agent-end --dirty=ask        Bail with details (LLM triages)
   crux sys agent-end --dry-run          Print actions, take none
 
 Options:
   --pr=URL           PR URL to attach to the Linear done comment.
                      With a PR: Linear → In Review.
                      Without:   Linear → Done.
-  --dirty=MODE       fail (default) | ask | force.
-                     fail/ask: bail (exit 2) on unexpected dirty paths or
-                              unpushed commits, listing each so the operator
-                              can commit/push/discard and re-run.
-                     force:   discard everything (current behavior of the
-                              old skill body).
+  --dirty=MODE       fail (default) | force.
+                     fail:  bail (exit 2) on unexpected dirty paths or
+                            unpushed commits, listing each so the operator
+                            can commit/push/discard and re-run.
+                     force: discard everything (matches the old skill's
+                            behaviour). Use only when you know what's dirty.
   --dry-run          Print the actions that would be taken, exit 0.
   --ci               Plain (no-color) output.
 
@@ -611,7 +646,7 @@ What runs (in order):
   4. pr-patrol stop                     Halt patrol daemon if running
   5. kill dev server on $DEV_PORT       Uses lsof -sTCP:LISTEN (port-scoped)
   6. rm .claude/wip-{checklist,context}.md
-  7. git checkout -- .claude/review-done .claude/review-phases-done .claude/simplify-done .claude/hooks/
+  7. rm gitignored markers (review-phases-done, simplify-done) + git checkout -- .claude/review-done .claude/hooks/
   8. agents close                       Close active agent + session row in DB
   9. git checkout main; pull --ff-only; git branch -D <feature>
   10. tmux rename-window A<slot>
@@ -619,7 +654,7 @@ What runs (in order):
 Exit codes:
   0  All steps passed (or dry-run).
   1  At least one step reported an error — review the output.
-  2  Bail before running any step (dirty state with --dirty=fail|ask).
+  2  Bail before running any step (dirty state with --dirty=fail).
 
 Examples:
   crux sys agent-end --dry-run

--- a/crux/commands/agent-end.ts
+++ b/crux/commands/agent-end.ts
@@ -546,7 +546,18 @@ async function agentEndCommand(
   const dirtyMode = parseDirtyMode(options.dirty);
   const isDryRun = Boolean(options.dryRun);
 
+  // Bail on unresolvable git state BEFORE running any side effects. A detached
+  // HEAD returns 'HEAD' from `git rev-parse --abbrev-ref HEAD` (not the
+  // commit), and an unreadable repo returns null → '(unknown)'. Either case
+  // means stepBranchReset can't safely reset, so the parallel block (Linear
+  // close, agents close, file unlinks) must not run.
   const branch = readCurrentBranch() ?? '(unknown)';
+  if (branch === '(unknown)' || branch === 'HEAD') {
+    let earlyOut = '';
+    earlyOut += `${c.red}✗${c.reset} Cannot run agent-end from a detached or unknown git HEAD (got: ${branch}).\n`;
+    earlyOut += `  Resolve the git state manually (e.g. \`git checkout main\`), then re-run.\n`;
+    return { output: earlyOut, exitCode: 2 };
+  }
   const plan = buildPlan(options, branch);
 
   let output = '';

--- a/crux/commands/agent-end.ts
+++ b/crux/commands/agent-end.ts
@@ -1,0 +1,629 @@
+/**
+ * Agent End — Close out a session and reset the slot back to clean main.
+ *
+ * Bundles the mechanical plumbing previously orchestrated step-by-step
+ * in `.claude/commands/agent-end.md` (QUA-1090).
+ *
+ * Usage:
+ *   crux sys agent-end                            Close & reset (defaults)
+ *   crux sys agent-end --pr=URL                   Pass PR URL to Linear `done`
+ *   crux sys agent-end --dirty=force              Discard unexpected dirty state
+ *   crux sys agent-end --dirty=ask                Bail with dirty details (LLM triages)
+ *   crux sys agent-end --dry-run                  Print actions only
+ */
+
+import { execSync } from 'child_process';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import { createLogger } from '../lib/output.ts';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import * as agentChecklistCommands from './agent-checklist.ts';
+import * as agentsCommands from './agents.ts';
+import * as linearCommands from './linear.ts';
+import * as prPatrolCommands from './pr-patrol.ts';
+
+interface CommandOptions extends BaseOptions {
+  pr?: string;
+  dirty?: string; // 'ask' | 'fail' | 'force'
+  dryRun?: boolean;
+  ci?: boolean;
+}
+
+type DirtyMode = 'ask' | 'fail' | 'force';
+
+// Files/directories that may legitimately be modified or untracked at session
+// end — they are session-scoped scaffolding we are about to clean. Anything
+// else dirty triggers the --dirty bail (unless --dirty=force).
+const EXPECTED_DIRTY_PATHS = [
+  '.claude/wip-checklist.md',
+  '.claude/wip-context.md',
+  '.claude/review-done',
+  '.claude/review-phases-done',
+  '.claude/simplify-done',
+  '.claude/agent-id',
+  '.claude/last-heartbeat',
+  '.claude/hooks/',
+  '.claude/sessions/',
+  '.agent-task',
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function exec(cmd: string, timeoutMs = 30000): string {
+  return execSync(cmd, { encoding: 'utf-8', timeout: timeoutMs, cwd: PROJECT_ROOT }).trim();
+}
+
+function execSafe(cmd: string, timeoutMs = 30000): string | null {
+  try {
+    return exec(cmd, timeoutMs);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Like execSafe but preserves whitespace. Use for command output where leading
+ * whitespace is semantic — notably `git status --porcelain` (a leading space in
+ * column 0 means "no staged change", and `.trim()` would corrupt the layout).
+ */
+function execRawSafe(cmd: string, timeoutMs = 30000): string | null {
+  try {
+    return execSync(cmd, { encoding: 'utf-8', timeout: timeoutMs, cwd: PROJECT_ROOT });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the Linear ID from the wip checklist (`> Linear: QUA-NNN`) first,
+ * then fall back to parsing the current branch (`claude/qua-NNN-...`).
+ */
+export function resolveLinearId(): string | null {
+  const checklistPath = join(PROJECT_ROOT, '.claude/wip-checklist.md');
+  if (existsSync(checklistPath)) {
+    const md = readFileSync(checklistPath, 'utf-8');
+    const m = md.match(/^>\s*Linear:\s*([A-Z]+-\d+)/m);
+    if (m) return m[1];
+  }
+  const branch = execSafe('git rev-parse --abbrev-ref HEAD');
+  if (branch) {
+    const m = branch.match(/claude\/(qua-\d+)/i);
+    if (m) return m[1].toUpperCase();
+  }
+  return null;
+}
+
+/**
+ * Read DEV_PORT from .env. Returns null if missing or non-numeric.
+ */
+export function readDevPort(): number | null {
+  const envPath = join(PROJECT_ROOT, '.env');
+  if (!existsSync(envPath)) return null;
+  for (const line of readFileSync(envPath, 'utf-8').split('\n')) {
+    const m = line.match(/^DEV_PORT=(\d+)\s*$/);
+    if (m) return Number(m[1]);
+  }
+  return null;
+}
+
+/**
+ * Read .agent-slot (e.g. "7" → 7). Returns null if missing or unparsable.
+ */
+export function readSlotNumber(): string | null {
+  const slotPath = join(PROJECT_ROOT, '.agent-slot');
+  if (!existsSync(slotPath)) return null;
+  const raw = readFileSync(slotPath, 'utf-8').trim();
+  return /^\d+$/.test(raw) ? raw : null;
+}
+
+/**
+ * Find PIDs listening on the given TCP port. Uses `lsof -sTCP:LISTEN` so we
+ * never accidentally match outbound browser connections (per QUA memory:
+ * `feedback_kill_port_safely.md`).
+ */
+export function findPortListeners(port: number): number[] {
+  const out = execSafe(`lsof -ti:${port} -sTCP:LISTEN`);
+  if (!out) return [];
+  return out
+    .split('\n')
+    .map((s) => Number(s.trim()))
+    .filter((n) => Number.isInteger(n) && n > 0);
+}
+
+interface DirtyStatus {
+  unexpectedFiles: string[];
+  unpushedCommits: number;
+  expectedFiles: string[];
+}
+
+/**
+ * Inspect the working tree for state /agent-end is not authorized to discard.
+ * Expected scaffolding (wip checklist, hooks/, etc.) is filtered out — those
+ * always get cleaned. Anything else is "unexpected" and triggers --dirty=fail.
+ *
+ * Unpushed commits are reported only on non-main branches (on main any unpushed
+ * work is a separate issue the user owns; agent-end does not amend that).
+ */
+export function inspectDirtyState(): DirtyStatus {
+  // execRawSafe (no trim): porcelain output uses two columns where column 0
+  // can legitimately be a space (" M file" = unstaged modify). Trim would
+  // corrupt the slice(3).
+  const status = execRawSafe('git status --porcelain') ?? '';
+  const branch = execSafe('git rev-parse --abbrev-ref HEAD') ?? '(unknown)';
+
+  const expectedFiles: string[] = [];
+  const unexpectedFiles: string[] = [];
+
+  for (const line of status.split('\n').filter(Boolean)) {
+    // Format: "XY <path>"  (X = staged, Y = unstaged; both single chars)
+    const path = line.slice(3);
+    const isExpected = EXPECTED_DIRTY_PATHS.some(
+      (p) => path === p || path.startsWith(p + '/') || (p.endsWith('/') && path.startsWith(p)),
+    );
+    if (isExpected) expectedFiles.push(line);
+    else unexpectedFiles.push(line);
+  }
+
+  let unpushedCommits = 0;
+  if (branch !== 'main' && branch !== '(unknown)') {
+    // 2>/dev/null swallows the "no upstream configured" error that fires for
+    // branches that were never pushed (research/abandoned sessions).
+    const counted = execSafe('git rev-list --count @{u}..HEAD 2>/dev/null');
+    if (counted) unpushedCommits = Number(counted) || 0;
+  }
+
+  return { unexpectedFiles, unpushedCommits, expectedFiles };
+}
+
+export function parseDirtyMode(raw: unknown): DirtyMode {
+  if (raw === 'ask' || raw === 'fail' || raw === 'force') return raw;
+  return 'fail';
+}
+
+// ---------------------------------------------------------------------------
+// Action steps — each returns one structured line for the parent summary
+// ---------------------------------------------------------------------------
+
+interface StepResult {
+  label: string;
+  ok: boolean;
+  detail: string;
+}
+
+interface Plan {
+  linearId: string | null;
+  prUrl: string | null;
+  branch: string;
+  slot: string | null;
+  devPort: number | null;
+  devPids: number[];
+  patrolPid: number | null;
+  isMain: boolean;
+}
+
+function buildPlan(options: CommandOptions): Plan {
+  const branch = execSafe('git rev-parse --abbrev-ref HEAD') ?? '(unknown)';
+  const linearId = resolveLinearId();
+  const slot = readSlotNumber();
+  const devPort = readDevPort();
+  const devPids = devPort ? findPortListeners(devPort) : [];
+  const patrolPid = (() => {
+    try {
+      // Reuse pr-patrol's daemon registry — same source the `stop` command uses.
+      // Falling back to null if anything throws.
+      const out = execSafe('pgrep -f "crux gh pr-patrol run" 2>/dev/null') ?? '';
+      const first = out.split('\n').find(Boolean);
+      return first ? Number(first) : null;
+    } catch {
+      return null;
+    }
+  })();
+
+  return {
+    linearId,
+    prUrl: typeof options.pr === 'string' ? options.pr : null,
+    branch,
+    slot,
+    devPort,
+    devPids,
+    patrolPid,
+    isMain: branch === 'main',
+  };
+}
+
+async function stepCompleteChecklist(_opts: CommandOptions): Promise<StepResult> {
+  // The checklist file may not exist (quick-fix sessions) — that's a no-op.
+  const checklistPath = join(PROJECT_ROOT, '.claude/wip-checklist.md');
+  if (!existsSync(checklistPath)) {
+    return { label: 'Checklist', ok: true, detail: 'no checklist (skipped)' };
+  }
+  const result = await agentChecklistCommands.commands.complete([], { ci: true });
+  // exitCode 0 = complete, 1 = unchecked items remain. Either way we proceed
+  // (the checklist command surfaces the warning; agent-end is meant to close
+  // the slot regardless of checklist state).
+  if (result.exitCode === 0) {
+    return { label: 'Checklist', ok: true, detail: 'all items complete' };
+  }
+  const unchecked = (result.output.match(/\[ \]/g) ?? []).length;
+  return { label: 'Checklist', ok: false, detail: `${unchecked} item(s) unchecked` };
+}
+
+async function stepLeakCheck(_opts: CommandOptions): Promise<StepResult> {
+  const result = await linearCommands.commands['leak-check']([], { ci: true });
+  // leakCheck is advisory and returns exit 0 even when leaks exist — the
+  // command's printed output names any leaked refs.
+  const leaks = (result.output.match(/QUA-\d+/g) ?? []).filter((v, i, a) => a.indexOf(v) === i);
+  if (leaks.length === 0) return { label: 'Linear leak-check', ok: true, detail: 'no extra refs' };
+  return { label: 'Linear leak-check', ok: true, detail: `flagged: ${leaks.join(', ')}` };
+}
+
+async function stepLinearDone(plan: Plan): Promise<StepResult> {
+  if (!plan.linearId) {
+    return { label: 'Linear done', ok: true, detail: 'no Linear ID resolved (skipped)' };
+  }
+  const opts: CommandOptions = { ci: true };
+  if (plan.prUrl) opts.pr = plan.prUrl;
+  try {
+    const result = await linearCommands.commands.done([plan.linearId], opts);
+    if (result.exitCode === 0) {
+      const target = plan.prUrl ? 'In Review' : 'Done';
+      const suffix = plan.prUrl ? ` (PR ${plan.prUrl})` : '';
+      return { label: 'Linear done', ok: true, detail: `${plan.linearId} → ${target}${suffix}` };
+    }
+    return { label: 'Linear done', ok: false, detail: result.output.trim().slice(0, 200) };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { label: 'Linear done', ok: false, detail: `error: ${msg}` };
+  }
+}
+
+async function stepPatrolStop(_opts: CommandOptions): Promise<StepResult> {
+  try {
+    const result = await prPatrolCommands.commands.stop([], { ci: true });
+    if (result.output.toLowerCase().includes('no patrol daemon')) {
+      return { label: 'Patrol daemon', ok: true, detail: 'not running (skipped)' };
+    }
+    if (result.exitCode === 0) {
+      return { label: 'Patrol daemon', ok: true, detail: 'stopped' };
+    }
+    return { label: 'Patrol daemon', ok: false, detail: result.output.trim().slice(0, 200) };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { label: 'Patrol daemon', ok: false, detail: `error: ${msg}` };
+  }
+}
+
+function stepKillDevServer(plan: Plan): StepResult {
+  if (!plan.devPort) {
+    return { label: 'Dev server', ok: true, detail: 'no DEV_PORT in .env (skipped)' };
+  }
+  if (plan.devPids.length === 0) {
+    return { label: 'Dev server', ok: true, detail: `port ${plan.devPort} has no listener` };
+  }
+  const failed: number[] = [];
+  for (const pid of plan.devPids) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      // ESRCH = already gone; treat as success
+      if (!msg.includes('ESRCH')) failed.push(pid);
+    }
+  }
+  if (failed.length === 0) {
+    return {
+      label: 'Dev server',
+      ok: true,
+      detail: `killed port ${plan.devPort} (PIDs: ${plan.devPids.join(', ')})`,
+    };
+  }
+  return {
+    label: 'Dev server',
+    ok: false,
+    detail: `failed to kill PIDs: ${failed.join(', ')}`,
+  };
+}
+
+function stepCleanWipArtifacts(): StepResult {
+  const removed: string[] = [];
+  const targets = [
+    '.claude/wip-checklist.md',
+    '.claude/wip-context.md',
+  ];
+  for (const rel of targets) {
+    const abs = join(PROJECT_ROOT, rel);
+    if (existsSync(abs)) {
+      try {
+        unlinkSync(abs);
+        removed.push(rel);
+      } catch {
+        // Non-fatal; the branch reset below also runs `git clean -fd`.
+      }
+    }
+  }
+  if (removed.length === 0) {
+    return { label: 'WIP artifacts', ok: true, detail: 'none to remove' };
+  }
+  return { label: 'WIP artifacts', ok: true, detail: `removed ${removed.length}` };
+}
+
+function stepRestoreTrackedFiles(): StepResult {
+  // Tracked files / dirs that get touched mid-session and must be returned to
+  // their committed state. `git checkout --` for tracked, plain rm for untracked.
+  const restored: string[] = [];
+  const cleared: string[] = [];
+
+  const trackedTargets = [
+    '.claude/review-done',
+    '.claude/review-phases-done',
+    '.claude/simplify-done',
+    '.claude/hooks/',
+  ];
+  for (const rel of trackedTargets) {
+    const abs = join(PROJECT_ROOT, rel);
+    if (execSafe(`git ls-files --error-unmatch -- "${rel}"`) !== null) {
+      // Tracked: discard local modifications
+      if (execSafe(`git checkout -- "${rel}"`) !== null) restored.push(rel);
+    } else if (existsSync(abs)) {
+      // Untracked: best-effort remove
+      try {
+        if (rel.endsWith('/')) {
+          // Directory: leave to `git clean -fd` later, since rm -rf is risky
+          cleared.push(rel + '(via clean)');
+        } else {
+          unlinkSync(abs);
+          cleared.push(rel);
+        }
+      } catch {
+        // Non-fatal
+      }
+    }
+  }
+
+  const all = [...restored, ...cleared];
+  if (all.length === 0) {
+    return { label: 'Tracked-file restore', ok: true, detail: 'nothing to restore' };
+  }
+  return { label: 'Tracked-file restore', ok: true, detail: `${all.length} target(s)` };
+}
+
+async function stepCloseAgentSession(_opts: CommandOptions): Promise<StepResult> {
+  try {
+    const result = await agentsCommands.commands.close([], { ci: true });
+    if (result.exitCode === 0) {
+      return { label: 'Agent session', ok: true, detail: 'closed in DB' };
+    }
+    return {
+      label: 'Agent session',
+      ok: false,
+      detail: result.output.trim().split('\n')[0]?.slice(0, 200) ?? 'unknown error',
+    };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { label: 'Agent session', ok: false, detail: `error: ${msg}` };
+  }
+}
+
+function stepBranchReset(plan: Plan): StepResult {
+  // Always run the discard pair — even on main this just reverts any session
+  // hook tweaks.
+  const discardOk = execSafe('git checkout -- .') !== null;
+  const cleanOk =
+    execSafe('git clean -fd --exclude=.agent-slot --exclude=.envrc --exclude=.env') !== null;
+
+  if (plan.isMain) {
+    if (!discardOk || !cleanOk) {
+      return { label: 'Branch reset', ok: false, detail: 'on main; discard/clean failed' };
+    }
+    return { label: 'Branch reset', ok: true, detail: 'already on main; cleaned' };
+  }
+
+  // The PreToolUse hook for branch switching is bypassed here because we are
+  // running outside the Bash tool (TS execSync is a child process, not a tool
+  // call). No `AGENT_RESET=1` needed.
+  if (execSafe('git checkout main') === null) {
+    return { label: 'Branch reset', ok: false, detail: `failed to checkout main from ${plan.branch}` };
+  }
+  // Pull latest; on conflict force to origin/main (the slot has no work to keep)
+  if (execSafe('git pull --ff-only origin main', 30000) === null) {
+    execSafe('git reset --hard origin/main');
+  }
+  // Delete the spent feature branch (best-effort — may already be gone)
+  execSafe(`git branch -D "${plan.branch}"`);
+
+  return { label: 'Branch reset', ok: true, detail: `switched main; deleted ${plan.branch}` };
+}
+
+function stepRenameTmux(plan: Plan): StepResult {
+  if (!plan.slot) return { label: 'Tmux rename', ok: true, detail: 'no .agent-slot (skipped)' };
+  if (!process.env.TMUX) return { label: 'Tmux rename', ok: true, detail: 'not in tmux (skipped)' };
+  const target = `A${plan.slot}`;
+  if (execSafe(`tmux rename-window "${target}"`) === null) {
+    return { label: 'Tmux rename', ok: false, detail: `failed to rename to ${target}` };
+  }
+  return { label: 'Tmux rename', ok: true, detail: `renamed to ${target}` };
+}
+
+// ---------------------------------------------------------------------------
+// Main command
+// ---------------------------------------------------------------------------
+
+function planLines(plan: Plan, dirtyMode: DirtyMode): string[] {
+  const out: string[] = [];
+  out.push(`branch:    ${plan.branch}${plan.isMain ? ' (already main — no delete)' : ''}`);
+  out.push(`slot:      ${plan.slot ?? '(none)'}`);
+  out.push(`linear:    ${plan.linearId ?? '(none — skip linear done)'}`);
+  out.push(`pr:        ${plan.prUrl ?? '(none — Linear → Done)'}`);
+  out.push(`dev port:  ${plan.devPort ?? '(none)'}${plan.devPids.length ? ` PIDs ${plan.devPids.join(', ')}` : ''}`);
+  out.push(`patrol:    ${plan.patrolPid ?? '(not running)'}`);
+  out.push(`dirty:     ${dirtyMode}`);
+  return out;
+}
+
+async function agentEndCommand(
+  _args: string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  const log = createLogger(Boolean(options.ci));
+  const c = log.colors;
+  const dirtyMode = parseDirtyMode(options.dirty);
+  const isDryRun = Boolean(options.dryRun);
+
+  const plan = buildPlan(options);
+
+  let output = '';
+  output += `${c.bold}Agent End${c.reset} — ${plan.slot ? `slot ${plan.slot}` : 'no slot marker'}${isDryRun ? ` ${c.dim}(dry-run)${c.reset}` : ''}\n`;
+  output += `${c.dim}${'─'.repeat(50)}${c.reset}\n`;
+
+  // ── 1. Dirty-state gate ────────────────────────────────────────────────
+  const dirty = inspectDirtyState();
+  const hasUnexpectedDirty = dirty.unexpectedFiles.length > 0 || dirty.unpushedCommits > 0;
+  if (hasUnexpectedDirty && dirtyMode !== 'force') {
+    output += `${c.red}✗${c.reset} Dirty state requires attention (--dirty=${dirtyMode}):\n`;
+    if (dirty.unexpectedFiles.length > 0) {
+      output += `  ${c.yellow}Unexpected uncommitted paths:${c.reset}\n`;
+      for (const f of dirty.unexpectedFiles.slice(0, 20)) output += `    ${f}\n`;
+      if (dirty.unexpectedFiles.length > 20) {
+        output += `    ${c.dim}... +${dirty.unexpectedFiles.length - 20} more${c.reset}\n`;
+      }
+    }
+    if (dirty.unpushedCommits > 0) {
+      output += `  ${c.yellow}${dirty.unpushedCommits} unpushed commit(s) on ${plan.branch}${c.reset}\n`;
+    }
+    output += '\n';
+    output += `${c.dim}Options:${c.reset}\n`;
+    output += `  • Commit/push/discard the changes, then re-run.\n`;
+    output += `  • Re-run with ${c.cyan}--dirty=force${c.reset} to discard everything.\n`;
+    return { output, exitCode: 2 };
+  }
+
+  // ── 2. Plan summary ────────────────────────────────────────────────────
+  for (const line of planLines(plan, dirtyMode)) {
+    output += `${c.dim}${line}${c.reset}\n`;
+  }
+  output += '\n';
+
+  // ── 3. Dry-run: print and exit ─────────────────────────────────────────
+  if (isDryRun) {
+    output += `${c.bold}Would execute:${c.reset}\n`;
+    output += `  • agent-checklist complete\n`;
+    output += `  • linear leak-check\n`;
+    if (plan.linearId) {
+      const target = plan.prUrl ? 'In Review' : 'Done';
+      output += `  • linear done ${plan.linearId} → ${target}${plan.prUrl ? ` (PR ${plan.prUrl})` : ''}\n`;
+    } else {
+      output += `  • linear done — skipped (no Linear ID)\n`;
+    }
+    output += `  • pr-patrol stop ${plan.patrolPid ? `(PID ${plan.patrolPid})` : '(not running)'}\n`;
+    if (plan.devPort) {
+      output += `  • kill dev server on port ${plan.devPort} ${plan.devPids.length ? `(PIDs: ${plan.devPids.join(', ')})` : '(no listener)'}\n`;
+    } else {
+      output += `  • dev server — no DEV_PORT in .env\n`;
+    }
+    output += `  • rm .claude/wip-checklist.md, .claude/wip-context.md\n`;
+    output += `  • git checkout -- .claude/review-done .claude/review-phases-done .claude/simplify-done .claude/hooks/\n`;
+    output += `  • agents close (DB session)\n`;
+    if (plan.isMain) {
+      output += `  • git checkout -- . && git clean -fd (already on main)\n`;
+    } else {
+      output += `  • git checkout -- . && git clean -fd && git checkout main && git pull && git branch -D ${plan.branch}\n`;
+    }
+    if (plan.slot) {
+      output += `  • tmux rename-window A${plan.slot}\n`;
+    }
+    output += `\n${c.dim}Re-run without --dry-run to execute.${c.reset}\n`;
+    return { output, exitCode: 0 };
+  }
+
+  // ── 4. Execute steps in order ──────────────────────────────────────────
+  const steps: StepResult[] = [];
+
+  steps.push(await stepCompleteChecklist(options));
+  steps.push(await stepLeakCheck(options));
+  steps.push(await stepLinearDone(plan));
+  steps.push(await stepPatrolStop(options));
+  steps.push(stepKillDevServer(plan));
+  steps.push(stepCleanWipArtifacts());
+  steps.push(stepRestoreTrackedFiles());
+  steps.push(await stepCloseAgentSession(options));
+  steps.push(stepBranchReset(plan));
+  steps.push(stepRenameTmux(plan));
+
+  for (const s of steps) {
+    const icon = s.ok ? `${c.green}✓${c.reset}` : `${c.red}✗${c.reset}`;
+    output += `${icon} ${s.label.padEnd(22)} ${c.dim}${s.detail}${c.reset}\n`;
+  }
+  output += '\n';
+
+  const failed = steps.filter((s) => !s.ok).length;
+  if (failed > 0) {
+    output += `${c.yellow}⚠ ${failed} step(s) reported errors — review above.${c.reset}\n`;
+  } else {
+    output += `${c.green}Done.${c.reset} Run ${c.cyan}/clear${c.reset} then ${c.cyan}/rename${c.reset} to finish handoff.\n`;
+  }
+
+  return { output, exitCode: failed > 0 ? 1 : 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const commands: Record<string, (args: string[], options: CommandOptions) => Promise<CommandResult>> = {
+  default: agentEndCommand,
+};
+
+export function getHelp(): string {
+  return `
+Agent End — Close out a session and reset the slot back to clean main
+
+Bundles the mechanical plumbing that /agent-end used to orchestrate step by
+step (Linear close, dev-server kill, wip cleanup, branch reset, tmux rename).
+Run this at session end when no PR is being shipped.
+
+Usage:
+  crux sys agent-end                    Close & reset (defaults)
+  crux sys agent-end --pr=URL           Pass PR URL to Linear \`done\`
+  crux sys agent-end --dirty=force      Discard unexpected dirty state
+  crux sys agent-end --dirty=ask        Bail with details (LLM triages)
+  crux sys agent-end --dry-run          Print actions, take none
+
+Options:
+  --pr=URL           PR URL to attach to the Linear done comment.
+                     With a PR: Linear → In Review.
+                     Without:   Linear → Done.
+  --dirty=MODE       fail (default) | ask | force.
+                     fail/ask: bail (exit 2) on unexpected dirty paths or
+                              unpushed commits, listing each so the operator
+                              can commit/push/discard and re-run.
+                     force:   discard everything (current behavior of the
+                              old skill body).
+  --dry-run          Print the actions that would be taken, exit 0.
+  --ci               Plain (no-color) output.
+
+What runs (in order):
+  1. agent-checklist complete           Mark checklist done in DB (best-effort)
+  2. linear leak-check                  Scan for stray QUA refs (advisory)
+  3. linear done QUA-NNN [--pr=URL]     QUA ID auto-resolved from checklist or branch
+  4. pr-patrol stop                     Halt patrol daemon if running
+  5. kill dev server on $DEV_PORT       Uses lsof -sTCP:LISTEN (port-scoped)
+  6. rm .claude/wip-{checklist,context}.md
+  7. git checkout -- .claude/review-done .claude/review-phases-done .claude/simplify-done .claude/hooks/
+  8. agents close                       Close active agent + session row in DB
+  9. git checkout main; pull --ff-only; git branch -D <feature>
+  10. tmux rename-window A<slot>
+
+Exit codes:
+  0  All steps passed (or dry-run).
+  1  At least one step reported an error — review the output.
+  2  Bail before running any step (dirty state with --dirty=fail|ask).
+
+Examples:
+  crux sys agent-end --dry-run
+  crux sys agent-end --pr=https://github.com/quantified-uncertainty/longterm-wiki/pull/4855
+  crux sys agent-end --dirty=force
+`;
+}

--- a/crux/commands/agent-end.ts
+++ b/crux/commands/agent-end.ts
@@ -718,7 +718,7 @@ What runs (in order):
 Exit codes:
   0  All steps passed (or dry-run).
   1  At least one step reported an error — review the output.
-  2  Bail before running any step (dirty state with --dirty=fail).
+  2  Bail before running any step (dirty state with --dirty=fail, or detached/unreadable HEAD).
 
 Examples:
   crux sys agent-end --dry-run

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -133,6 +133,7 @@ import * as scorecardsCommands from './commands/scorecards.ts';
 import * as branchesCommands from './commands/branches.ts';
 import * as deployTasksCommands from './commands/deploy-tasks.ts';
 import * as agentResetCommands from './commands/agent-reset.ts';
+import * as agentEndCommands from './commands/agent-end.ts';
 import * as costCommands from './commands/cost.ts';
 import * as benchmarksCommands from './commands/benchmarks.ts';
 import * as usagePatternsCommands from './commands/usage-patterns.ts';
@@ -245,6 +246,7 @@ const domains = {
   branches: branchesCommands,
   'deploy-tasks': deployTasksCommands,
   'agent-reset': agentResetCommands,
+  'agent-end': agentEndCommands,
   cost: costCommands,
   benchmarks: benchmarksCommands,
   'usage-patterns': usagePatternsCommands,

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -143,6 +143,7 @@ export const GROUPS: Record<string, GroupDef> = {
       'wiki-server',
       'quality',
       'agent-reset',
+      'agent-end',
       'cost',
       'usage-patterns',
       'session-finalize',

--- a/docs/agent-workflows/agent-end.md
+++ b/docs/agent-workflows/agent-end.md
@@ -200,7 +200,15 @@ git clean -fd --exclude=.agent-slot --exclude=.envrc --exclude=.env
 
 if [ "$BRANCH" != "main" ]; then
   git checkout main
-  git pull --ff-only origin main || git reset --hard origin/main
+  git fetch origin
+  AHEAD=$(git rev-list --count origin/main..main 2>/dev/null || echo 0)
+  if [ "$AHEAD" -ne 0 ]; then
+    echo "REFUSED: local main has $AHEAD commit(s) not in origin/main."
+    echo "Resolve (push, rebase, or explicitly discard) before re-running."
+    echo "Prefer 'pnpm crux sys agent-end' — it applies this same guard automatically."
+    exit 1
+  fi
+  git pull --ff-only origin main
   git branch -D "$BRANCH" 2>/dev/null || true
 fi
 ```

--- a/docs/agent-workflows/agent-end.md
+++ b/docs/agent-workflows/agent-end.md
@@ -9,12 +9,16 @@ This is the canonical cross-agent close-out workflow. Tool-specific slash
 commands or skills should stay thin and point here.
 
 > **Fast path:** `pnpm crux sys agent-end` (added in QUA-1090) executes
-> Steps 1–9 below in one Node process — no LLM round-tripping required. Use
-> that as the default; fall back to running the steps by hand only when
-> pnpm is unavailable, when debugging a single step, or when the
-> consolidated command's `--dirty=fail` gate refuses to proceed and you
-> need to triage a specific path. See `pnpm crux sys agent-end --help` for
-> the action list and `--dry-run` to preview without side effects.
+> the automated close-out steps below — checklist complete, Linear close,
+> patrol stop, dev-server kill, wip cleanup, agents close, branch reset,
+> tmux rename — in one Node process, with no LLM round-tripping. Step 4
+> (legacy GitHub issue cleanup) is **not** automated and remains manual
+> for the rare sessions tied to a legacy GitHub issue. Use the fast path
+> as the default; fall back to running steps by hand only when pnpm is
+> unavailable, when debugging a single step, or when the consolidated
+> command's `--dirty=fail` gate refuses to proceed and you need to triage
+> a specific path. See `pnpm crux sys agent-end --help` for the action
+> list and `--dry-run` to preview without side effects.
 
 ## 0. Choose the Right Workflow
 

--- a/docs/agent-workflows/agent-end.md
+++ b/docs/agent-workflows/agent-end.md
@@ -8,6 +8,14 @@ For sessions that ship code through a PR, use the
 This is the canonical cross-agent close-out workflow. Tool-specific slash
 commands or skills should stay thin and point here.
 
+> **Fast path:** `pnpm crux sys agent-end` (added in QUA-1090) executes
+> Steps 1–9 below in one Node process — no LLM round-tripping required. Use
+> that as the default; fall back to running the steps by hand only when
+> pnpm is unavailable, when debugging a single step, or when the
+> consolidated command's `--dirty=fail` gate refuses to proceed and you
+> need to triage a specific path. See `pnpm crux sys agent-end --help` for
+> the action list and `--dry-run` to preview without side effects.
+
 ## 0. Choose the Right Workflow
 
 | Scenario | Use |


### PR DESCRIPTION
## Summary

Reduces `/agent-end` from ~189 lines of LLM-orchestrated bash to ~25 lines that just call `pnpm crux sys agent-end`. The TS command bundles every mechanical step (Linear close, dev-server kill, branch reset, tmux rename, etc.) so a real session-close runs in ≤2 LLM round-trips instead of the previous ~10.

Same cost-cutting pattern as QUA-1051 (rules trimming) and QUA-961 (review-pr phase pruning).

## Architecture

This PR is complementary to PR #4865 (shared cross-runtime workflow doc):

- `docs/agent-workflows/agent-end.md` — cross-runtime contract (Claude/Codex/etc.)
- `crux sys agent-end` — TS implementation that runs every step in one Node process
- `.claude/commands/agent-end.md` — thin skill that prefers the consolidated command, falls back to the shared doc

## Flags

- `--pr=URL` — passed to Linear `done` (Linear → In Review with PR, Done without)
- `--dirty=fail|force` — defaults to `fail`. Bails with exit 2 on unexpected dirty paths or unpushed commits, listing each so the operator can commit/push/discard and re-run. `force` discards everything (matches the old skill's behaviour).
- `--dry-run` — print the action plan, exit 0 with no side effects.

## What runs (in order)

1. `agent-checklist complete` — mark checklist done in DB (best-effort)
2. `linear leak-check` — scan for stray QUA refs (advisory)
3. `linear done QUA-NNN [--pr=URL]` — QUA ID auto-resolved from `> Linear:` line in checklist or `claude/qua-NNN-*` branch (uses team-key allowlist from `crux/lib/linear/parse-id.ts`)
4. `pr-patrol stop`
5. Kill dev server on `$DEV_PORT` (uses `lsof -sTCP:LISTEN` per `feedback_kill_port_safely.md`)
6. `rm .claude/wip-{checklist,context}.md`
7. Restore review markers + `git checkout -- .claude/hooks/`
8. `agents close` (DB session row)
9. Branch reset: `git checkout main`, fetch, **refuse if local main has commits not in origin** (data-loss guard caught in review), pull `--ff-only`, delete feature branch
10. `tmux rename-window A<slot>`

Steps 1–8 run in `Promise.all` (saves 1–2s per session-end since 4 of them hit the wiki-server). Steps 9–10 run sequentially.

## Reuse of existing helpers

- `gitSafe` from `crux/lib/git.ts` for all git calls (execFileSync, no shell, injection-safe by construction)
- `parseLinearId` / `resolveLinearId` from `crux/lib/linear/parse-id.ts` (team-key allowlist)
- `findSlotFromAncestors` from `crux/lib/session/session-context.ts` (canonical slot detection)

## Tests

31 unit tests covering pure helpers (parseDirtyMode, resolveLinearId, readDevPort, readSlotNumber, inspectDirtyState, findPortListeners), the dirty-state gate (fail/force, rename-row porcelain), the dry-run smoke (asserts no side-effect command runs), and the destructive execution path including the new local-main safety guard.

## Test plan

- [x] `npx vitest run crux/commands/agent-end.test.ts` — 31/31 pass
- [x] `pnpm crux w validate gate --scope=content` — 3/3 pass
- [x] `pnpm crux sys agent-end --dry-run` printed correct plan from this slot
- [x] `pnpm crux sys agent-end --help` text accurate
- [x] Hostile review pass: 4 real issues found and fixed (silent local-main data loss, broken rename detection, missing tests, misnamed step)
- [x] Three-agent simplify pass: applied reuse + parallelism + delegate-extraction
- [ ] Real `/agent-end` run on a slot after merge — observe ≤2 LLM round-trips per acceptance criteria

Closes QUA-1090


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an agent-end command (pnpm crux sys agent-end) to streamline session closeout with dry-run preview, PR URL support, exit-code signals, and explicit end-of-workflow steps (including Claude-specific /clear and /rename).

* **Documentation**
  * Added a "Fast path" workflow, troubleshooting guidance for dirty git states, and fallback steps for environments without pnpm.

* **Tests**
  * Added comprehensive tests covering dry-run and real execution flows, dirty-state gating, and cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->