### PR TITLE
auto: backfill source URLs (8 matches)

### DIFF
--- a/packages/factbase/data/fb-entities/connor-leahy.yaml
+++ b/packages/factbase/data/fb-entities/connor-leahy.yaml
@@ -4,11 +4,12 @@ facts:
     property: born-year
     value: 1998
     notes: "Born approximately 1998; grew up in Germany"
+    source: https://radaris.com/p/Connor/Leahy
 
   - id: f_cL1aB2cD3e
     property: notable-for
-    value: "CEO of Conjecture; co-founder of EleutherAI; prominent AI safety
-      advocate; testified before UK Parliament and EU on AI risks"
+    value: "CEO of Conjecture; co-founder of EleutherAI; prominent AI safety advocate; testified before UK Parliament and EU
+      on AI risks"
     source: https://en.wikipedia.org/wiki/Connor_Leahy
 
   - id: f_cL4fG5hI6j

--- a/packages/factbase/data/fb-entities/connor-leahy.yaml
+++ b/packages/factbase/data/fb-entities/connor-leahy.yaml
@@ -3,7 +3,7 @@ facts:
   - id: f_2HGntp6Jt1
     property: born-year
     value: 1998
-    notes: "Born approximately 1998; grew up in Germany"
+    notes: "Born approximately 1998; grew up in Germany; [auto-discovered by tb backfill-sources]"
     source: https://radaris.com/p/Connor/Leahy
 
   - id: f_cL1aB2cD3e

--- a/packages/factbase/data/fb-entities/mira-murati.yaml
+++ b/packages/factbase/data/fb-entities/mira-murati.yaml
@@ -7,12 +7,17 @@ facts:
   - id: f_f3XKVPdewA
     property: notable-for
     value: "Former CTO of OpenAI; led development of ChatGPT, DALL-E, and GPT-4; now building a new AI company"
+    source: https://businessinsider.com/mira-murati-openai-startup-2025-4
+    notes: "[auto-discovered by tb backfill-sources]"
 
   - id: f_ekVZn67U9A
     property: education
     value: "BS in Mechanical Engineering, Dartmouth College"
+    source: https://albaniandailynews.com/news/meet-mira-murati-the-36-year-old-tech-prodigy-who-shot-to-fame-at-openai-and-now-runs-a-startup-that-s-a-poaching-target-for-zuckerberg
+    notes: "[auto-discovered by tb backfill-sources]"
 
   - id: f_vatTbYjtnQ
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Mira_Murati"
-
+    source: https://en.wikipedia.org/wiki/Mira_Murati
+    notes: "[auto-discovered by tb backfill-sources]"

--- a/packages/factbase/data/fb-entities/ozzie-gooen.yaml
+++ b/packages/factbase/data/fb-entities/ozzie-gooen.yaml
@@ -3,10 +3,9 @@ facts:
   - id: f_OG1descr01
     property: description
     value: >-
-      Founder and Executive Director of QURI (Quantified Uncertainty Research
-      Institute). Created Guesstimate (2016) and leads development of Squiggle,
-      a probabilistic programming language for estimation. Previously worked at
-      the Future of Humanity Institute at Oxford.
+      Founder and Executive Director of QURI (Quantified Uncertainty Research Institute). Created Guesstimate (2016) and
+      leads development of Squiggle, a probabilistic programming language for estimation. Previously worked at the
+      Future of Humanity Institute at Oxford.
     asOf: !date 2026-03
   - id: f_OG4educa01
     property: education
@@ -16,7 +15,11 @@ facts:
     property: notable-for
     value: "Founded QURI; created Guesstimate (2016); leads Squiggle development; FHI background"
     asOf: !date 2026-03
+    source: https://mutualunderstanding.substack.com/p/ozzie-gooen
+    notes: "[auto-discovered by tb backfill-sources]"
 
   - id: f_OG6githb01
     property: github-profile
     value: "https://github.com/OAGr"
+    source: https://github.com/OAGr
+    notes: "[auto-discovered by tb backfill-sources]"


### PR DESCRIPTION
## Summary

Auto-generated PR mirroring source-URL writes from `crux tb backfill-sources` into YAML so the next sync from YAML → PG does not wipe them.

- Matched records this run: **8**
- `facts` YAML writes:        **3**
- `policy_stakeholders` writes: **0**
- YAML files touched:        **3**

## Test plan
- [ ] CI green
- [ ] Spot-check a few changed YAMLs for sane `source:` values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added source URLs to multiple facts across entity profiles (birth years, notable achievements, education, and professional links).
  * Appended auto-discovery notes to fact metadata to indicate origin and discovery method.
  * Reformatted fact text for improved consistency and readability while preserving original content and meaning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4883)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->