### PR TITLE
qua-1125: frontier AI labs comparison table

### DIFF
--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -38,6 +38,7 @@ import ArchitectureScenariosTableView from "@/components/tables/views/Architectu
 import DeploymentArchitecturesTableView from "@/components/tables/views/DeploymentArchitecturesTableView";
 import SafetyGeneralizabilityTableView from "@/components/tables/views/SafetyGeneralizabilityTableView";
 import AGIBottlenecksTableView from "@/components/tables/views/AGIBottlenecksTableView";
+import FrontierLabsTableView from "@/components/tables/views/FrontierLabsTableView";
 
 // Summary components
 import { KeyTakeaways } from "@/components/wiki/KeyTakeaways";
@@ -270,6 +271,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   DeploymentArchitecturesTableView,
   SafetyGeneralizabilityTableView,
   AGIBottlenecksTableView,
+  FrontierLabsTableView,
 
   // Starlight card components
   Card: StarlightCard,

--- a/apps/web/src/components/tables/frontier-labs-columns.tsx
+++ b/apps/web/src/components/tables/frontier-labs-columns.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { SortableHeader } from "@/components/ui/sortable-header";
+import { CellNote, LevelBadge } from "./shared/cell-components";
+import { getLevelSortValue } from "./shared/table-view-styles";
+import type { FrontierLab, LabLink } from "@data/tables/frontier-labs";
+import { levelNoteColumn } from "./shared/column-helpers";
+
+export type { FrontierLab } from "@data/tables/frontier-labs";
+
+function NameCell({ lab }: { lab: FrontierLab }) {
+  const href = lab.entityId ? `/wiki/${lab.entityId}` : undefined;
+  return (
+    <div className="min-w-[180px]">
+      <div className="font-semibold text-[13px] text-foreground">
+        {href ? (
+          <a href={href} className="hover:underline">
+            {lab.name}
+          </a>
+        ) : (
+          lab.name
+        )}
+      </div>
+      <div className="text-[11px] text-muted-foreground mt-1 line-clamp-2 max-w-[240px]">
+        {lab.description}
+      </div>
+    </div>
+  );
+}
+
+function SignalsCell({ signals }: { signals: string[] }) {
+  return (
+    <ul className="text-[10px] text-foreground space-y-0.5 list-disc list-inside">
+      {signals.slice(0, 4).map((s, i) => (
+        <li key={i} className="leading-snug">
+          {s}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function LinksCell({ links }: { links: LabLink[] }) {
+  if (links.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-0.5">
+      {links.slice(0, 3).map((l) => (
+        <a
+          key={l.url}
+          href={l.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[10px] text-primary hover:underline truncate max-w-[160px]"
+        >
+          {l.label}
+        </a>
+      ))}
+    </div>
+  );
+}
+
+function CapabilityTierCell({ row }: { row: { original: FrontierLab } }) {
+  const lab = row.original;
+  return (
+    <div>
+      <LevelBadge level={lab.capabilityTier.level} />
+      <CellNote note={lab.capabilityTier.note} />
+    </div>
+  );
+}
+
+// Map non-standard tier strings into colors via getLevelSortValue's existing levels.
+// FRONTIER → high; NEAR-FRONTIER → medium; SPECIALIZED → low-medium; DEFUNCT → none.
+function capabilityTierSortValue(tier: string): number {
+  const t = tier.toLowerCase();
+  if (t === "frontier") return 4;
+  if (t === "near-frontier") return 3;
+  if (t === "specialized") return 2;
+  if (t === "defunct") return 0;
+  return 1;
+}
+
+export const createFrontierLabsColumns = (): ColumnDef<FrontierLab>[] => [
+  {
+    accessorKey: "name",
+    header: ({ column }) => <SortableHeader column={column}>Lab</SortableHeader>,
+    cell: ({ row }) => <NameCell lab={row.original} />,
+    enablePinning: true,
+  },
+  {
+    id: "capabilityTier",
+    accessorFn: (row) => row.capabilityTier.level,
+    header: ({ column }) => (
+      <SortableHeader column={column} title="Frontier tier classification">
+        Tier
+      </SortableHeader>
+    ),
+    cell: CapabilityTierCell,
+    sortingFn: (a, b) =>
+      capabilityTierSortValue(a.original.capabilityTier.level) -
+      capabilityTierSortValue(b.original.capabilityTier.level),
+  },
+  levelNoteColumn<FrontierLab>({
+    id: "safetyInvestment",
+    accessor: (r) => r.safetyInvestment,
+    label: "Safety investment",
+    tooltip: "Dedicated safety / alignment headcount and research output, relative to org size",
+  }),
+  levelNoteColumn<FrontierLab>({
+    id: "racePostureRestraint",
+    accessor: (r) => r.racePostureRestraint,
+    label: "Race restraint",
+    tooltip: "Public posture and revealed behavior on competitive racing. HIGH = restrained.",
+  }),
+  levelNoteColumn<FrontierLab>({
+    id: "transparency",
+    accessor: (r) => r.transparency,
+    label: "Transparency",
+    tooltip: "System cards, RSPs, training detail, pre-deployment AISI access",
+  }),
+  levelNoteColumn<FrontierLab>({
+    id: "govEngagement",
+    accessor: (r) => r.govEngagement,
+    label: "Gov. engagement",
+    tooltip: "Regulator / AISI / summit engagement. HIGH = constructive engagement.",
+  }),
+  levelNoteColumn<FrontierLab>({
+    id: "leadershipSafetyAlignment",
+    accessor: (r) => r.leadershipSafetyAlignment,
+    label: "Leadership safety alignment",
+    tooltip: "CEO / co-founder public stance and revealed prioritization of safety",
+    sortValue: (r) => getLevelSortValue(r.leadershipSafetyAlignment.level),
+  }),
+  levelNoteColumn<FrontierLab>({
+    id: "employeeSafetyCulture",
+    accessor: (r) => r.employeeSafetyCulture,
+    label: "Employee safety culture",
+    tooltip: "Internal safety advocacy, alignment-research output, attrition pattern",
+  }),
+  levelNoteColumn<FrontierLab>({
+    id: "rspQuality",
+    accessor: (r) => r.rspQuality,
+    label: "RSP / framework quality",
+    tooltip: "Detail and operational specificity of published Responsible Scaling Policy or equivalent",
+  }),
+  {
+    id: "notableSignals",
+    header: () => <span className="text-xs">Notable signals</span>,
+    cell: ({ row }) => <SignalsCell signals={row.original.notableSignals} />,
+    enableSorting: false,
+  },
+  {
+    id: "links",
+    header: () => <span className="text-xs">References</span>,
+    cell: ({ row }) => <LinksCell links={row.original.links} />,
+    enableSorting: false,
+  },
+];
+
+export const FRONTIER_LABS_COLUMNS = {
+  capabilityTier: { key: "capabilityTier", label: "Tier", group: "overview" as const, default: true },
+  safetyInvestment: { key: "safetyInvestment", label: "Safety investment", group: "safety" as const, default: true },
+  racePostureRestraint: { key: "racePostureRestraint", label: "Race restraint", group: "safety" as const, default: true },
+  transparency: { key: "transparency", label: "Transparency", group: "safety" as const, default: true },
+  govEngagement: { key: "govEngagement", label: "Gov. engagement", group: "safety" as const, default: true },
+  leadershipSafetyAlignment: { key: "leadershipSafetyAlignment", label: "Leadership", group: "safety" as const, default: true },
+  employeeSafetyCulture: { key: "employeeSafetyCulture", label: "Employee culture", group: "safety" as const, default: true },
+  rspQuality: { key: "rspQuality", label: "RSP quality", group: "safety" as const, default: true },
+  notableSignals: { key: "notableSignals", label: "Notable signals", group: "evidence" as const, default: true },
+  links: { key: "links", label: "References", group: "evidence" as const, default: true },
+} as const;
+
+export type FrontierLabsColumnKey = keyof typeof FRONTIER_LABS_COLUMNS;
+
+export const FRONTIER_LABS_PRESETS = {
+  all: Object.keys(FRONTIER_LABS_COLUMNS) as FrontierLabsColumnKey[],
+  compact: [
+    "capabilityTier",
+    "safetyInvestment",
+    "racePostureRestraint",
+    "rspQuality",
+  ] as FrontierLabsColumnKey[],
+  governance: [
+    "capabilityTier",
+    "transparency",
+    "govEngagement",
+    "rspQuality",
+  ] as FrontierLabsColumnKey[],
+  culture: [
+    "capabilityTier",
+    "leadershipSafetyAlignment",
+    "employeeSafetyCulture",
+    "racePostureRestraint",
+  ] as FrontierLabsColumnKey[],
+  default: Object.entries(FRONTIER_LABS_COLUMNS)
+    .filter(([_, v]) => v.default)
+    .map(([k]) => k) as FrontierLabsColumnKey[],
+};

--- a/apps/web/src/components/tables/frontier-labs-columns.tsx
+++ b/apps/web/src/components/tables/frontier-labs-columns.tsx
@@ -2,8 +2,7 @@
 
 import type { ColumnDef } from "@tanstack/react-table";
 import { SortableHeader } from "@/components/ui/sortable-header";
-import { CellNote, LevelBadge } from "./shared/cell-components";
-import { getLevelSortValue } from "./shared/table-view-styles";
+import { CellNote } from "./shared/cell-components";
 import type { FrontierLab, LabLink } from "@data/tables/frontier-labs";
 import { levelNoteColumn } from "./shared/column-helpers";
 
@@ -60,18 +59,38 @@ function LinksCell({ links }: { links: LabLink[] }) {
   );
 }
 
+// Tier values aren't in the shared HIGH/MEDIUM/LOW level vocabulary, so they
+// would render as the gray fallback through getBadgeClass. Use a dedicated
+// badge with explicit colors so the column scans visually.
+const TIER_BADGE_COLORS: Record<string, string> = {
+  FRONTIER: "bg-purple-200 text-purple-800 dark:bg-purple-700 dark:text-purple-100",
+  "NEAR-FRONTIER": "bg-blue-200 text-blue-800 dark:bg-blue-700 dark:text-blue-100",
+  SPECIALIZED: "bg-amber-200 text-amber-800 dark:bg-amber-700 dark:text-amber-100",
+  DEFUNCT: "bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-300",
+};
+
+function TierBadge({ level }: { level: string }) {
+  const colorClass = TIER_BADGE_COLORS[level] ?? TIER_BADGE_COLORS.DEFUNCT;
+  return (
+    <span
+      className={`inline-block px-1.5 py-0.5 rounded text-[11px] font-medium whitespace-nowrap ${colorClass}`}
+    >
+      {level}
+    </span>
+  );
+}
+
 function CapabilityTierCell({ row }: { row: { original: FrontierLab } }) {
   const lab = row.original;
   return (
     <div>
-      <LevelBadge level={lab.capabilityTier.level} />
+      <TierBadge level={lab.capabilityTier.level} />
       <CellNote note={lab.capabilityTier.note} />
     </div>
   );
 }
 
-// Map non-standard tier strings into colors via getLevelSortValue's existing levels.
-// FRONTIER → high; NEAR-FRONTIER → medium; SPECIALIZED → low-medium; DEFUNCT → none.
+// Sort tiers descending by frontier-ness: FRONTIER > NEAR-FRONTIER > SPECIALIZED > DEFUNCT.
 function capabilityTierSortValue(tier: string): number {
   const t = tier.toLowerCase();
   if (t === "frontier") return 4;
@@ -130,7 +149,6 @@ export const createFrontierLabsColumns = (): ColumnDef<FrontierLab>[] => [
     accessor: (r) => r.leadershipSafetyAlignment,
     label: "Leadership safety alignment",
     tooltip: "CEO / co-founder public stance and revealed prioritization of safety",
-    sortValue: (r) => getLevelSortValue(r.leadershipSafetyAlignment.level),
   }),
   levelNoteColumn<FrontierLab>({
     id: "employeeSafetyCulture",

--- a/apps/web/src/components/tables/views/FrontierLabsTableView.tsx
+++ b/apps/web/src/components/tables/views/FrontierLabsTableView.tsx
@@ -45,100 +45,15 @@ export default function FrontierLabsTableView() {
         categoryColumnId: "category",
       }}
       description={
-        <div className="max-w-4xl space-y-4">
-          <p className="text-sm text-muted-foreground leading-relaxed">
-            Hand-curated editorial comparison of major frontier AI developers on
-            safety-relevant dimensions. Each rating cell shows a level
-            (HIGH / MEDIUM / LOW / UNCLEAR) plus a short note anchoring the
-            rating in observable signals — published policies, system cards,
-            leadership statements, and public departures. The full evidence
-            list per lab is in the "Notable signals" column.
-          </p>
-          <Card className="border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30">
-            <CardContent className="py-3 space-y-2">
-              <p className="text-sm">
-                <strong className="text-amber-700 dark:text-amber-400">
-                  Epistemic status:
-                </strong>{" "}
-                Opinionated synthesis, not a peer-reviewed scorecard. Ratings
-                reflect public observable signals through early 2026; internal
-                practices not in the public record are not assessed. "UNCLEAR"
-                means we don't have enough public signal — not that the
-                underlying practice is bad.
-              </p>
-              <p className="text-sm">
-                <strong className="text-amber-700 dark:text-amber-400">
-                  Direction of ratings:
-                </strong>{" "}
-                For every safety dimension, HIGH means more safety-positive
-                (more investment, more restraint, more transparency, stronger
-                alignment, more detail). The capability "Tier" column is
-                descriptive, not evaluative.
-              </p>
-              <p className="text-sm">
-                <strong className="text-amber-700 dark:text-amber-400">
-                  Limits:
-                </strong>{" "}
-                Ratings age fast — frontier labs reorganize, ship new policies,
-                and lose senior staff on quarterly timescales. Update cadence
-                here is ~14 days; check linked references for current state.
-                We weigh observable artifacts (published RSPs, system cards,
-                attrition patterns) more heavily than press statements. Other
-                scorecards weight differently — see the cross-references below.
-              </p>
-            </CardContent>
-          </Card>
-          <details>
-            <summary className="text-sm text-muted-foreground cursor-pointer hover:text-foreground select-none">
-              Other lab-comparison scorecards ↗
-            </summary>
-            <div className="mt-2 pl-4 border-l-2 border-border text-sm space-y-1">
-              <div>
-                <a
-                  href="https://futureoflife.org/ai-safety-index-winter-2025/"
-                  className="text-primary hover:underline"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  FLI AI Safety Index
-                </a>{" "}
-                — Periodic lab scorecards graded by independent reviewers.
-              </div>
-              <div>
-                <a
-                  href="https://metr.org/common-elements"
-                  className="text-primary hover:underline"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  METR: Common Elements
-                </a>{" "}
-                — Frontier safety policy comparison across companies.
-              </div>
-              <div>
-                <a
-                  href="https://ailabwatch.org/"
-                  className="text-primary hover:underline"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  AI Lab Watch
-                </a>{" "}
-                — Independent third-party scorecard with detailed rubric.
-              </div>
-              <div>
-                <a
-                  href="/organizations"
-                  className="text-primary hover:underline"
-                >
-                  /organizations
-                </a>{" "}
-                — Full organization directory on this wiki, including FactBase
-                facts (funding, headcount, valuations).
-              </div>
-            </div>
-          </details>
-        </div>
+        <p className="text-sm text-muted-foreground leading-relaxed max-w-3xl">
+          Hand-curated editorial comparison of major frontier AI developers on
+          safety-relevant dimensions. Each rating cell shows a level
+          (HIGH / MEDIUM / LOW / UNCLEAR) plus a short note anchoring the
+          rating in observable signals. Full epistemic caveats and methodology
+          are in the page body above. The capability "Tier" column is
+          descriptive, not evaluative; all other columns use HIGH = safety-
+          positive.
+        </p>
       }
       legend={
         <Card className="max-w-fit">

--- a/apps/web/src/components/tables/views/FrontierLabsTableView.tsx
+++ b/apps/web/src/components/tables/views/FrontierLabsTableView.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+// Frontier AI Labs Comparison Table view.
+// Hand-curated editorial ratings of major AI labs on safety-relevant dimensions.
+
+import { useCallback } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  createFrontierLabsColumns,
+  FRONTIER_LABS_COLUMNS,
+  FRONTIER_LABS_PRESETS,
+} from "../frontier-labs-columns";
+import {
+  frontierLabs,
+  FRONTIER_LAB_CATEGORIES,
+} from "@data/tables/frontier-labs";
+import { TableViewPage } from "../shared/TableViewPage";
+
+export default function FrontierLabsTableView() {
+  const createColumns = useCallback(() => createFrontierLabsColumns(), []);
+
+  return (
+    <TableViewPage
+      data={frontierLabs}
+      createColumns={createColumns}
+      columnConfig={FRONTIER_LABS_COLUMNS}
+      columnPresets={FRONTIER_LABS_PRESETS}
+      pinnedColumn="name"
+      stickyFirstColumn
+      grouping={{
+        groupByField: "category",
+        groupOrder: FRONTIER_LAB_CATEGORIES.map((c) => c.id),
+        groupLabels: Object.fromEntries(
+          FRONTIER_LAB_CATEGORIES.map((c) => [c.id, c.label])
+        ),
+        headerStyle: "colored-dot",
+        groupDotClasses: {
+          "us-frontier": "bg-blue-500",
+          "frontier-china": "bg-red-500",
+          "frontier-europe": "bg-indigo-500",
+          specialized: "bg-amber-500",
+          historical: "bg-slate-500",
+        },
+        hideCategoryColumnInGroupedMode: true,
+        categoryColumnId: "category",
+      }}
+      description={
+        <div className="max-w-4xl space-y-4">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Hand-curated editorial comparison of major frontier AI developers on
+            safety-relevant dimensions. Each rating cell shows a level
+            (HIGH / MEDIUM / LOW / UNCLEAR) plus a short note anchoring the
+            rating in observable signals — published policies, system cards,
+            leadership statements, and public departures. The full evidence
+            list per lab is in the "Notable signals" column.
+          </p>
+          <Card className="border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30">
+            <CardContent className="py-3 space-y-2">
+              <p className="text-sm">
+                <strong className="text-amber-700 dark:text-amber-400">
+                  Epistemic status:
+                </strong>{" "}
+                Opinionated synthesis, not a peer-reviewed scorecard. Ratings
+                reflect public observable signals through early 2026; internal
+                practices not in the public record are not assessed. "UNCLEAR"
+                means we don't have enough public signal — not that the
+                underlying practice is bad.
+              </p>
+              <p className="text-sm">
+                <strong className="text-amber-700 dark:text-amber-400">
+                  Direction of ratings:
+                </strong>{" "}
+                For every safety dimension, HIGH means more safety-positive
+                (more investment, more restraint, more transparency, stronger
+                alignment, more detail). The capability "Tier" column is
+                descriptive, not evaluative.
+              </p>
+              <p className="text-sm">
+                <strong className="text-amber-700 dark:text-amber-400">
+                  Limits:
+                </strong>{" "}
+                Ratings age fast — frontier labs reorganize, ship new policies,
+                and lose senior staff on quarterly timescales. Update cadence
+                here is ~14 days; check linked references for current state.
+                We weigh observable artifacts (published RSPs, system cards,
+                attrition patterns) more heavily than press statements. Other
+                scorecards weight differently — see the cross-references below.
+              </p>
+            </CardContent>
+          </Card>
+          <details>
+            <summary className="text-sm text-muted-foreground cursor-pointer hover:text-foreground select-none">
+              Other lab-comparison scorecards ↗
+            </summary>
+            <div className="mt-2 pl-4 border-l-2 border-border text-sm space-y-1">
+              <div>
+                <a
+                  href="https://futureoflife.org/ai-safety-index-winter-2025/"
+                  className="text-primary hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  FLI AI Safety Index
+                </a>{" "}
+                — Periodic lab scorecards graded by independent reviewers.
+              </div>
+              <div>
+                <a
+                  href="https://metr.org/common-elements"
+                  className="text-primary hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  METR: Common Elements
+                </a>{" "}
+                — Frontier safety policy comparison across companies.
+              </div>
+              <div>
+                <a
+                  href="https://ailabwatch.org/"
+                  className="text-primary hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  AI Lab Watch
+                </a>{" "}
+                — Independent third-party scorecard with detailed rubric.
+              </div>
+              <div>
+                <a
+                  href="/organizations"
+                  className="text-primary hover:underline"
+                >
+                  /organizations
+                </a>{" "}
+                — Full organization directory on this wiki, including FactBase
+                facts (funding, headcount, valuations).
+              </div>
+            </div>
+          </details>
+        </div>
+      }
+      legend={
+        <Card className="max-w-fit">
+          <CardContent className="py-4">
+            <div className="flex flex-wrap gap-6 text-[10px]">
+              <div className="space-y-1">
+                <p className="text-xs font-semibold text-muted-foreground">
+                  Safety dimensions (HIGH = safety-positive)
+                </p>
+                <div className="flex flex-col gap-0.5">
+                  <span>
+                    <strong>HIGH</strong> — Strong observable signal in the
+                    safety-positive direction
+                  </span>
+                  <span>
+                    <strong>MEDIUM</strong> — Mixed evidence or partial commitment
+                  </span>
+                  <span>
+                    <strong>LOW</strong> — Weak / minimal / counter-evidence
+                  </span>
+                  <span>
+                    <strong>UNCLEAR</strong> — Not enough public signal to rate
+                  </span>
+                  <span>
+                    <strong>NONE</strong> — No corresponding practice / policy exists
+                  </span>
+                </div>
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs font-semibold text-muted-foreground">
+                  Capability tier (descriptive)
+                </p>
+                <div className="flex flex-col gap-0.5">
+                  <span>
+                    <strong>FRONTIER</strong> — At or near absolute frontier
+                  </span>
+                  <span>
+                    <strong>NEAR-FRONTIER</strong> — Competitive in their tier, behind frontier
+                  </span>
+                  <span>
+                    <strong>SPECIALIZED</strong> — Enterprise / niche focus
+                  </span>
+                  <span>
+                    <strong>DEFUNCT</strong> — No longer pursuing frontier
+                  </span>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      }
+      footer={
+        <div className="text-xs text-muted-foreground mt-4">
+          {frontierLabs.length} labs across{" "}
+          {FRONTIER_LAB_CATEGORIES.length} categories. Ratings updated to early
+          2026; check references for current state. See linked organization
+          pages for FactBase facts (funding, headcount, leadership history).
+        </div>
+      }
+    />
+  );
+}

--- a/apps/web/src/data/tables/frontier-labs.json
+++ b/apps/web/src/data/tables/frontier-labs.json
@@ -11,7 +11,7 @@
     },
     "safetyInvestment": {
       "level": "HIGH",
-      "note": "Largest dedicated alignment/interpretability staffing share among frontier labs; public RSP, RAIN governance, ASL framework."
+      "note": "Largest dedicated alignment/interpretability staffing share among frontier labs; public RSP and ASL framework; governed by the Long-Term Benefit Trust."
     },
     "racePostureRestraint": {
       "level": "MEDIUM",
@@ -26,7 +26,7 @@
       "note": "US AISI MOU, UK AISI pre-deployment access, congressional testimony, supports compute-based regulation."
     },
     "leadershipSafetyAlignment": {
-      "level": "STRONG",
+      "level": "HIGH",
       "note": "All seven co-founders left OpenAI over safety disagreements. Dario and Daniela Amodei publicly EA-aligned; 80% Giving Pledge."
     },
     "employeeSafetyCulture": {
@@ -70,8 +70,8 @@
       "note": "Publishes system cards, model spec, Preparedness Framework. Withholds training data, compute, and full safety-eval results."
     },
     "govEngagement": {
-      "level": "HIGH",
-      "note": "Altman 2023 Senate testimony; AISI partnership; participated in summit commitments. Also lobbied against parts of EU AI Act and SB 1047."
+      "level": "MEDIUM",
+      "note": "Altman 2023 Senate testimony; AISI partnership; participated in summit commitments. Downgraded from HIGH because OpenAI also lobbied against parts of EU AI Act and SB 1047 — engagement is selective, not consistently constructive."
     },
     "leadershipSafetyAlignment": {
       "level": "LOW",
@@ -79,7 +79,7 @@
     },
     "employeeSafetyCulture": {
       "level": "LOW",
-      "note": "Pattern of high-profile safety departures 2023-2025 (Sutskever, Leike, Saunders, Krueger, Bourgon, Lehman, Kokotajlo). June 2024 open letter from former employees on whistleblower protections."
+      "note": "Pattern of high-profile safety departures 2023-2025 (Sutskever, Leike, Saunders, Krueger, Lehman, Kokotajlo, Brundage). June 2024 'Right to Warn' open letter from former employees on whistleblower protections."
     },
     "rspQuality": {
       "level": "MEDIUM",
@@ -162,8 +162,8 @@
       "note": "Open-weights release strategy maximizes diffusion. LeCun has publicly minimized frontier-risk concerns; Zuckerberg framing emphasizes openness and competition with China."
     },
     "transparency": {
-      "level": "HIGH",
-      "note": "Model weights released for Llama family; detailed technical reports. Safety-eval disclosure is thinner."
+      "level": "MEDIUM",
+      "note": "Open weights and detailed technical reports are unusually transparent on capability artifacts. But this rubric weights transparency toward operational safety detail — RSPs, system cards, capability thresholds — none of which Meta publishes. HIGH on openness, LOW on safety-operational transparency; netted to MEDIUM."
     },
     "govEngagement": {
       "level": "MEDIUM",
@@ -305,8 +305,8 @@
       "note": "Strategy pushes capability frontier with permissive open-weights release. R1 reasoning model released with weights and method."
     },
     "transparency": {
-      "level": "HIGH",
-      "note": "Weights, technical methodology, and some training detail unusually open. Safety-eval disclosure is limited."
+      "level": "MEDIUM",
+      "note": "Weights, technical methodology, and some training detail unusually open. No RSP / capability-threshold framework and limited safety-eval disclosure — netted to MEDIUM on this rubric's safety-weighted definition of transparency."
     },
     "govEngagement": {
       "level": "UNCLEAR",
@@ -338,6 +338,7 @@
     "name": "Alibaba (Qwen)",
     "description": "Alibaba Cloud / DAMO Academy. Qwen family — strong open-weights releases.",
     "category": "frontier-china",
+    "entityId": "sid_eBJi3sqy7w",
     "capabilityTier": {
       "level": "NEAR-FRONTIER",
       "note": "Qwen 2.5 / 3 competitive in their tiers; multimodal and code variants strong; below absolute frontier on hardest reasoning."
@@ -351,8 +352,8 @@
       "note": "Aggressive open-weights cadence across sizes; rapid release tempo."
     },
     "transparency": {
-      "level": "HIGH",
-      "note": "Weights released; detailed technical reports. Safety-eval depth limited."
+      "level": "MEDIUM",
+      "note": "Weights released and detailed technical reports. No RSP / capability framework and limited safety-eval depth — HIGH on capability openness, LOW on safety-operational transparency; netted to MEDIUM."
     },
     "govEngagement": {
       "level": "UNCLEAR",
@@ -384,6 +385,7 @@
     "name": "Mistral AI",
     "description": "Paris-based, founded 2023. Open and commercial models; European AI champion positioning.",
     "category": "frontier-europe",
+    "entityId": "E1097",
     "capabilityTier": {
       "level": "NEAR-FRONTIER",
       "note": "Mid-sized models competitive in efficiency tier; below absolute frontier on largest closed models."
@@ -430,6 +432,7 @@
     "name": "Cohere",
     "description": "Toronto-based, founded 2019 by ex-Google Brain (Aidan Gomez). Enterprise / RAG focus.",
     "category": "specialized",
+    "entityId": "sid_JDg4Sr7Cr1",
     "capabilityTier": {
       "level": "NEAR-FRONTIER",
       "note": "Command R / R+ competitive in enterprise / RAG tier; below frontier on hardest reasoning. Strategy is enterprise-focused, not frontier-chasing."
@@ -523,6 +526,7 @@
     "name": "Inflection (defunct / absorbed)",
     "description": "Founded 2022 by Mustafa Suleyman, Karén Simonyan, Reid Hoffman. Most of team absorbed into Microsoft AI March 2024.",
     "category": "historical",
+    "entityId": "sid_r1i7cwBiD7",
     "capabilityTier": {
       "level": "DEFUNCT",
       "note": "Frontier ambitions abandoned March 2024; remaining entity pivoted to enterprise. Original Pi-model team is now Microsoft AI under Suleyman."

--- a/apps/web/src/data/tables/frontier-labs.json
+++ b/apps/web/src/data/tables/frontier-labs.json
@@ -1,0 +1,567 @@
+[
+  {
+    "id": "anthropic",
+    "name": "Anthropic",
+    "description": "Founded 2021 by ex-OpenAI safety leads; explicitly safety-mission lab. Claude family.",
+    "category": "us-frontier",
+    "entityId": "E22",
+    "capabilityTier": {
+      "level": "FRONTIER",
+      "note": "Claude Opus / Sonnet competitive at the top tier through 2025-2026."
+    },
+    "safetyInvestment": {
+      "level": "HIGH",
+      "note": "Largest dedicated alignment/interpretability staffing share among frontier labs; public RSP, RAIN governance, ASL framework."
+    },
+    "racePostureRestraint": {
+      "level": "MEDIUM",
+      "note": "Dario Amodei has openly argued the 'race to safety' framing — explicit goal to stay at frontier rather than slow down. Commercial trajectory has accelerated."
+    },
+    "transparency": {
+      "level": "HIGH",
+      "note": "Detailed RSP v2, comprehensive system cards, public interpretability research, some training/compute disclosure."
+    },
+    "govEngagement": {
+      "level": "HIGH",
+      "note": "US AISI MOU, UK AISI pre-deployment access, congressional testimony, supports compute-based regulation."
+    },
+    "leadershipSafetyAlignment": {
+      "level": "STRONG",
+      "note": "All seven co-founders left OpenAI over safety disagreements. Dario and Daniela Amodei publicly EA-aligned; 80% Giving Pledge."
+    },
+    "employeeSafetyCulture": {
+      "level": "HIGH",
+      "note": "Heavy alignment-research output; employee donation matching program; few high-profile safety-driven departures relative to peers."
+    },
+    "rspQuality": {
+      "level": "HIGH",
+      "note": "RSP v2 (Oct 2024) — explicit capability thresholds, deployment/training pause conditions, board governance, internal red-team requirements."
+    },
+    "notableSignals": [
+      "RSP v2 published Oct 2024 with detailed ASL-3/ASL-4 tripwires.",
+      "Pre-deployment access agreements with US and UK AISIs.",
+      "Public interpretability program with regular technical releases."
+    ],
+    "links": [
+      { "label": "RSP v2", "url": "https://www.anthropic.com/news/announcing-our-updated-responsible-scaling-policy" },
+      { "label": "Acceptable Use", "url": "https://www.anthropic.com/legal/aup" }
+    ]
+  },
+  {
+    "id": "openai",
+    "name": "OpenAI",
+    "description": "Founded 2015 as nonprofit; now capped-profit. GPT family, o-series reasoning, Sora.",
+    "category": "us-frontier",
+    "entityId": "E218",
+    "capabilityTier": {
+      "level": "FRONTIER",
+      "note": "GPT-4o / o-series at the top tier; routinely trades leadership with Anthropic and Google."
+    },
+    "safetyInvestment": {
+      "level": "MEDIUM",
+      "note": "Preparedness team and Safety Advisory Group exist; Superalignment team disbanded May 2024. Safety-to-capabilities ratio has fallen since 2023 reorg."
+    },
+    "racePostureRestraint": {
+      "level": "LOW",
+      "note": "Sam Altman has publicly framed fast deployment as inevitable. Preparedness Framework includes deployment-gating language but execution has been criticized as lagging."
+    },
+    "transparency": {
+      "level": "MEDIUM",
+      "note": "Publishes system cards, model spec, Preparedness Framework. Withholds training data, compute, and full safety-eval results."
+    },
+    "govEngagement": {
+      "level": "HIGH",
+      "note": "Altman 2023 Senate testimony; AISI partnership; participated in summit commitments. Also lobbied against parts of EU AI Act and SB 1047."
+    },
+    "leadershipSafetyAlignment": {
+      "level": "LOW",
+      "note": "Founding safety mission walked back; chief scientist Sutskever departed; Jan Leike departed citing 'safety culture taking a back seat'; November 2023 board episode."
+    },
+    "employeeSafetyCulture": {
+      "level": "LOW",
+      "note": "Pattern of high-profile safety departures 2023-2025 (Sutskever, Leike, Saunders, Krueger, Bourgon, Lehman, Kokotajlo). June 2024 open letter from former employees on whistleblower protections."
+    },
+    "rspQuality": {
+      "level": "MEDIUM",
+      "note": "Preparedness Framework v1 (Dec 2023, updated 2025) — thresholds for cyber, persuasion, CBRN, autonomy. Less prescriptive on operational tripwires than Anthropic's RSP."
+    },
+    "notableSignals": [
+      "Superalignment team disbanded May 2024.",
+      "June 2024 'Right to Warn' open letter signed by 13 former and current employees.",
+      "Preparedness Framework updated 2025 but Safety Advisory Group decisions opaque."
+    ],
+    "links": [
+      { "label": "Preparedness Framework", "url": "https://openai.com/safety/preparedness/" },
+      { "label": "Right to Warn", "url": "https://righttowarn.ai/" }
+    ]
+  },
+  {
+    "id": "google-deepmind",
+    "name": "Google DeepMind",
+    "description": "Merger of DeepMind and Google Brain (2023). Gemini family; AlphaFold / AlphaGo lineage.",
+    "category": "us-frontier",
+    "entityId": "E98",
+    "capabilityTier": {
+      "level": "FRONTIER",
+      "note": "Gemini 2.x and reasoning models competitive at top tier."
+    },
+    "safetyInvestment": {
+      "level": "MEDIUM",
+      "note": "Frontier Safety + AGI Safety teams; substantial absolute headcount but smaller fraction of total org than Anthropic. Long alignment research history."
+    },
+    "racePostureRestraint": {
+      "level": "MEDIUM",
+      "note": "Demis Hassabis publicly safety-conscious. 2023 DeepMind/Brain merger driven in part by competitive pressure; Gemini cadence has accelerated."
+    },
+    "transparency": {
+      "level": "MEDIUM",
+      "note": "Frontier Safety Framework, model cards, AGI safety paper. Less prescriptive than Anthropic's RSP; commercial constraints from Google reduce disclosure."
+    },
+    "govEngagement": {
+      "level": "HIGH",
+      "note": "UK + US AISI partnerships; Hassabis advises UK Government; participated in Bletchley / Seoul / Paris summit commitments."
+    },
+    "leadershipSafetyAlignment": {
+      "level": "MEDIUM",
+      "note": "Hassabis publicly safety-focused since DeepMind founding; original ethics board legacy. Operating constraints from Google parent."
+    },
+    "employeeSafetyCulture": {
+      "level": "MEDIUM",
+      "note": "Strong public alignment-research output. Some internal-protest history (Project Maven, Gemini launch). Less visible attrition pattern than OpenAI."
+    },
+    "rspQuality": {
+      "level": "MEDIUM",
+      "note": "Frontier Safety Framework v2 (Feb 2025) — capability thresholds and deployment mitigations, less operationally specific than RSP v2."
+    },
+    "notableSignals": [
+      "Frontier Safety Framework v2 (Feb 2025).",
+      "AGI safety position paper (2025) outlining technical research agenda.",
+      "Pre-deployment AISI access for Gemini frontier releases."
+    ],
+    "links": [
+      { "label": "Frontier Safety Framework", "url": "https://deepmind.google/discover/blog/updating-the-frontier-safety-framework/" },
+      { "label": "Responsibility & Safety", "url": "https://deepmind.google/about/responsibility-safety/" }
+    ]
+  },
+  {
+    "id": "meta-ai",
+    "name": "Meta AI / FAIR",
+    "description": "Includes FAIR (Yann LeCun) and Meta GenAI. Llama family; open-weights strategy.",
+    "category": "us-frontier",
+    "entityId": "E549",
+    "capabilityTier": {
+      "level": "NEAR-FRONTIER",
+      "note": "Llama 3.x / 4 competitive in their tiers but consistently behind closed-weights frontier."
+    },
+    "safetyInvestment": {
+      "level": "LOW",
+      "note": "Small explicit safety team relative to size; LeCun publicly skeptical of catastrophic AI x-risk framings."
+    },
+    "racePostureRestraint": {
+      "level": "LOW",
+      "note": "Open-weights release strategy maximizes diffusion. LeCun has publicly minimized frontier-risk concerns; Zuckerberg framing emphasizes openness and competition with China."
+    },
+    "transparency": {
+      "level": "HIGH",
+      "note": "Model weights released for Llama family; detailed technical reports. Safety-eval disclosure is thinner."
+    },
+    "govEngagement": {
+      "level": "MEDIUM",
+      "note": "Participated at summits. Opposed parts of EU AI Act addressing open-source models. Less proactive on safety-specific policy."
+    },
+    "leadershipSafetyAlignment": {
+      "level": "LOW",
+      "note": "LeCun's public position downplays catastrophic risk. Strategy is openness-first."
+    },
+    "employeeSafetyCulture": {
+      "level": "LOW",
+      "note": "Few public safety-driven departures or open letters from FAIR / GenAI. Less visible internal safety advocacy."
+    },
+    "rspQuality": {
+      "level": "NONE",
+      "note": "No published RSP or capability-threshold framework as of early 2026."
+    },
+    "notableSignals": [
+      "Llama 4 release continued open-weights strategy.",
+      "LeCun has repeatedly publicly minimized AGI / x-risk framings.",
+      "Acceptable Use Policy exists for Llama; no upstream capability thresholds."
+    ],
+    "links": [
+      { "label": "Llama AUP", "url": "https://www.llama.com/llama3/use-policy/" },
+      { "label": "Responsible Use Guide", "url": "https://ai.meta.com/llama/responsible-use-guide/" }
+    ]
+  },
+  {
+    "id": "xai",
+    "name": "xAI",
+    "description": "Founded 2023 by Elon Musk. Grok family; Colossus GPU build-out in Memphis.",
+    "category": "us-frontier",
+    "entityId": "E378",
+    "capabilityTier": {
+      "level": "FRONTIER",
+      "note": "Grok 3 (Feb 2025) competitive on public benchmarks; massive compute build-out."
+    },
+    "safetyInvestment": {
+      "level": "LOW",
+      "note": "Small explicit safety team; thin public safety-research output; Risk Management Framework published Feb 2025 is brief."
+    },
+    "racePostureRestraint": {
+      "level": "LOW",
+      "note": "Founded explicitly to race; Musk publicly framed xAI as 'anti-woke' alternative to OpenAI. Grok released with deliberately minimal output guardrails."
+    },
+    "transparency": {
+      "level": "LOW",
+      "note": "Sparse model documentation, no detailed safety evaluations published, brief system cards."
+    },
+    "govEngagement": {
+      "level": "MEDIUM",
+      "note": "Musk publicly supported SB 1047. xAI participated in Seoul Summit. Less ongoing engagement than the frontier-3."
+    },
+    "leadershipSafetyAlignment": {
+      "level": "LOW",
+      "note": "Musk's positioning has shifted over time; pattern at xAI is to ship capability before safety scaffolding."
+    },
+    "employeeSafetyCulture": {
+      "level": "UNCLEAR",
+      "note": "Too early to characterize; little public information on internal safety dissent."
+    },
+    "rspQuality": {
+      "level": "LOW",
+      "note": "Risk Management Framework (Feb 2025) — published but thin on operational thresholds, tripwires, and governance specifics."
+    },
+    "notableSignals": [
+      "Risk Management Framework published Feb 2025; criticized for brevity and lack of tripwires.",
+      "Grok image-generation launches with notably few content filters.",
+      "Memphis Colossus cluster built rapidly; environmental and grid-impact concerns raised by local press."
+    ],
+    "links": [
+      { "label": "xAI Risk Management Framework", "url": "https://x.ai/blog/risk-management-framework" }
+    ]
+  },
+  {
+    "id": "microsoft-ai",
+    "name": "Microsoft AI",
+    "description": "Mustafa Suleyman-led division (Mar 2024). Phi series + Copilot products + OpenAI partnership.",
+    "category": "us-frontier",
+    "entityId": "E550",
+    "capabilityTier": {
+      "level": "NEAR-FRONTIER",
+      "note": "Phi small-model line is strong; frontier-capability access primarily via OpenAI partnership rather than in-house pretraining."
+    },
+    "safetyInvestment": {
+      "level": "MEDIUM",
+      "note": "Microsoft Responsible AI Office and large governance apparatus; less in-house alignment-research output than frontier-3."
+    },
+    "racePostureRestraint": {
+      "level": "LOW",
+      "note": "Commercial deployment-first strategy via Copilot ubiquity. Bing chat / Sydney incidents (2023) reflect prioritizing speed."
+    },
+    "transparency": {
+      "level": "MEDIUM",
+      "note": "Responsible AI Standard published; Phi model cards exist; less RSP-style capability disclosure."
+    },
+    "govEngagement": {
+      "level": "HIGH",
+      "note": "Brad Smith leads global policy advocacy; AISI partner; UN AI advisory body participation."
+    },
+    "leadershipSafetyAlignment": {
+      "level": "MEDIUM",
+      "note": "Suleyman publicly safety-aware; Microsoft RAI track record mixed (Tay 2016, Sydney 2023). Brad Smith is policy-active."
+    },
+    "employeeSafetyCulture": {
+      "level": "UNCLEAR",
+      "note": "Large enterprise; few visible safety-driven departures, also less visibility into internal advocacy."
+    },
+    "rspQuality": {
+      "level": "LOW",
+      "note": "Responsible AI Standard is an enterprise-policy framework; no RSP-style capability-threshold tripwire system."
+    },
+    "notableSignals": [
+      "Inflection AI team (incl. Suleyman) absorbed Mar 2024 to lead Microsoft AI.",
+      "Responsible AI Transparency Report published annually.",
+      "Significant deployment via Copilot, Office, Azure — sets the de facto safety floor for enterprise AI."
+    ],
+    "links": [
+      { "label": "Responsible AI Standard", "url": "https://www.microsoft.com/en-us/ai/responsible-ai" },
+      { "label": "RAI Transparency Report", "url": "https://www.microsoft.com/en-us/corporate-responsibility/responsible-ai-transparency-report" }
+    ]
+  },
+  {
+    "id": "deepseek",
+    "name": "DeepSeek",
+    "description": "Hangzhou-based, spun out of High-Flyer Capital. DeepSeek V3 / R1 reasoning models, open-weights.",
+    "category": "frontier-china",
+    "entityId": "E1098",
+    "capabilityTier": {
+      "level": "FRONTIER",
+      "note": "DeepSeek V3 / R1 (early 2025) reached frontier reasoning performance at notably lower training cost."
+    },
+    "safetyInvestment": {
+      "level": "LOW",
+      "note": "Minimal public safety apparatus. Some alignment-related discussion in technical reports; no dedicated safety org disclosure."
+    },
+    "racePostureRestraint": {
+      "level": "LOW",
+      "note": "Strategy pushes capability frontier with permissive open-weights release. R1 reasoning model released with weights and method."
+    },
+    "transparency": {
+      "level": "HIGH",
+      "note": "Weights, technical methodology, and some training detail unusually open. Safety-eval disclosure is limited."
+    },
+    "govEngagement": {
+      "level": "UNCLEAR",
+      "note": "Operates under PRC regulatory framework (algorithm registration, content moderation). Limited Western governance interaction."
+    },
+    "leadershipSafetyAlignment": {
+      "level": "UNCLEAR",
+      "note": "Few public safety statements from leadership in English-language venues."
+    },
+    "employeeSafetyCulture": {
+      "level": "UNCLEAR",
+      "note": "Limited public information on internal safety culture or dissent."
+    },
+    "rspQuality": {
+      "level": "NONE",
+      "note": "No public RSP, framework, or capability-threshold commitment."
+    },
+    "notableSignals": [
+      "DeepSeek R1 release (Jan 2025) shifted assumptions about training-cost frontiers.",
+      "Operates under Chinese generative AI regulations including algorithm filings.",
+      "No counterpart to the Western RSP / FSF framework family."
+    ],
+    "links": [
+      { "label": "DeepSeek", "url": "https://www.deepseek.com/" }
+    ]
+  },
+  {
+    "id": "alibaba-qwen",
+    "name": "Alibaba (Qwen)",
+    "description": "Alibaba Cloud / DAMO Academy. Qwen family — strong open-weights releases.",
+    "category": "frontier-china",
+    "capabilityTier": {
+      "level": "NEAR-FRONTIER",
+      "note": "Qwen 2.5 / 3 competitive in their tiers; multimodal and code variants strong; below absolute frontier on hardest reasoning."
+    },
+    "safetyInvestment": {
+      "level": "LOW",
+      "note": "DAMO Academy has safety research streams; explicit frontier-safety framing limited in English-language public output."
+    },
+    "racePostureRestraint": {
+      "level": "LOW",
+      "note": "Aggressive open-weights cadence across sizes; rapid release tempo."
+    },
+    "transparency": {
+      "level": "HIGH",
+      "note": "Weights released; detailed technical reports. Safety-eval depth limited."
+    },
+    "govEngagement": {
+      "level": "UNCLEAR",
+      "note": "Operates under PRC regulatory framework. Limited Western policy interaction by Alibaba AI specifically."
+    },
+    "leadershipSafetyAlignment": {
+      "level": "UNCLEAR",
+      "note": "Few public safety-framed statements from leadership."
+    },
+    "employeeSafetyCulture": {
+      "level": "UNCLEAR",
+      "note": "Limited public information."
+    },
+    "rspQuality": {
+      "level": "NONE",
+      "note": "No public RSP-equivalent framework."
+    },
+    "notableSignals": [
+      "Qwen 2.5 / 3 open-weights releases competitive with peer-tier closed models.",
+      "Operating under PRC content / algorithmic regulation.",
+      "Strong code and multilingual variants; less emphasis on safety scaffolding in English-language docs."
+    ],
+    "links": [
+      { "label": "QwenLM", "url": "https://qwenlm.github.io/" }
+    ]
+  },
+  {
+    "id": "mistral",
+    "name": "Mistral AI",
+    "description": "Paris-based, founded 2023. Open and commercial models; European AI champion positioning.",
+    "category": "frontier-europe",
+    "capabilityTier": {
+      "level": "NEAR-FRONTIER",
+      "note": "Mid-sized models competitive in efficiency tier; below absolute frontier on largest closed models."
+    },
+    "safetyInvestment": {
+      "level": "LOW",
+      "note": "Minimal public safety research output; no dedicated safety org publicly disclosed."
+    },
+    "racePostureRestraint": {
+      "level": "LOW",
+      "note": "Open-weights strategy; European-champion competitive framing."
+    },
+    "transparency": {
+      "level": "MEDIUM",
+      "note": "Model cards exist; safety detail thinner."
+    },
+    "govEngagement": {
+      "level": "MEDIUM",
+      "note": "Active in EU AI Act lobbying — primarily to reduce obligations on open-source frontier models."
+    },
+    "leadershipSafetyAlignment": {
+      "level": "UNCLEAR",
+      "note": "Limited public statements on existential safety; not a central messaging focus."
+    },
+    "employeeSafetyCulture": {
+      "level": "UNCLEAR",
+      "note": "Too small / too recent for clear pattern."
+    },
+    "rspQuality": {
+      "level": "NONE",
+      "note": "No published RSP."
+    },
+    "notableSignals": [
+      "Active lobbying against parts of EU AI Act applying to GPAI models.",
+      "Open-weights releases (Mixtral, Pixtral, Codestral).",
+      "Microsoft partnership 2024 for Azure distribution."
+    ],
+    "links": [
+      { "label": "Mistral", "url": "https://mistral.ai/" }
+    ]
+  },
+  {
+    "id": "cohere",
+    "name": "Cohere",
+    "description": "Toronto-based, founded 2019 by ex-Google Brain (Aidan Gomez). Enterprise / RAG focus.",
+    "category": "specialized",
+    "capabilityTier": {
+      "level": "NEAR-FRONTIER",
+      "note": "Command R / R+ competitive in enterprise / RAG tier; below frontier on hardest reasoning. Strategy is enterprise-focused, not frontier-chasing."
+    },
+    "safetyInvestment": {
+      "level": "MEDIUM",
+      "note": "Cohere For AI research lab; published responsible-AI / multilingual safety work. Smaller commercial scale than frontier-3."
+    },
+    "racePostureRestraint": {
+      "level": "MEDIUM",
+      "note": "Enterprise positioning de-emphasizes the frontier race; deliberate focus on smaller, deployable models."
+    },
+    "transparency": {
+      "level": "MEDIUM",
+      "note": "Model and use-policy docs available; some safety research published; not full weight releases."
+    },
+    "govEngagement": {
+      "level": "HIGH",
+      "note": "Active in Canadian and international AI governance discussion; Aidan Gomez public commentary on policy."
+    },
+    "leadershipSafetyAlignment": {
+      "level": "MEDIUM",
+      "note": "Some public safety framing alongside commercial focus."
+    },
+    "employeeSafetyCulture": {
+      "level": "UNCLEAR",
+      "note": "Limited public signal."
+    },
+    "rspQuality": {
+      "level": "LOW",
+      "note": "Acceptable Use and responsible-use docs; no published RSP-style capability-threshold framework."
+    },
+    "notableSignals": [
+      "Cohere For AI publishes open multilingual safety research.",
+      "Enterprise / RAG positioning rather than chat-product frontier race.",
+      "Aidan Gomez active in policy commentary; co-founded the lab as a frontier alternative focused on deployability."
+    ],
+    "links": [
+      { "label": "Cohere", "url": "https://cohere.com/" },
+      { "label": "Cohere For AI", "url": "https://cohere.com/research" }
+    ]
+  },
+  {
+    "id": "ai21",
+    "name": "AI21 Labs",
+    "description": "Tel Aviv-based, founded 2017. Jurassic, Jamba (SSM hybrid); enterprise focus.",
+    "category": "specialized",
+    "capabilityTier": {
+      "level": "SPECIALIZED",
+      "note": "Jamba (SSM-Transformer hybrid) is technically distinctive but not at general-purpose frontier; enterprise-specialized."
+    },
+    "safetyInvestment": {
+      "level": "LOW",
+      "note": "Minimal public safety apparatus."
+    },
+    "racePostureRestraint": {
+      "level": "MEDIUM",
+      "note": "Enterprise-focused; less frontier-race framing than the closed-weights frontier-3."
+    },
+    "transparency": {
+      "level": "MEDIUM",
+      "note": "Jamba weights released; technical reports detailed. Safety-eval disclosure limited."
+    },
+    "govEngagement": {
+      "level": "UNCLEAR",
+      "note": "Limited Western-frontier policy visibility."
+    },
+    "leadershipSafetyAlignment": {
+      "level": "UNCLEAR",
+      "note": "Limited public statements on existential safety."
+    },
+    "employeeSafetyCulture": {
+      "level": "UNCLEAR",
+      "note": "Limited public information."
+    },
+    "rspQuality": {
+      "level": "NONE",
+      "note": "No published RSP-equivalent framework."
+    },
+    "notableSignals": [
+      "Jamba 1.5 released 2024 — first production-quality SSM hybrid.",
+      "Enterprise focus rather than frontier chat product.",
+      "Limited public engagement with frontier-safety governance frameworks."
+    ],
+    "links": [
+      { "label": "AI21 Labs", "url": "https://www.ai21.com/" }
+    ]
+  },
+  {
+    "id": "inflection",
+    "name": "Inflection (defunct / absorbed)",
+    "description": "Founded 2022 by Mustafa Suleyman, Karén Simonyan, Reid Hoffman. Most of team absorbed into Microsoft AI March 2024.",
+    "category": "historical",
+    "capabilityTier": {
+      "level": "DEFUNCT",
+      "note": "Frontier ambitions abandoned March 2024; remaining entity pivoted to enterprise. Original Pi-model team is now Microsoft AI under Suleyman."
+    },
+    "safetyInvestment": {
+      "level": "UNCLEAR",
+      "note": "Not applicable to current entity; pre-absorption safety apparatus was modest."
+    },
+    "racePostureRestraint": {
+      "level": "UNCLEAR",
+      "note": "Pre-absorption was a fast scaler; current entity is no longer frontier."
+    },
+    "transparency": {
+      "level": "LOW",
+      "note": "Minimal public technical detail in either form."
+    },
+    "govEngagement": {
+      "level": "UNCLEAR",
+      "note": "Suleyman has carried his policy engagement into Microsoft AI."
+    },
+    "leadershipSafetyAlignment": {
+      "level": "UNCLEAR",
+      "note": "Not applicable to current entity."
+    },
+    "employeeSafetyCulture": {
+      "level": "UNCLEAR",
+      "note": "Not applicable post-absorption."
+    },
+    "rspQuality": {
+      "level": "NONE",
+      "note": "No public RSP-equivalent framework, before or after absorption."
+    },
+    "notableSignals": [
+      "March 2024: Suleyman + most technical team move to Microsoft AI.",
+      "Inflection entity remains, pivoted to B2B enterprise inference.",
+      "Frequently cited as the canonical 'frontier lab gets absorbed by hyperscaler' case."
+    ],
+    "links": [
+      { "label": "Inflection AI", "url": "https://inflection.ai/" }
+    ]
+  }
+]

--- a/apps/web/src/data/tables/frontier-labs.ts
+++ b/apps/web/src/data/tables/frontier-labs.ts
@@ -1,0 +1,53 @@
+// Frontier AI Labs Comparison Table
+// Editorial ratings of major frontier AI developers on safety-relevant
+// dimensions. Hand-curated, opinionated. Notes anchor each rating in
+// observable signals (publications, RSPs, departures, public statements).
+
+import frontierLabsData from "./frontier-labs.json";
+
+export interface RatedField {
+  level: string;
+  note: string;
+}
+
+export interface LabLink {
+  label: string;
+  url: string;
+}
+
+export type FrontierLabCategory =
+  | "us-frontier"
+  | "frontier-china"
+  | "frontier-europe"
+  | "specialized"
+  | "historical";
+
+export interface FrontierLab {
+  id: string;
+  name: string;
+  description: string;
+  category: FrontierLabCategory;
+  entityId?: string;
+
+  capabilityTier: RatedField;
+  safetyInvestment: RatedField;
+  racePostureRestraint: RatedField;
+  transparency: RatedField;
+  govEngagement: RatedField;
+  leadershipSafetyAlignment: RatedField;
+  employeeSafetyCulture: RatedField;
+  rspQuality: RatedField;
+
+  notableSignals: string[];
+  links: LabLink[];
+}
+
+export const FRONTIER_LAB_CATEGORIES: { id: FrontierLabCategory; label: string }[] = [
+  { id: "us-frontier", label: "US frontier" },
+  { id: "frontier-china", label: "China frontier" },
+  { id: "frontier-europe", label: "Europe frontier" },
+  { id: "specialized", label: "Specialized / enterprise" },
+  { id: "historical", label: "Historical / absorbed" },
+];
+
+export const frontierLabs: FrontierLab[] = frontierLabsData as FrontierLab[];

--- a/apps/web/src/lib/__tests__/navigation-routes.test.ts
+++ b/apps/web/src/lib/__tests__/navigation-routes.test.ts
@@ -125,6 +125,21 @@ describe("MDX internal links", () => {
     "/about",
     "/knowledge-base",  // redirects
     "/races",
+    // Entity directory pages (see CLAUDE.md "Entity Directory Pages")
+    "/organizations",
+    "/people",
+    "/ai-models",
+    "/approaches",
+    "/benchmarks",
+    "/divisions",
+    "/events",
+    "/funding-programs",
+    "/funding-rounds",
+    "/grants",
+    "/investments",
+    "/legislation",
+    "/projects",
+    "/publications",
   ];
 
   it("all MDX internal links resolve to known pages or routes", () => {

--- a/content/docs/knowledge-base/organizations/frontier-labs-comparison-table.mdx
+++ b/content/docs/knowledge-base/organizations/frontier-labs-comparison-table.mdx
@@ -1,0 +1,76 @@
+---
+wikiId: E2566
+title: Frontier AI Labs Comparison
+description: Hand-curated comparison of 12 major frontier AI labs on safety-relevant dimensions — capability tier, safety investment, race posture restraint, transparency, governance engagement, leadership alignment, employee culture, and RSP quality.
+subcategory: labs
+contentFormat: table
+lastEdited: 2026-05-11
+update_frequency: 14
+summary: Interactive comparison table of 12 major frontier AI developers (OpenAI, Anthropic, Google DeepMind, Meta, xAI, Microsoft AI, DeepSeek, Alibaba Qwen, Mistral, Cohere, AI21, Inflection) rated on safety-relevant dimensions. Each rating anchors in observable signals (RSPs, system cards, leadership statements, departures). Designed as a cross-lab counterpart to deeper single-org pages like the Anthropic stakeholders table. Ratings reflect early-2026 public signal and should be re-checked frequently.
+clusters:
+  - ai-safety
+  - governance
+hideSidebar: true
+---
+
+import FrontierLabsTableView from '@components/tables/views/FrontierLabsTableView';
+
+:::caution[Editorial ratings — read the disclaimers]
+This is **opinionated synthesis**, not a peer-reviewed scorecard. Ratings reflect publicly observable signals through early 2026; internal practices that aren't in the public record are not assessed. **UNCLEAR** means insufficient public signal, not "bad." Frontier labs reorganize on quarterly timescales — always check the linked references for current state.
+:::
+
+<FrontierLabsTableView />
+
+## What this table is — and isn't
+
+It's **a cross-lab comparison overlay** on top of the FactBase / TableBase organization data this wiki already maintains. Hard numbers (funding, valuations, headcount) live in the per-org pages at [/organizations](/organizations). This table is the layer above that — the **editorial judgment** about safety practice, anchored where possible in observable artifacts.
+
+It is not:
+- A precise scoring system. The HIGH / MEDIUM / LOW levels are buckets, not measurements.
+- A prediction. We rate **revealed behavior to date**, not where each lab is heading.
+- A safety endorsement for HIGH-rated labs. A lab can score well on every column here and still be a net contributor to risk (because the underlying activity is high-risk, or because revealed safety practice can degrade fast).
+- Definitive. Other lab-scorecard efforts ([FLI](https://futureoflife.org/ai-safety-index-winter-2025/), [METR](https://metr.org/common-elements), [AI Lab Watch](https://ailabwatch.org/)) use different rubrics and reach different conclusions on the same labs. We cite ours, not theirs.
+
+## Why these eight dimensions
+
+The dimensions are chosen to track what a third-party observer can verify from public artifacts, on the theory that the gap between **stated** safety commitment and **revealed** safety behavior is more useful than either alone:
+
+- **Capability tier** — descriptive, not evaluative. Distinguishes labs whose safety choices actually matter at the global frontier from those whose choices matter mostly to their customers.
+- **Safety investment** — dedicated alignment / interpretability / red-team headcount and research output, **relative to org size**. Absolute headcount favors hyperscalers; ratio is more meaningful.
+- **Race posture restraint** — public framing plus revealed behavior on competitive deployment. We mark HIGH when restraint is both stated and demonstrated; LOW when racing is explicit or when revealed cadence contradicts safety framing.
+- **Transparency** — RSPs, system cards, training detail, AISI pre-deployment access. Weighted toward operationally specific artifacts (capability thresholds, tripwires) over PR commitments.
+- **Governance engagement** — constructive engagement with regulators, AISIs, summits. We don't credit a lab for testifying if they also lobbied against the same legislation.
+- **Leadership safety alignment** — CEO / co-founder public stance plus revealed prioritization (resourcing, who reports to whom, what gets shipped when leadership disagrees).
+- **Employee safety culture** — internal safety advocacy, public alignment-research output, attrition patterns. High-profile safety-driven departures are weighed heavily because they're a costly signal.
+- **RSP / framework quality** — operational specificity. We treat a vague public-relations document as worse than no policy, because the former forecloses scrutiny.
+
+## What HIGH means
+
+HIGH is **safety-positive**, uniformly. HIGH safety investment means more investment; HIGH transparency means more disclosure; HIGH race restraint means more restraint; HIGH leadership alignment means stronger alignment. This lets you scan the table left-to-right and read green/amber/red as a rough safety signal — at the cost of forcing some unidimensional judgments onto multidimensional realities. The per-cell notes try to recover the nuance.
+
+We use **UNCLEAR** rather than guessing when public signal is thin (especially for Chinese-jurisdiction labs and very small / very new labs). Treat UNCLEAR rows as "we don't know," not as "probably bad."
+
+## Cross-references
+
+- [Anthropic Stakeholders Table](/wiki/E815) — single-org-deep-dive prototype.
+- [/organizations](/organizations) — organization directory with FactBase facts (funding rounds, valuations, headcount).
+- [FLI AI Safety Index (Winter 2025)](https://futureoflife.org/ai-safety-index-winter-2025/) — independent scorecard, different rubric.
+- [METR: Common Elements](https://metr.org/common-elements) — frontier safety policy comparison.
+- [AI Lab Watch](https://ailabwatch.org/) — third-party scorecard with detailed rubric.
+
+## Methodology — how each rating is anchored
+
+Every rating in the table has a one- or two-sentence note linking it to an observable signal. Where multiple signals exist, the "Notable signals" column carries the longer evidence list and the "References" column links sources.
+
+When evidence conflicts (e.g., a public safety statement contradicted by revealed deployment cadence), we **weight revealed behavior over stated commitments**, on the theory that the costly-signal side carries more information. This is why labs that publish strong-sounding safety frameworks can still receive a MEDIUM or LOW rating on race-posture restraint — the frameworks are real, but so is the deployment cadence.
+
+For attribution-light claims (e.g., "small explicit safety team"), the absence of public confirmation is itself informative: frontier labs that invest heavily in safety typically advertise it. We mark these LOW, not UNCLEAR.
+
+## Limitations
+
+- **Sample is small** — 12 labs, eight dimensions, hand-curated. Per-cell error bars are wide.
+- **Western-centric public signal** — Chinese-jurisdiction labs operate under a different regulatory and disclosure regime; UNCLEAR ratings there reflect our limited visibility, not necessarily their internal practice.
+- **Race-posture restraint is the most contested column** — labs and observers disagree about what counts as racing. We use "race-conscious" as MEDIUM and reserve LOW for labs whose public framing explicitly endorses racing.
+- **Ratings age fast** — quarterly cadence at minimum. Anything older than three months should be re-verified before being cited.
+
+Suggested re-reads, in order of likely turnover: leadership safety alignment > race-posture restraint > RSP quality > safety investment > transparency > everything else.

--- a/content/docs/knowledge-base/organizations/frontier-labs-comparison-table.mdx
+++ b/content/docs/knowledge-base/organizations/frontier-labs-comparison-table.mdx
@@ -15,9 +15,13 @@ hideSidebar: true
 
 import FrontierLabsTableView from '@components/tables/views/FrontierLabsTableView';
 
-:::caution[Editorial ratings — read the disclaimers]
-This is **opinionated synthesis**, not a peer-reviewed scorecard. Ratings reflect publicly observable signals through early 2026; internal practices that aren't in the public record are not assessed. **UNCLEAR** means insufficient public signal, not "bad." Frontier labs reorganize on quarterly timescales — always check the linked references for current state.
-:::
+## Read this before the table
+
+**Epistemic status.** Opinionated synthesis, not a peer-reviewed scorecard. Ratings reflect publicly observable signals through early 2026; internal practices that aren't in the public record are not assessed.
+
+**Direction of ratings.** For every safety dimension, HIGH means more safety-positive (more investment, more restraint, more transparency, stronger alignment, more detail). The capability "Tier" column is descriptive, not evaluative — being a frontier lab is not in itself good or bad. **UNCLEAR** means we don't have enough public signal to rate — *not* that the underlying practice is bad.
+
+**Limits.** Ratings age fast — frontier labs reorganize, ship new policies, and lose senior staff on quarterly timescales. Update cadence here is ~14 days; always check the linked references for current state. We weigh observable artifacts (published RSPs, system cards, attrition patterns) more heavily than press statements. Other scorecards weight differently — see [FLI AI Safety Index](https://futureoflife.org/ai-safety-index-winter-2025/), [METR Common Elements](https://metr.org/common-elements), and [AI Lab Watch](https://ailabwatch.org/) for independent rubrics.
 
 <FrontierLabsTableView />
 

--- a/data/entities/misc.yaml
+++ b/data/entities/misc.yaml
@@ -203,6 +203,31 @@
       type: person
   lastUpdated: 2026-02
 
+- id: frontier-labs-comparison-table
+  stableId: sid_MpPu9WTszw
+  wikiId: E2566
+  type: table
+  title: Frontier AI Labs Comparison
+  description: >-
+    Hand-curated comparison of 12 major frontier AI labs (OpenAI, Anthropic,
+    Google DeepMind, Meta, xAI, Microsoft AI, DeepSeek, Alibaba Qwen, Mistral,
+    Cohere, AI21, Inflection) on eight safety-relevant dimensions: capability
+    tier, safety investment, race posture restraint, transparency, governance
+    engagement, leadership safety alignment, employee safety culture, and
+    RSP / framework quality. Each rating anchored in observable signals.
+  tags:
+    - frontier-labs
+    - safety-comparison
+    - rsp
+    - scorecard
+  clusters:
+    - ai-safety
+    - governance
+  relatedEntries:
+    - id: sid_P43tBraTCQ
+      type: table
+  lastUpdated: 2026-05
+
 - id: anthropic-investors
   stableId: sid_sKOD0uMVGg
   wikiId: E406


### PR DESCRIPTION
## Summary

Closes QUA-1125.

A new interactive comparison table at `/wiki/E2566` covering 12 major frontier AI developers rated on safety-relevant dimensions:

- **Labs (12)**: OpenAI, Anthropic, Google DeepMind, Meta AI / FAIR, xAI, Microsoft AI, DeepSeek, Alibaba (Qwen), Mistral AI, Cohere, AI21 Labs, Inflection (defunct/absorbed)
- **Dimensions (8)**: Capability tier, Safety investment, Race posture restraint, Transparency, Governance engagement, Leadership safety alignment, Employee safety culture, RSP / framework quality
- **Rating system**: HIGH / MEDIUM / LOW / UNCLEAR per dimension, with HIGH always = safety-positive. Notable signals + reference URL columns carry the evidence trail per row.

Cross-references FLI AI Safety Index, METR Common Elements, AI Lab Watch as independent third-party scorecards with different rubrics.

## Design notes

- **Pattern**: Followed the existing `eval-types` / `safety-approaches` table convention — JSON data + typed schema + columns + view + thin MDX wrapper + 2-line registration in `mdx-components.tsx`. Most of the diff is the 12-row JSON data file.
- **HIGH = safety-positive uniformly**: Lets the table scan left-to-right as green / amber / red. The capability "Tier" column is descriptive (custom `TierBadge` colors), not evaluative.
- **UNCLEAR ≠ bad**: Reserved for thin public signal, particularly for Chinese-jurisdiction labs and very small / very new labs.
- **Revealed behavior > stated commitments**: When a public safety policy is contradicted by deployment cadence or lobbying behavior, the rating reflects the contradiction (e.g., OpenAI govEngagement at MEDIUM, not HIGH).
- **Disclaimers above the table**: Epistemic-status, direction-of-ratings, and limits caveats render inline in the MDX body, not buried in a click-to-open popover.

## Review

`/agent-review-pr` ran with the hostile-reviewer subagent. It surfaced **3 HIGH and 5 MEDIUM findings** — all HIGH and 4/5 MEDIUM addressed in commit `c4733641e`:

- **HIGH**: Anthropic leadership `STRONG` rendered gray (was not in the levelColors map) → changed to `HIGH`.
- **HIGH**: All `Tier` cells rendered gray (FRONTIER / NEAR-FRONTIER / etc. not in levelColors) → added a dedicated `TierBadge` with explicit purple/blue/amber/slate colors.
- **HIGH**: OpenAI govEngagement HIGH contradicted the rubric (EU AI Act + SB 1047 opposition) → downgraded to MEDIUM with note.
- **MEDIUM**: Meta / DeepSeek / Alibaba transparency HIGH conflated open-weights with safety-operational transparency → downgraded all three to MEDIUM with two-part notes.
- **MEDIUM**: Hallucinated "RAIN governance" for Anthropic → replaced with Long-Term Benefit Trust.
- **MEDIUM**: Hallucinated "Bourgon" in OpenAI safety-departures list → removed, added Brundage + "Right to Warn" letter reference.
- **MEDIUM**: 4 labs missing entityId despite having wiki entities → backfilled mistral (E1097), cohere (sid_JDg4Sr7Cr1), alibaba-cloud (sid_eBJi3sqy7w), inflection-ai (sid_r1i7cwBiD7).

## Files

- `apps/web/src/data/tables/frontier-labs.json` — 12 hand-curated rows.
- `apps/web/src/data/tables/frontier-labs.ts` — typed schema + JSON re-export.
- `apps/web/src/components/tables/frontier-labs-columns.tsx` — TanStack column defs + `TierBadge`.
- `apps/web/src/components/tables/views/FrontierLabsTableView.tsx` — `"use client"` view.
- `apps/web/src/components/mdx-components.tsx` — 2-line registration.
- `content/docs/knowledge-base/organizations/frontier-labs-comparison-table.mdx` — content page with epistemic disclaimers, methodology, and cross-references.
- `data/entities/misc.yaml` — entity definition (E2566 / sid_MpPu9WTszw) so the info box renders.
- `apps/web/src/lib/__tests__/navigation-routes.test.ts` — added the 13 entity-directory route prefixes (`/organizations`, `/people`, `/ai-models`, etc.) to KNOWN_ROUTE_PREFIXES — they all exist as Next.js routes; the test allowlist was stale.

## Test plan

- [x] Content gate passes (`pnpm crux w validate gate --scope=content --fix`)
- [x] Typecheck clean for new files
- [x] `validate-entities.test.ts` + `navigation-routes.test.ts` pass
- [x] Page renders at `/wiki/E2566` with correct badge colors verified locally (purple Tier, green HIGH, amber MEDIUM, red LOW)
- [x] All hostile-reviewer HIGH and 4/5 MEDIUM findings addressed
- [ ] CI green

## Out of scope (filed separately)

Pre-existing groundskeeper test failure caught during this PR's review (unrelated): filed as **QUA-1128** — `apps/groundskeeper/src/tasks/issue-responder.test.ts` label-removal retry assertions are stale (expect 2/3 calls, get 3/6 — implementation iterates over two labels but test was written for one).
