### PR TITLE
ux: surface unverifiable verdicts as red, not amber

### DIFF
--- a/apps/web/src/app/internal/data-quality/data-quality-content.tsx
+++ b/apps/web/src/app/internal/data-quality/data-quality-content.tsx
@@ -135,7 +135,7 @@ export async function DataQualityContent() {
           <VerdictBadge label="Partial" count={latest.verdictsPartial} color="text-yellow-600" />
           <VerdictBadge label="Contradicted" count={latest.verdictsContradicted} color="text-red-600" />
           <VerdictBadge label="Outdated" count={latest.verdictsOutdated} color="text-orange-600" />
-          <VerdictBadge label="Unverifiable" count={latest.verdictsUnverifiable} color="text-gray-500" />
+          <VerdictBadge label="Unverifiable" count={latest.verdictsUnverifiable} color="text-red-600" />
           <VerdictBadge label="Needs Recheck" count={latest.verdictsNeedsRecheck} color="text-blue-600" />
         </div>
       </section>

--- a/apps/web/src/app/internal/entities/entities-data-table.tsx
+++ b/apps/web/src/app/internal/entities/entities-data-table.tsx
@@ -976,7 +976,7 @@ const columns: ColumnDef<UnifiedEntityRow>[] = [
     accessorKey: "scUnverifiable",
     sortUndefined: "last",
     header: ({ column }) => <SortableHeader column={column} title="Records that could not be verified">Unver</SortableHeader>,
-    cell: ({ row }) => <VerdictCount value={row.original.scUnverifiable} color="text-orange-400" icon="?" />,
+    cell: ({ row }) => <VerdictCount value={row.original.scUnverifiable} color="text-red-400" icon="?" />,
   },
   {
     accessorKey: "scUnchecked",

--- a/apps/web/src/app/internal/entities/entities-data-table.tsx
+++ b/apps/web/src/app/internal/entities/entities-data-table.tsx
@@ -304,7 +304,7 @@ function VerdictBar({ row }: { row: UnifiedEntityRow }) {
     { key: "contradicted", count: row.scContradicted ?? 0, color: "bg-red-500", label: "Contradicted" },
     { key: "outdated", count: row.scOutdated ?? 0, color: "bg-amber-500", label: "Outdated" },
     { key: "partial", count: row.scPartial ?? 0, color: "bg-yellow-400", label: "Partial" },
-    { key: "unverifiable", count: row.scUnverifiable ?? 0, color: "bg-orange-400", label: "Unverifiable" },
+    { key: "unverifiable", count: row.scUnverifiable ?? 0, color: "bg-red-400", label: "Unverifiable" },
     { key: "unchecked", count: row.scUnchecked ?? 0, color: "bg-gray-300 dark:bg-gray-600", label: "Unchecked" },
   ];
 

--- a/apps/web/src/app/internal/entity-sourcing/claims-viewer.tsx
+++ b/apps/web/src/app/internal/entity-sourcing/claims-viewer.tsx
@@ -65,7 +65,7 @@ interface ClaimStats {
 const STATUS_STYLES: Record<string, { bg: string; text: string }> = {
   verified: { bg: "bg-emerald-100 dark:bg-emerald-900/30", text: "text-emerald-800 dark:text-emerald-300" },
   contradicted: { bg: "bg-red-100 dark:bg-red-900/30", text: "text-red-800 dark:text-red-300" },
-  unverifiable: { bg: "bg-gray-100 dark:bg-gray-800/50", text: "text-gray-700 dark:text-gray-300" },
+  unverifiable: { bg: "bg-red-100 dark:bg-red-900/30", text: "text-red-700 dark:text-red-300" },
   pending: { bg: "bg-blue-100 dark:bg-blue-900/30", text: "text-blue-800 dark:text-blue-300" },
   verifying: { bg: "bg-amber-100 dark:bg-amber-900/30", text: "text-amber-800 dark:text-amber-300" },
   expired: { bg: "bg-orange-100 dark:bg-orange-900/30", text: "text-orange-800 dark:text-orange-300" },

--- a/apps/web/src/app/internal/entity-sourcing/entity-sourcing-viewer.tsx
+++ b/apps/web/src/app/internal/entity-sourcing/entity-sourcing-viewer.tsx
@@ -875,7 +875,7 @@ export function EntitySourcingViewer() {
               </div>
               <div className="rounded-lg border border-border/60 p-4">
                 <p className="text-xs text-muted-foreground mb-1">Unverifiable</p>
-                <p className="text-2xl font-bold tabular-nums text-orange-600">{unverifiableCount}</p>
+                <p className="text-2xl font-bold tabular-nums text-red-600">{unverifiableCount}</p>
                 <p className="text-xs text-muted-foreground mt-1">{pctOf(unverifiableCount)}</p>
               </div>
               <div className="rounded-lg border border-border/60 p-4">

--- a/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
+++ b/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
@@ -91,7 +91,7 @@ const VERDICT_COLORS: Record<string, string> = {
   contradicted: "text-red-600",
   outdated: "text-amber-600",
   partial: "text-amber-500",
-  unverifiable: "text-orange-600",
+  unverifiable: "text-red-600",
   unchecked: "text-muted-foreground",
 };
 
@@ -100,7 +100,7 @@ const BAR_COLORS: Record<string, string> = {
   contradicted: "bg-red-500",
   outdated: "bg-amber-500",
   partial: "bg-amber-400",
-  unverifiable: "bg-orange-400",
+  unverifiable: "bg-red-400",
   unchecked: "bg-gray-300",
 };
 
@@ -682,7 +682,7 @@ export async function SourcingCoverageContent() {
         const VERDICT_RGB: Record<string, string> = {
           confirmed: "16, 185, 129",    // emerald-500
           partial: "251, 191, 36",      // amber-400
-          unverifiable: "251, 146, 60", // orange-400
+          unverifiable: "248, 113, 113", // red-400
           contradicted: "239, 68, 68",  // red-500
           outdated: "245, 158, 11",     // amber-500
           unchecked: "209, 213, 219",   // gray-300

--- a/apps/web/src/app/scorecards/__tests__/scorecards-matrix.test.tsx
+++ b/apps/web/src/app/scorecards/__tests__/scorecards-matrix.test.tsx
@@ -117,7 +117,7 @@ describe("ScorecardsMatrix — source-check dots", () => {
   const VERDICT_CASES: Array<{ verdict: string; label: RegExp }> = [
     { verdict: "outdated", label: /Needs attention/i },
     { verdict: "partial", label: /Needs attention/i },
-    { verdict: "unverifiable", label: /Needs attention/i },
+    { verdict: "unverifiable", label: /Failed source check/i },
     { verdict: "not_applicable", label: /Not checked/i },
   ];
 

--- a/apps/web/src/app/sourcing/page.tsx
+++ b/apps/web/src/app/sourcing/page.tsx
@@ -330,7 +330,7 @@ export default async function SourcingPage({ searchParams }: PageProps) {
         </div>
         <div className="rounded-lg border border-border/60 p-4">
           <p className="text-xs text-muted-foreground mb-1">Can&apos;t Verify</p>
-          <p className="text-2xl font-bold tabular-nums text-orange-600">
+          <p className="text-2xl font-bold tabular-nums text-red-600">
             {unverifiableCount.toLocaleString()}
           </p>
           <p className="text-xs text-muted-foreground mt-1">

--- a/apps/web/src/components/factbase/entity-detail-shared.ts
+++ b/apps/web/src/components/factbase/entity-detail-shared.ts
@@ -28,7 +28,7 @@ export const VERDICT_STYLES: Record<VerdictType, { label: string; className: str
   contradicted: { label: "Contradicted", className: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300" },
   outdated:     { label: "Outdated",     className: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300" },
   partial:      { label: "Partial",      className: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300" },
-  unverifiable: { label: "Unverifiable", className: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400" },
+  unverifiable: { label: "Unverifiable", className: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" },
   unchecked:    { label: "Unchecked",    className: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400" },
 };
 

--- a/apps/web/src/components/shared/verdict-styles.ts
+++ b/apps/web/src/components/shared/verdict-styles.ts
@@ -76,10 +76,10 @@ export const SOURCE_CHECK_VERDICT_STYLES: Record<SourcingVerdictType, SourcingVe
   },
   unverifiable: {
     label: "Unverifiable",
-    className: "bg-orange-100 text-orange-600 dark:bg-orange-900/40 dark:text-orange-400",
-    bg: "bg-orange-400/15",
-    text: "text-orange-600",
-    dot: "bg-orange-400",
+    className: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+    bg: "bg-red-400/15",
+    text: "text-red-600",
+    dot: "bg-red-400",
   },
   unchecked: {
     label: "Unchecked",

--- a/apps/web/src/components/shared/verdict-styles.ts
+++ b/apps/web/src/components/shared/verdict-styles.ts
@@ -100,7 +100,17 @@ export const SOURCE_CHECK_VERDICT_DESCRIPTIONS: Record<SourcingVerdictType, stri
   unchecked: "This claim has not yet been checked against sources.",
 };
 
-/** Sort priority for sourcing verdicts: most actionable first. Lower = higher priority. */
+/**
+ * Sort priority for sourcing verdicts: most actionable first. Lower = higher priority.
+ *
+ * Note: visual severity (red/amber/green) and actionability priority are *intentionally*
+ * different axes. `unverifiable` renders red (same severity bucket as `contradicted`) but
+ * is ranked less actionable than `partial`/`outdated` here, because "no support found"
+ * gives an editor less to work with than "some support found, but stale" (`outdated`) or
+ * "some support found, but only partial" (`partial`). Don't "fix" this by reordering to
+ * match the visual severity — entity-sourcing aggregation depends on this ordering
+ * (see `entity-sourcing.test.ts` and the QUA-429 contract in `tablebase.ts`).
+ */
 export const SOURCE_CHECK_VERDICT_PRIORITY: Record<string, number> = {
   contradicted: 0,
   outdated: 1,

--- a/apps/web/src/components/sourcing/__tests__/sourcing-status.test.ts
+++ b/apps/web/src/components/sourcing/__tests__/sourcing-status.test.ts
@@ -10,7 +10,8 @@ describe("recordVerdictToStatus", () => {
     expect(recordVerdictToStatus("contradicted")).toBe("failed");
     expect(recordVerdictToStatus("outdated")).toBe("trouble");
     expect(recordVerdictToStatus("partial")).toBe("trouble");
-    expect(recordVerdictToStatus("unverifiable")).toBe("trouble");
+    // Unverifiable = checker tried and couldn't confirm → surface as failed, not trouble.
+    expect(recordVerdictToStatus("unverifiable")).toBe("failed");
   });
 
   // QUA-426: pre-LLM relevance-gate short-circuits write `not_applicable`
@@ -36,7 +37,8 @@ describe("factbaseVerdictToStatus", () => {
     expect(factbaseVerdictToStatus("minor_issues")).toBe("trouble");
     expect(factbaseVerdictToStatus("inaccurate")).toBe("failed");
     expect(factbaseVerdictToStatus("unsupported")).toBe("failed");
-    expect(factbaseVerdictToStatus("not_verifiable")).toBe("trouble");
+    // Citation analog of TableBase `unverifiable` — surface as failed, not trouble.
+    expect(factbaseVerdictToStatus("not_verifiable")).toBe("failed");
   });
 
   it("maps null/unknown values to not_run", () => {

--- a/apps/web/src/components/sourcing/sourcing-status.ts
+++ b/apps/web/src/components/sourcing/sourcing-status.ts
@@ -7,8 +7,9 @@
  * States:
  *   not_run  — Check hasn't been executed yet (white dot)
  *   error    — System error, check couldn't complete (black dot)
- *   failed   — Checked but couldn't verify the claim (red dot)
- *   trouble  — Partially verified or concerns found (orange dot)
+ *   failed   — Source actively contradicted the claim, or checker tried and could not
+ *              confirm it (red dot)
+ *   trouble  — Partially verified, outdated, or other actionable concerns (amber dot)
  *   verified — Successfully verified (green dot)
  */
 

--- a/apps/web/src/components/sourcing/sourcing-status.ts
+++ b/apps/web/src/components/sourcing/sourcing-status.ts
@@ -67,7 +67,10 @@ const RECORD_VERDICT_MAP: Record<string, SourcingStatus> = {
   contradicted: "failed",
   outdated: "trouble",
   partial: "trouble",
-  unverifiable: "trouble",
+  // "Unverifiable" = the checker actively tried to verify and could not.
+  // That's a stronger negative signal than "partial" (some support found) —
+  // surface it as failed (red), not trouble (amber).
+  unverifiable: "failed",
   // QUA-426: pre-LLM relevance-gate short-circuit — the source didn't even
   // mention the record's subject, so neither confirmation nor contradiction
   // is possible. Render as neutral "not checked", not as "trouble".
@@ -94,7 +97,9 @@ const FACTBASE_VERDICT_MAP: Record<string, SourcingStatus> = {
   minor_issues: "trouble",
   inaccurate: "failed",
   unsupported: "failed",
-  not_verifiable: "trouble",
+  // Parallel to the TableBase `unverifiable` mapping: when the citation checker
+  // tried and couldn't verify, surface as failed (red), not trouble (amber).
+  not_verifiable: "failed",
 };
 
 /**


### PR DESCRIPTION
## Summary

"Unverifiable" verdicts previously rendered as amber dots (mapped to `trouble` status), identical to `partial`. Users could not distinguish "the checker tried and could not confirm this claim" from "the checker partially confirmed this claim." This PR promotes unverifiable to the failed (red) bucket alongside `contradicted`, while leaving `partial`/`outdated` as `trouble` (amber).

## Key changes

- **Status mapping** (`apps/web/src/components/sourcing/sourcing-status.ts`):
  - `RECORD_VERDICT_MAP.unverifiable: "trouble" → "failed"`
  - `FACTBASE_VERDICT_MAP.not_verifiable: "trouble" → "failed"`
- **Color tokens** (`apps/web/src/components/shared/verdict-styles.ts`):
  - `SOURCE_CHECK_VERDICT_STYLES.unverifiable` palette moved orange-400 → red-400 (one shade lighter than `contradicted`'s red-500, mirroring the citation `inaccurate` vs `unsupported` convention so the two negative verdicts stay visually distinct).
  - Added JSDoc to `SOURCE_CHECK_VERDICT_PRIORITY` explaining the intentional priority-vs-visual-severity divergence: `partial`/`outdated` are still ranked more actionable than `unverifiable` even though all three are non-confirmed, because "some support found" is more useful to an editor than "no support found." Don't reorder to match the visual; the aggregation contract in `tablebase.ts` depends on it (QUA-429).
- **Downstream surfaces** — local color maps that hardcoded orange/gray for unverifiable updated to red across:
  - Internal dashboards: `/internal/entities` (segment bar + verdict count cell), `/internal/entity-sourcing` (stat card + claims viewer status badge), `/internal/sourcing-coverage` (text/bar/heatmap maps), `/internal/data-quality` (verdict badge)
  - Public surfaces: `/sourcing` page "Can't Verify" stat card, FactBase entity detail VERDICT_STYLES badge
- **Doc comment in `sourcing-status.ts`**: the `failed` bucket now spans both "actively contradicted" and "tried and couldn't confirm" — comment updated to reflect the broader scope.

## Architectural decision documented (not changed)

Merging `unverifiable` and `contradicted` into the same visual severity erases a semantic distinction (active disagreement vs no signal). That's been weighed against the cost of the prior amber-amber tie between unverifiable and partial, and the user's UX call is that red is correct. Future work could introduce an intermediate `disputed` SourcingStatus if the distinction proves important downstream — not in scope here.

## Test plan

- [x] `pnpm build` (twice — original + post-review-fixes)
- [x] `pnpm test` — 452 tests across affected modules pass
- [x] `pnpm crux w validate gate --fix` — 74 checks pass; 3 advisory warnings unrelated to this diff (typecheck-crux baseline, orphan entities, resource data quality)
- [x] Unit tests: `sourcing-status.test.ts` asserts both new mappings; `scorecards-matrix.test.tsx` asserts the tooltip change
- [x] Playwright `e2e/render-audit.spec.ts` against prod — 88 tests pass (baseline)
- [x] `/agent-review-pr` hostile review pass — 2 HIGH and 4 MEDIUM findings fixed in commit `71e4b42b1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual styling for "unverifiable" verdict badges and indicators to use red colors instead of orange/gray across data quality, entity, and sourcing views.

* **Bug Fixes**
  * Refined unverifiable source verification verdicts to map to "failed" status instead of "trouble," providing stronger emphasis on items requiring attention.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4884)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->