### PR TITLE
feat(backfill-sources): dual-judge + YAML dual-write + auto-PR + cron (squashed)

### DIFF
--- a/.github/workflows/auto-merge-backfill.yml
+++ b/.github/workflows/auto-merge-backfill.yml
@@ -43,11 +43,17 @@ jobs:
           set -euo pipefail
 
           # List open PRs from auto-backfill branches with their CI status.
+          # base:main filter prevents accidentally merging into release branches.
           PRS=$(gh pr list \
             --repo "$GITHUB_REPOSITORY" \
             --state open \
+            --base main \
             --search "head:claude/backfill-sources-yaml-" \
-            --json number,headRefName,mergeable,statusCheckRollup,title)
+            --json number,headRefName,baseRefName,mergeable,statusCheckRollup,title)
+
+          # Defense-in-depth: re-filter by baseRefName == "main" in case the
+          # --base flag is ever loosened or the search syntax changes.
+          PRS=$(echo "$PRS" | jq -c '[.[] | select(.baseRefName == "main")]')
 
           COUNT=$(echo "$PRS" | jq 'length')
           echo "Found $COUNT open auto-backfill PR(s)"

--- a/.github/workflows/auto-merge-backfill.yml
+++ b/.github/workflows/auto-merge-backfill.yml
@@ -48,6 +48,7 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --state open \
             --base main \
+            --limit 200 \
             --search "head:claude/backfill-sources-yaml-" \
             --json number,headRefName,baseRefName,mergeable,statusCheckRollup,title)
 

--- a/.github/workflows/auto-merge-backfill.yml
+++ b/.github/workflows/auto-merge-backfill.yml
@@ -1,0 +1,86 @@
+name: Auto-Merge Backfill PRs
+run-name: "Auto-Merge Backfill PRs${{ vars.AUTOMATION_PAUSED == 'true' && ' [PAUSED]' || '' }}"
+
+# Auto-merges open PRs from the source-backfill auto-PR flow
+# (`crux tb backfill-sources` opens these on `claude/backfill-sources-yaml-*`
+# branches; they are mechanical YAML mirrors with nothing to review by hand).
+#
+# Merge criteria:
+#   - PR is open and on a `claude/backfill-sources-yaml-*` head branch
+#   - All status checks succeeded (statusCheckRollup is all SUCCESS)
+#   - mergeable == MERGEABLE (no conflicts)
+#
+# CodeRabbit review state is intentionally NOT checked — its reviews are
+# advisory on this repo (no branch protection requires them) and the YAML
+# diffs are mechanical.
+
+on:
+  schedule:
+    - cron: '*/20 * * * *'   # every 20 minutes
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-merge-backfill
+  cancel-in-progress: false
+
+jobs:
+  paused-notice:
+    uses: ./.github/workflows/_paused-notice.yml
+
+  merge:
+    if: vars.AUTOMATION_PAUSED != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Find and merge eligible PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # List open PRs from auto-backfill branches with their CI status.
+          PRS=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "head:claude/backfill-sources-yaml-" \
+            --json number,headRefName,mergeable,statusCheckRollup,title)
+
+          COUNT=$(echo "$PRS" | jq 'length')
+          echo "Found $COUNT open auto-backfill PR(s)"
+
+          if [ "$COUNT" -eq 0 ]; then
+            exit 0
+          fi
+
+          # Filter to PRs that are MERGEABLE and have all checks passing.
+          # statusCheckRollup is an array of {conclusion, status, name}; we
+          # require every entry to be conclusion=SUCCESS (or status=COMPLETED
+          # with no failures). Empty rollup => no checks ran => skip (don't
+          # merge a PR that hasn't been validated).
+          ELIGIBLE=$(echo "$PRS" | jq -c '[.[] |
+            select(.mergeable == "MERGEABLE") |
+            select((.statusCheckRollup | length) > 0) |
+            select([.statusCheckRollup[] |
+              (.conclusion == "SUCCESS" or .conclusion == "NEUTRAL" or .conclusion == "SKIPPED")
+            ] | all)
+          ]')
+
+          ELIGIBLE_COUNT=$(echo "$ELIGIBLE" | jq 'length')
+          echo "$ELIGIBLE_COUNT PR(s) eligible to merge"
+
+          echo "$ELIGIBLE" | jq -c '.[]' | while read -r pr; do
+            NUM=$(echo "$pr" | jq -r '.number')
+            BRANCH=$(echo "$pr" | jq -r '.headRefName')
+            TITLE=$(echo "$pr" | jq -r '.title')
+            echo "::group::Merging PR #$NUM ($BRANCH): $TITLE"
+            if gh pr merge "$NUM" --repo "$GITHUB_REPOSITORY" --merge --delete-branch; then
+              echo "✓ Merged PR #$NUM"
+            else
+              echo "::warning::Failed to merge PR #$NUM — will retry next run"
+            fi
+            echo "::endgroup::"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 dev/sql/
 dev/reports/
 
+# backfill-sources analysis outputs (large, per-run, non-deterministic)
+dev/cache/
+dev/audits/
+dev/backfill-content-cache/
+
 # build output
 dist/
 
@@ -141,3 +146,6 @@ crux/calibration/data/corpus.json
 crux/calibration/data/results-*.json
 .claude/scratch/
 .claude/research-cache/
+
+# Local-only top-level scratch docs
+OVERVIEW.md

--- a/apps/groundskeeper/src/config.ts
+++ b/apps/groundskeeper/src/config.ts
@@ -19,6 +19,13 @@ export interface AutoUpdateEnqueueConfig extends TaskConfig {
   maxPages: number;
 }
 
+export interface BackfillSourcesEnqueueConfig extends TaskConfig {
+  /** Max records per table per run (default: 100). */
+  limit: number;
+  /** Max dollars per backfill run (default: 5). */
+  maxCost: number;
+}
+
 export interface Config {
   githubAppId: string;
   githubInstallationId: string;
@@ -39,6 +46,7 @@ export interface Config {
     dataQualitySnapshot: TaskConfig;
     jobWorkerHealth: TaskConfig;
     autoUpdateEnqueue: AutoUpdateEnqueueConfig;
+    backfillSourcesEnqueue: BackfillSourcesEnqueueConfig;
     jobFailureTriage: TaskConfig;
     tablebaseScan: TaskConfig;
     e2ePostDeployWatcher: TaskConfig;
@@ -143,6 +151,13 @@ export function loadConfig(): Config {
           process.env["TASK_AUTO_UPDATE_ENQUEUE_SCHEDULE"] ?? "0 6 * * *", // daily at 6am UTC
         budget: envInt("TASK_AUTO_UPDATE_ENQUEUE_BUDGET", 30),
         maxPages: envInt("TASK_AUTO_UPDATE_ENQUEUE_MAX_PAGES", 5),
+      },
+      backfillSourcesEnqueue: {
+        enabled: envBool("TASK_BACKFILL_SOURCES_ENQUEUE_ENABLED", true),
+        schedule:
+          process.env["TASK_BACKFILL_SOURCES_ENQUEUE_SCHEDULE"] ?? "0 2 * * *", // daily at 2am UTC
+        limit: envInt("TASK_BACKFILL_SOURCES_ENQUEUE_LIMIT", 100),
+        maxCost: envInt("TASK_BACKFILL_SOURCES_ENQUEUE_MAX_COST", 5),
       },
       jobFailureTriage: {
         enabled: envBool("TASK_JOB_FAILURE_TRIAGE_ENABLED", true),

--- a/apps/groundskeeper/src/incident-buffer.test.ts
+++ b/apps/groundskeeper/src/incident-buffer.test.ts
@@ -54,6 +54,7 @@ function makeConfig(): Config {
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
+      backfillSourcesEnqueue: { enabled: false, schedule: "0 2 * * *", limit: 100, maxCost: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
       e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },

--- a/apps/groundskeeper/src/index.ts
+++ b/apps/groundskeeper/src/index.ts
@@ -12,6 +12,7 @@ import { activeAgentsSweep } from "./tasks/active-agents-sweep.js";
 import { dataQualitySnapshot } from "./tasks/data-quality-snapshot.js";
 import { jobWorkerHealth } from "./tasks/job-worker-health.js";
 import { autoUpdateEnqueue } from "./tasks/auto-update-enqueue.js";
+import { backfillSourcesEnqueue } from "./tasks/backfill-sources-enqueue.js";
 import { jobFailureTriage } from "./tasks/job-failure-triage.js";
 import { tablebaseScan } from "./tasks/tablebase-scan.js";
 import { e2ePostDeployWatcher } from "./tasks/e2e-post-deploy-watcher.js";
@@ -63,6 +64,12 @@ logger.info({
       schedule: config.tasks.autoUpdateEnqueue.schedule,
       budget: config.tasks.autoUpdateEnqueue.budget,
       maxPages: config.tasks.autoUpdateEnqueue.maxPages,
+    },
+    backfillSourcesEnqueue: {
+      enabled: config.tasks.backfillSourcesEnqueue.enabled,
+      schedule: config.tasks.backfillSourcesEnqueue.schedule,
+      limit: config.tasks.backfillSourcesEnqueue.limit,
+      maxCost: config.tasks.backfillSourcesEnqueue.maxCost,
     },
     jobFailureTriage: {
       enabled: config.tasks.jobFailureTriage.enabled,
@@ -157,6 +164,14 @@ registerTask(
   config.tasks.autoUpdateEnqueue.schedule,
   config.tasks.autoUpdateEnqueue.enabled,
   () => autoUpdateEnqueue(config)
+);
+
+registerTask(
+  config,
+  "backfill-sources-enqueue",
+  config.tasks.backfillSourcesEnqueue.schedule,
+  config.tasks.backfillSourcesEnqueue.enabled,
+  () => backfillSourcesEnqueue(config)
 );
 
 registerTask(

--- a/apps/groundskeeper/src/run-tracker.test.ts
+++ b/apps/groundskeeper/src/run-tracker.test.ts
@@ -33,6 +33,7 @@ function makeConfig(runLogPath: string): Config {
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
+      backfillSourcesEnqueue: { enabled: false, schedule: "0 2 * * *", limit: 100, maxCost: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
       e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },

--- a/apps/groundskeeper/src/scheduler.test.ts
+++ b/apps/groundskeeper/src/scheduler.test.ts
@@ -57,6 +57,7 @@ function makeConfig(): Config {
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
+      backfillSourcesEnqueue: { enabled: false, schedule: "0 2 * * *", limit: 100, maxCost: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
       e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },

--- a/apps/groundskeeper/src/tasks/active-agents-sweep.test.ts
+++ b/apps/groundskeeper/src/tasks/active-agents-sweep.test.ts
@@ -34,6 +34,7 @@ function makeConfig(): Config {
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
+      backfillSourcesEnqueue: { enabled: false, schedule: "0 2 * * *", limit: 100, maxCost: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
       e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },

--- a/apps/groundskeeper/src/tasks/backfill-sources-enqueue.ts
+++ b/apps/groundskeeper/src/tasks/backfill-sources-enqueue.ts
@@ -1,0 +1,46 @@
+import type { Config } from "../config.js";
+import { logger as rootLogger } from "../logger.js";
+import { apiRequest } from "../wiki-server.js";
+
+const logger = rootLogger.child({ task: "backfill-sources-enqueue" });
+
+/**
+ * Enqueue a backfill-sources run via the wiki-server jobs API.
+ *
+ * Creates a job of type "backfill-sources" with limit and maxCost from config.
+ * The job worker picks it up and runs `crux tb backfill-sources --apply`.
+ */
+export async function backfillSourcesEnqueue(
+  config: Config,
+): Promise<{ success: boolean; summary?: string }> {
+  const { limit, maxCost } = config.tasks.backfillSourcesEnqueue;
+
+  logger.info({ limit, maxCost }, "Enqueuing backfill-sources job");
+
+  try {
+    const result = await apiRequest<{ id: number }>(
+      config,
+      "POST",
+      "/api/jobs",
+      {
+        type: "backfill-sources",
+        payload: { limit, maxCost },
+      },
+    );
+
+    if (result.ok && result.data) {
+      logger.info({ jobId: result.data.id }, "Backfill-sources job enqueued");
+      return { success: true, summary: `Job #${result.data.id} enqueued` };
+    }
+
+    logger.warn(
+      { error: result.error },
+      "Failed to enqueue backfill-sources job",
+    );
+    return { success: false, summary: result.error ?? "Unknown error" };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logger.error({ error: msg }, "Backfill-sources enqueue failed");
+    return { success: false, summary: msg };
+  }
+}

--- a/apps/groundskeeper/src/tasks/e2e-post-deploy-watcher.test.ts
+++ b/apps/groundskeeper/src/tasks/e2e-post-deploy-watcher.test.ts
@@ -53,6 +53,7 @@ function makeConfig(): Config {
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
+      backfillSourcesEnqueue: { enabled: false, schedule: "0 2 * * *", limit: 100, maxCost: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
       e2ePostDeployWatcher: { enabled: true, schedule: "15 * * * *" },

--- a/apps/groundskeeper/src/tasks/health-check.test.ts
+++ b/apps/groundskeeper/src/tasks/health-check.test.ts
@@ -85,6 +85,7 @@ function makeConfig(overrides?: Partial<Config>): Config {
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
+      backfillSourcesEnqueue: { enabled: false, schedule: "0 2 * * *", limit: 100, maxCost: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
       e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },

--- a/apps/groundskeeper/src/tasks/issue-responder.test.ts
+++ b/apps/groundskeeper/src/tasks/issue-responder.test.ts
@@ -102,6 +102,7 @@ function makeConfig(): Config {
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
+      backfillSourcesEnqueue: { enabled: false, schedule: "0 2 * * *", limit: 100, maxCost: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
       e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },

--- a/apps/groundskeeper/src/tasks/job-failure-triage.test.ts
+++ b/apps/groundskeeper/src/tasks/job-failure-triage.test.ts
@@ -82,6 +82,7 @@ function makeConfig(): Config {
         budget: 30,
         maxPages: 5,
       },
+      backfillSourcesEnqueue: { enabled: false, schedule: "0 2 * * *", limit: 100, maxCost: 5 },
       jobFailureTriage: { enabled: true, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
       e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },

--- a/apps/groundskeeper/src/tasks/session-sweep.test.ts
+++ b/apps/groundskeeper/src/tasks/session-sweep.test.ts
@@ -40,6 +40,7 @@ function makeConfig(): Config {
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
+      backfillSourcesEnqueue: { enabled: false, schedule: "0 2 * * *", limit: 100, maxCost: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
       e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },

--- a/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
+++ b/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
@@ -44,6 +44,7 @@ function makeConfig(keep = 100): Config {
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
+      backfillSourcesEnqueue: { enabled: false, schedule: "0 2 * * *", limit: 100, maxCost: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
       e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },

--- a/apps/groundskeeper/src/tasks/tablebase-scan.test.ts
+++ b/apps/groundskeeper/src/tasks/tablebase-scan.test.ts
@@ -37,6 +37,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
         budget: 30,
         maxPages: 5,
       },
+      backfillSourcesEnqueue: { enabled: false, schedule: "0 2 * * *", limit: 100, maxCost: 5 },
       jobFailureTriage: { enabled: true, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: true, schedule: "0 5 * * *" },
       e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },

--- a/apps/groundskeeper/src/tasks/things-search-refresh.test.ts
+++ b/apps/groundskeeper/src/tasks/things-search-refresh.test.ts
@@ -35,6 +35,7 @@ function makeConfig(): Config {
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
+      backfillSourcesEnqueue: { enabled: false, schedule: "0 2 * * *", limit: 100, maxCost: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
       e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },

--- a/crux/commands/backfill-sources.ts
+++ b/crux/commands/backfill-sources.ts
@@ -324,7 +324,7 @@ async function processAllRecords(
         const yamlOutcome = writeRecordToYaml(record, result.url, indexes);
         yamlReport = {
           status: yamlOutcome.status,
-          filepath: yamlOutcome.filepath,
+          ...(yamlOutcome.filepath ? { filepath: yamlOutcome.filepath } : {}),
           ...(yamlOutcome.applicable && yamlOutcome.status === 'error' && yamlOutcome.error
             ? { error: yamlOutcome.error }
             : {}),

--- a/crux/commands/backfill-sources.ts
+++ b/crux/commands/backfill-sources.ts
@@ -20,7 +20,18 @@ import { fetchMissingSources, updateRecordSource } from '../lib/backfill-sources
 import { extractMatchTerms } from '../lib/backfill-sources/match-terms.ts';
 import { processRecord } from '../lib/backfill-sources/process-record.ts';
 import { buildSummaryLines, writeOutcomesJson } from '../lib/backfill-sources/report.ts';
-import type { CostBreakdown, MissingSourceRecord, RecordOutcome } from '../lib/backfill-sources/types.ts';
+import type {
+  CostBreakdown,
+  MissingSourceRecord,
+  RecordOutcome,
+  YamlWriteRecordReport,
+} from '../lib/backfill-sources/types.ts';
+import { openYamlPr } from '../lib/backfill-sources/yaml-pr.ts';
+import {
+  buildFactbaseEntityIndex,
+  buildPolicyEntityIndex,
+} from '../lib/backfill-sources/yaml-target-resolvers.ts';
+import { writeRecordToYaml, type YamlIndexes } from '../lib/backfill-sources/yaml-write.ts';
 
 type CommandResult = { exitCode?: number; output?: string };
 type CommandOptions = Record<string, unknown>;
@@ -35,6 +46,10 @@ interface ParsedOptions {
   verbose: boolean;
   debug: boolean;
   unmatchedOut: string;
+  /** When true, skip the end-of-run YAML branch + commit + push + PR.
+   *  Defaults to false; set via --no-yaml-pr for local dry-application
+   *  testing where you want the YAML mutations on disk but no git activity. */
+  skipYamlPr: boolean;
 }
 
 async function backfillSourcesCommand(args: string[], rawOptions: CommandOptions): Promise<CommandResult> {
@@ -62,6 +77,7 @@ async function backfillSourcesCommand(args: string[], rawOptions: CommandOptions
   console.log(`Found ${fetchResult.totalMissing} records without sources.`);
   console.log(`Budget cap: $${parsed.maxCost.toFixed(2)} (per-record cap $${PER_RECORD_BUDGET.toFixed(2)})\n`);
 
+  const runStartedAt = new Date().toISOString();
   const run = await processAllRecords(records, parsed);
 
   const lines = buildSummaryLines({
@@ -90,6 +106,32 @@ async function backfillSourcesCommand(args: string[], rawOptions: CommandOptions
     matched: run.matched,
   });
   if (outcomeStatus) lines.push(outcomeStatus);
+
+  if (parsed.apply) {
+    lines.push(
+      `  YAML writes: ${run.factsYamlWritten} facts, ${run.stakeholdersYamlWritten} policy stakeholders` +
+      ` (${run.touchedYamlPaths.size} files touched)`,
+    );
+  }
+
+  if (parsed.apply && !parsed.skipYamlPr && run.touchedYamlPaths.size > 0) {
+    const prResult = openYamlPr({
+      touchedPaths: [...run.touchedYamlPaths].sort(),
+      runStartedAt,
+      summary: {
+        matched: run.matched,
+        factsWritten: run.factsYamlWritten,
+        stakeholdersWritten: run.stakeholdersYamlWritten,
+      },
+    });
+    if (prResult.kind === 'opened') {
+      lines.push(`  YAML PR opened: ${prResult.prUrl} (branch: ${prResult.branch})`);
+    } else if (prResult.kind === 'refused') {
+      lines.push(`  YAML PR skipped: ${prResult.reason}`);
+    } else {
+      lines.push(`  YAML PR FAILED: ${prResult.error}`);
+    }
+  }
 
   return { exitCode: 0, output: lines.join('\n') };
 }
@@ -125,6 +167,7 @@ function parseOptions(o: CommandOptions): ParsedOptions | { error: string } {
     debug: !!o.debug,
     unmatchedOut: (o.unmatchedOut as string | undefined)
       ?? `dev/reports/backfill-unmatched-${new Date().toISOString().replace(/[:.]/g, '-')}.json`,
+    skipYamlPr: !!o.noYamlPr,
   };
 }
 
@@ -179,6 +222,10 @@ interface RunTotals {
   budgetStopped: boolean;
   totalBreakdown: CostBreakdown;
   winningProviderCounts: Record<string, number>;
+  /** YAML files mutated during this run — staged explicitly at PR time. */
+  touchedYamlPaths: Set<string>;
+  factsYamlWritten: number;
+  stakeholdersYamlWritten: number;
 }
 
 async function processAllRecords(
@@ -196,7 +243,26 @@ async function processAllRecords(
     budgetStopped: false,
     totalBreakdown: emptyCost(),
     winningProviderCounts: {},
+    touchedYamlPaths: new Set<string>(),
+    factsYamlWritten: 0,
+    stakeholdersYamlWritten: 0,
   };
+
+  // Build YAML target indexes once per apply-run. In dry-run we skip this
+  // entirely — no writes happen so the index is unused.
+  const indexes: YamlIndexes | null = parsed.apply
+    ? {
+        facts: buildFactbaseEntityIndex(),
+        policies: buildPolicyEntityIndex(),
+      }
+    : null;
+  if (indexes) {
+    console.log(
+      `YAML target index: ${indexes.facts.sidToFilepath.size} factbase entities` +
+      ` (skipped ${indexes.facts.unindexedCount}), ${indexes.policies.sidToFilepath.size} policy entities` +
+      ` (parse failures: ${indexes.policies.parseFailureCount}).\n`,
+    );
+  }
 
   for (let i = 0; i < records.length; i++) {
     const record = records[i];
@@ -227,7 +293,15 @@ async function processAllRecords(
     addCost(run.totalBreakdown, result.cost);
 
     if (!result.matched) {
-      run.outcomes.push({ record, outcome: { kind: 'no-match', reason: result.reason, cost: result.cost } });
+      run.outcomes.push({
+        record,
+        outcome: {
+          kind: 'no-match',
+          reason: result.reason,
+          cost: result.cost,
+          candidates: result.candidates,
+        },
+      });
       continue;
     }
 
@@ -236,10 +310,34 @@ async function processAllRecords(
       (run.winningProviderCounts[result.provider ?? 'unknown'] ?? 0) + 1;
 
     let updated: boolean | undefined;
+    let yamlReport: YamlWriteRecordReport | undefined;
     if (parsed.apply) {
       updated = await updateRecordSource(record, result.url);
       if (updated) run.updatedCount++;
       else { run.updateFailed++; console.warn(`  ✗ Update failed — source not written`); }
+
+      // Dual-write to YAML for facts + policy_stakeholders. The PG write
+      // above is wiped by the YAML→PG sync workflow on the next push to
+      // data/entities or packages/factbase/data/fb-entities, so we mirror
+      // the write into YAML and let the sync re-populate PG durably.
+      if (updated && indexes) {
+        const yamlOutcome = writeRecordToYaml(record, result.url, indexes);
+        yamlReport = {
+          status: yamlOutcome.status,
+          filepath: yamlOutcome.filepath,
+          ...(yamlOutcome.applicable && yamlOutcome.status === 'error' && yamlOutcome.error
+            ? { error: yamlOutcome.error }
+            : {}),
+        };
+        if (yamlOutcome.applicable && yamlOutcome.status === 'wrote' && yamlOutcome.filepath) {
+          run.touchedYamlPaths.add(yamlOutcome.filepath);
+          if (record.record_table === 'facts') run.factsYamlWritten++;
+          if (record.record_table === 'policy_stakeholders') run.stakeholdersYamlWritten++;
+          console.log(`    → YAML write: ${yamlOutcome.filepath}`);
+        } else if (yamlOutcome.applicable) {
+          console.warn(`    → YAML write ${yamlOutcome.status}` + (yamlReport.error ? `: ${yamlReport.error}` : ''));
+        }
+      }
     }
 
     run.outcomes.push({
@@ -250,7 +348,9 @@ async function processAllRecords(
         provider: result.provider,
         quotes: result.quotes,
         updated,
+        yaml_write: yamlReport,
         cost: result.cost,
+        candidates: result.candidates,
       },
     });
   }

--- a/crux/lib/backfill-sources/__tests__/yaml-target-resolvers.test.ts
+++ b/crux/lib/backfill-sources/__tests__/yaml-target-resolvers.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildFactbaseEntityIndex,
+  buildPolicyEntityIndex,
+} from '../yaml-target-resolvers.ts';
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'yaml-resolvers-'));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('buildFactbaseEntityIndex', () => {
+  it('indexes entity:-format files and skips legacy thing: files', () => {
+    const fbDir = join(tmpRoot, 'fb');
+    mkdirSync(fbDir, { recursive: true });
+    writeFileSync(join(fbDir, 'a.yaml'), 'entity: sid_AAAaaaaaaa\nfacts:\n  - id: f_x\n');
+    writeFileSync(join(fbDir, 'b.yaml'), 'entity: sid_BBBbbbbbbb\nfacts: []\n');
+    writeFileSync(join(fbDir, 'legacy.yaml'), 'thing:\n  id: legacy-slug\nfacts: []\n');
+    writeFileSync(join(fbDir, 'README.md'), 'ignored');
+
+    const idx = buildFactbaseEntityIndex(fbDir);
+    expect(idx.sidToFilepath.size).toBe(2);
+    expect(idx.sidToFilepath.get('sid_AAAaaaaaaa')).toBe(join(fbDir, 'a.yaml'));
+    expect(idx.sidToFilepath.get('sid_BBBbbbbbbb')).toBe(join(fbDir, 'b.yaml'));
+    expect(idx.unindexedCount).toBe(1);
+  });
+
+  it('returns empty index when directory has no yaml files', () => {
+    const dir = join(tmpRoot, 'empty');
+    mkdirSync(dir, { recursive: true });
+    const idx = buildFactbaseEntityIndex(dir);
+    expect(idx.sidToFilepath.size).toBe(0);
+    expect(idx.unindexedCount).toBe(0);
+  });
+});
+
+describe('buildPolicyEntityIndex', () => {
+  it('indexes only policy-type entities with stableId', () => {
+    const dir = join(tmpRoot, 'entities');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'mixed.yaml'),
+      [
+        '- id: an-org',
+        '  stableId: sid_OrgOrgOrgO',
+        '  type: organization',
+        '- id: a-policy',
+        '  stableId: sid_PolicyPol1',
+        '  type: policy',
+        '  stakeholders:',
+        '    - name: Foo',
+        '      position: support',
+        '- id: another-policy',
+        '  stableId: sid_PolicyPol2',
+        '  type: policy',
+        '',
+      ].join('\n'),
+    );
+    writeFileSync(
+      join(dir, 'just-a-concept.yaml'),
+      [
+        '- id: a-concept',
+        '  stableId: sid_ConceptCo1',
+        '  type: concept',
+        '',
+      ].join('\n'),
+    );
+
+    const idx = buildPolicyEntityIndex(dir);
+    expect(idx.sidToFilepath.size).toBe(2);
+    expect(idx.sidToFilepath.get('sid_PolicyPol1')).toBe(join(dir, 'mixed.yaml'));
+    expect(idx.sidToFilepath.get('sid_PolicyPol2')).toBe(join(dir, 'mixed.yaml'));
+    expect(idx.parseFailureCount).toBe(0);
+  });
+
+  it('counts parse failures without throwing', () => {
+    const dir = join(tmpRoot, 'broken');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'bad.yaml'), '{{{not yaml');
+    writeFileSync(join(dir, 'ok.yaml'), '- id: x\n  stableId: sid_OkOkOkOkOk\n  type: policy\n');
+
+    const idx = buildPolicyEntityIndex(dir);
+    expect(idx.sidToFilepath.size).toBe(1);
+    expect(idx.parseFailureCount).toBe(1);
+  });
+
+  it('skips entries without stableId or with non-sid stableId', () => {
+    const dir = join(tmpRoot, 'skip');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'x.yaml'),
+      [
+        '- id: nope-no-sid',
+        '  type: policy',
+        '- id: nope-bare-id',
+        '  stableId: bare10char',
+        '  type: policy',
+        '',
+      ].join('\n'),
+    );
+    const idx = buildPolicyEntityIndex(dir);
+    expect(idx.sidToFilepath.size).toBe(0);
+  });
+});

--- a/crux/lib/backfill-sources/__tests__/yaml-write-fact.test.ts
+++ b/crux/lib/backfill-sources/__tests__/yaml-write-fact.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeFactSourceToYaml } from '../yaml-write-fact.ts';
+import type { FactbaseEntityIndex } from '../yaml-target-resolvers.ts';
+
+const SAMPLE = `entity: sid_EntEntEnt0
+facts:
+  - id: f_FactFactNo
+    property: revenue
+    value: 1.2e+9
+    asOf: 2025-09
+  - id: f_HasSourceX
+    property: revenue
+    value: 1e+8
+    asOf: 2024-06
+    source: https://existing.example.com
+`;
+
+let tmpRoot: string;
+let yamlPath: string;
+let index: FactbaseEntityIndex;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'yaml-fact-'));
+  mkdirSync(tmpRoot, { recursive: true });
+  yamlPath = join(tmpRoot, 'ent.yaml');
+  writeFileSync(yamlPath, SAMPLE, 'utf-8');
+  index = {
+    sidToFilepath: new Map([['sid_EntEntEnt0', yamlPath]]),
+    unindexedCount: 0,
+  };
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('writeFactSourceToYaml', () => {
+  it('writes source for a fact missing one', () => {
+    const out = writeFactSourceToYaml({
+      entitySid: 'sid_EntEntEnt0',
+      factId: 'f_FactFactNo',
+      url: 'https://example.com/news',
+      index,
+    });
+    expect(out.status).toBe('wrote');
+
+    const after = readFileSync(yamlPath, 'utf-8');
+    expect(after).toContain('source: https://example.com/news');
+    // The other fact's existing source is untouched.
+    expect(after).toContain('https://existing.example.com');
+  });
+
+  it('returns skipped-existing when fact already has a source', () => {
+    const out = writeFactSourceToYaml({
+      entitySid: 'sid_EntEntEnt0',
+      factId: 'f_HasSourceX',
+      url: 'https://example.com/replacement',
+      index,
+    });
+    expect(out.status).toBe('skipped-existing');
+    const after = readFileSync(yamlPath, 'utf-8');
+    expect(after).not.toContain('https://example.com/replacement');
+  });
+
+  it('returns not-found when factId is absent', () => {
+    const out = writeFactSourceToYaml({
+      entitySid: 'sid_EntEntEnt0',
+      factId: 'f_DoesNotExi',
+      url: 'https://example.com/x',
+      index,
+    });
+    expect(out.status).toBe('not-found');
+  });
+
+  it('returns no-yaml-target when entity sid is not indexed', () => {
+    const out = writeFactSourceToYaml({
+      entitySid: 'sid_NotIndexed',
+      factId: 'f_FactFactNo',
+      url: 'https://example.com/x',
+      index,
+    });
+    expect(out.status).toBe('no-yaml-target');
+    expect(out.filepath).toBeNull();
+  });
+
+  // Regression: PR #4871 — same root cause as the stakeholder writer. The
+  // FactBase YAML serializer at default lineWidth:80 re-wraps long strings on
+  // every save. We pass lineWidth:120 to match the codebase's other YAML
+  // writers (extract-structured-data, factbase-migrate). Lines ≤120 cols must
+  // survive verbatim.
+  it('preserves moderately-long unrelated lines verbatim (≤120 cols)', () => {
+    // ~110 chars — would fold at default 80, must NOT fold at 120.
+    const MODERATE_NOTE =
+      'Series E at $61.5B post-money per Bloomberg, Reuters; Lightspeed lead, Salesforce Ventures and Cisco participating.';
+
+    const moderateLineYaml = `entity: sid_EntModrLin
+facts:
+  - id: f_FactNoSrc1
+    property: revenue
+    value: 1.2e+9
+    asOf: 2025-09
+  - id: f_FactHasSrc
+    property: valuation
+    value: 6.15e+10
+    asOf: 2025-03
+    notes: ${MODERATE_NOTE}
+    source: https://existing.example.com/series-e
+`;
+    writeFileSync(yamlPath, moderateLineYaml, 'utf-8');
+    index = {
+      sidToFilepath: new Map([['sid_EntModrLin', yamlPath]]),
+      unindexedCount: 0,
+    };
+
+    const out = writeFactSourceToYaml({
+      entitySid: 'sid_EntModrLin',
+      factId: 'f_FactNoSrc1',
+      url: 'https://example.com/news',
+      index,
+    });
+    expect(out.status).toBe('wrote');
+
+    const after = readFileSync(yamlPath, 'utf-8');
+
+    expect(after).toContain(`notes: ${MODERATE_NOTE}\n`);
+    expect(after).toContain('source: https://example.com/news');
+    expect(after).toContain('source: https://existing.example.com/series-e');
+  });
+
+  // Regression: PR #4871 follow-up. The writer was unconditionally setting
+  // `notes: [auto-discovered by tb backfill-sources]` on the targeted fact,
+  // overwriting any human-written notes. Existing notes must survive.
+  it('does not clobber existing notes on the targeted fact', () => {
+    const HUMAN_NOTE = 'Verified against Anthropic shareholder filing 2025-03';
+    const yaml = `entity: sid_EntKeepNot
+facts:
+  - id: f_FactKeepNo
+    property: revenue
+    value: 1.2e+9
+    asOf: 2025-09
+    notes: ${HUMAN_NOTE}
+`;
+    writeFileSync(yamlPath, yaml, 'utf-8');
+    index = {
+      sidToFilepath: new Map([['sid_EntKeepNot', yamlPath]]),
+      unindexedCount: 0,
+    };
+
+    const out = writeFactSourceToYaml({
+      entitySid: 'sid_EntKeepNot',
+      factId: 'f_FactKeepNo',
+      url: 'https://example.com/news',
+      index,
+    });
+    expect(out.status).toBe('wrote');
+
+    const after = readFileSync(yamlPath, 'utf-8');
+    expect(after).toContain(`notes: ${HUMAN_NOTE}`);
+    expect(after).toContain('source: https://example.com/news');
+    expect(after).not.toContain('[auto-discovered by tb backfill-sources]');
+  });
+});

--- a/crux/lib/backfill-sources/__tests__/yaml-write-stakeholder.test.ts
+++ b/crux/lib/backfill-sources/__tests__/yaml-write-stakeholder.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeStakeholderSourceToYaml } from '../yaml-write-stakeholder.ts';
+import type { PolicyEntityIndex } from '../yaml-target-resolvers.ts';
+
+const SAMPLE_YAML = `- id: aisi
+  stableId: sid_PolicyPol1
+  type: policy
+  title: AISI
+  stakeholders:
+    - name: UK Government
+      position: support
+      importance: high
+      reason: pioneered AISI
+    - name: US Government
+      position: support
+      importance: high
+      reason: established USAISI
+- id: ca-sb1047
+  stableId: sid_PolicyPol2
+  type: policy
+  stakeholders:
+    - name: California Senate
+      position: oppose
+      importance: high
+      reason: vetoed
+    - name: Tech industry
+      position: oppose
+      importance: medium
+      reason: feared overreach
+    - name: Tech industry
+      position: support
+      importance: low
+      reason: subset endorsed gates
+`;
+
+let tmpRoot: string;
+let yamlPath: string;
+let index: PolicyEntityIndex;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'yaml-stake-'));
+  mkdirSync(tmpRoot, { recursive: true });
+  yamlPath = join(tmpRoot, 'responses.yaml');
+  writeFileSync(yamlPath, SAMPLE_YAML, 'utf-8');
+  index = {
+    sidToFilepath: new Map([
+      ['sid_PolicyPol1', yamlPath],
+      ['sid_PolicyPol2', yamlPath],
+    ]),
+    parseFailureCount: 0,
+  };
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('writeStakeholderSourceToYaml', () => {
+  it('writes source to a single name match', () => {
+    const out = writeStakeholderSourceToYaml({
+      policyEntitySid: 'sid_PolicyPol1',
+      stakeholderName: 'UK Government',
+      position: 'support',
+      url: 'https://example.com/uk-aisi',
+      index,
+    });
+    expect(out.status).toBe('wrote');
+    expect(out.filepath).toBe(yamlPath);
+
+    const after = readFileSync(yamlPath, 'utf-8');
+    expect(after).toContain('source: https://example.com/uk-aisi');
+    expect(after).toContain('reason: pioneered AISI');
+    expect(after).toContain('reason: established USAISI');
+    // The other policy is untouched.
+    expect(after).toContain('California Senate');
+  });
+
+  it('skips when source already exists and is non-empty', () => {
+    const initial = SAMPLE_YAML.replace(
+      'reason: pioneered AISI',
+      'reason: pioneered AISI\n      source: https://existing.example.com',
+    );
+    writeFileSync(yamlPath, initial, 'utf-8');
+
+    const out = writeStakeholderSourceToYaml({
+      policyEntitySid: 'sid_PolicyPol1',
+      stakeholderName: 'UK Government',
+      position: 'support',
+      url: 'https://example.com/new-source',
+      index,
+    });
+    expect(out.status).toBe('skipped-existing');
+    const after = readFileSync(yamlPath, 'utf-8');
+    expect(after).toContain('https://existing.example.com');
+    expect(after).not.toContain('https://example.com/new-source');
+  });
+
+  it('returns no-yaml-target when policy sid not in index', () => {
+    const out = writeStakeholderSourceToYaml({
+      policyEntitySid: 'sid_NotInIndex',
+      stakeholderName: 'UK Government',
+      position: 'support',
+      url: 'https://example.com/x',
+      index,
+    });
+    expect(out.status).toBe('no-yaml-target');
+    expect(out.filepath).toBeNull();
+  });
+
+  it('returns not-found when stakeholder name absent in policy', () => {
+    const out = writeStakeholderSourceToYaml({
+      policyEntitySid: 'sid_PolicyPol1',
+      stakeholderName: 'Atlantis Senate',
+      position: 'support',
+      url: 'https://example.com/x',
+      index,
+    });
+    expect(out.status).toBe('not-found');
+  });
+
+  it('disambiguates duplicate names by position', () => {
+    const out = writeStakeholderSourceToYaml({
+      policyEntitySid: 'sid_PolicyPol2',
+      stakeholderName: 'Tech industry',
+      position: 'support',
+      url: 'https://example.com/tech-support',
+      index,
+    });
+    expect(out.status).toBe('wrote');
+
+    const after = readFileSync(yamlPath, 'utf-8');
+    expect(after).toContain('source: https://example.com/tech-support');
+    // The other Tech-industry entry (oppose) does not get a source.
+    const opposeSection = after
+      .split('- name: Tech industry\n      position: oppose')[1]
+      ?.split('- name: Tech industry\n      position: support')[0] ?? '';
+    expect(opposeSection).not.toContain('source: https://example.com/tech-support');
+  });
+
+  it('returns not-found on duplicate name without a position to disambiguate', () => {
+    const out = writeStakeholderSourceToYaml({
+      policyEntitySid: 'sid_PolicyPol2',
+      stakeholderName: 'Tech industry',
+      position: null,
+      url: 'https://example.com/x',
+      index,
+    });
+    expect(out.status).toBe('not-found');
+  });
+
+  // Regression: PR #4871 showed responses.yaml getting reformatted end-to-end
+  // because doc.toString() defaults to lineWidth: 80 and re-wraps long string
+  // literals (typical descriptions/reasons in these files are ~100 chars).
+  // We pass lineWidth: 120 to match the convention used by other writers
+  // (extract-structured-data, political-data, factbase-migrate) so the same
+  // file isn't re-folded back and forth. Lines ≤120 chars must survive
+  // verbatim.
+  it('preserves moderately-long unrelated lines verbatim (≤120 cols)', () => {
+    // 90-100 chars at deepest indent — would fold at default 80, must NOT
+    // fold at 120 even after the stakeholder-level indent (6 spaces).
+    const MODERATE_DESCRIPTION =
+      'Government-run AISI institutions evaluating frontier AI systems for dangerous capabilities.';
+    const MODERATE_REASON =
+      'Pursues its own AI safety evaluation approach through domestic institutions.';
+
+    const moderateLineYaml = `- id: aisi
+  stableId: sid_PolicyMod1
+  type: policy
+  title: AISI
+  description: ${MODERATE_DESCRIPTION}
+  stakeholders:
+    - name: UK Government
+      position: support
+      importance: high
+      reason: pioneered AISI
+    - name: China
+      position: mixed
+      importance: medium
+      reason: ${MODERATE_REASON}
+`;
+    writeFileSync(yamlPath, moderateLineYaml, 'utf-8');
+    index = {
+      sidToFilepath: new Map([['sid_PolicyMod1', yamlPath]]),
+      parseFailureCount: 0,
+    };
+
+    const out = writeStakeholderSourceToYaml({
+      policyEntitySid: 'sid_PolicyMod1',
+      stakeholderName: 'UK Government',
+      position: 'support',
+      url: 'https://example.com/uk-aisi',
+      index,
+    });
+    expect(out.status).toBe('wrote');
+
+    const after = readFileSync(yamlPath, 'utf-8');
+
+    expect(after).toContain(`description: ${MODERATE_DESCRIPTION}\n`);
+    expect(after).toContain(`reason: ${MODERATE_REASON}\n`);
+
+    const beforeLines = moderateLineYaml.split('\n');
+    const afterLines = after.split('\n');
+    expect(afterLines.length).toBe(beforeLines.length + 1);
+  });
+});

--- a/crux/lib/backfill-sources/content-cache.ts
+++ b/crux/lib/backfill-sources/content-cache.ts
@@ -1,0 +1,44 @@
+/**
+ * On-disk cache of every page text that was ever sent to a judge during a
+ * backfill-sources run. The candidate record stores only the sha256; the
+ * actual bytes are written here so a single candidate can be replayed
+ * byte-for-byte after the run by reading the file at
+ * `<dir>/<sha256>.txt`.
+ *
+ * Default location: `dev/backfill-content-cache/`. Override with
+ * `BACKFILL_CONTENT_CACHE_DIR=<path>`.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DEFAULT_DIR = 'dev/backfill-content-cache';
+
+let _cacheDir: string | null = null;
+function cacheDir(): string {
+  if (_cacheDir !== null) return _cacheDir;
+  _cacheDir = process.env.BACKFILL_CONTENT_CACHE_DIR ?? DEFAULT_DIR;
+  mkdirSync(_cacheDir, { recursive: true });
+  return _cacheDir;
+}
+
+/**
+ * Hash + persist `text`. Returns the sha256. Idempotent: if a file at the
+ * sha256 path already exists we skip the write. Writes are best-effort —
+ * a write failure logs a warning but does not throw, since the run can
+ * continue without the cache (the hash is still recorded in the report).
+ */
+export function rememberContent(text: string): string {
+  const sha = createHash('sha256').update(text).digest('hex');
+  const path = join(cacheDir(), `${sha}.txt`);
+  if (!existsSync(path)) {
+    try {
+      writeFileSync(path, text);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[content-cache] write failed for ${sha.slice(0, 8)}: ${msg}`);
+    }
+  }
+  return sha;
+}

--- a/crux/lib/backfill-sources/content-cache.ts
+++ b/crux/lib/backfill-sources/content-cache.ts
@@ -16,11 +16,24 @@ import { join } from 'node:path';
 const DEFAULT_DIR = 'dev/backfill-content-cache';
 
 let _cacheDir: string | null = null;
+let _cacheDirReady = false;
 function cacheDir(): string {
   if (_cacheDir !== null) return _cacheDir;
   _cacheDir = process.env.BACKFILL_CONTENT_CACHE_DIR ?? DEFAULT_DIR;
-  mkdirSync(_cacheDir, { recursive: true });
   return _cacheDir;
+}
+
+function ensureCacheDir(dir: string): boolean {
+  if (_cacheDirReady) return true;
+  try {
+    mkdirSync(dir, { recursive: true });
+    _cacheDirReady = true;
+    return true;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[content-cache] mkdir failed for ${dir}: ${msg}`);
+    return false;
+  }
 }
 
 /**
@@ -31,7 +44,9 @@ function cacheDir(): string {
  */
 export function rememberContent(text: string): string {
   const sha = createHash('sha256').update(text).digest('hex');
-  const path = join(cacheDir(), `${sha}.txt`);
+  const dir = cacheDir();
+  if (!ensureCacheDir(dir)) return sha;
+  const path = join(dir, `${sha}.txt`);
   if (!existsSync(path)) {
     try {
       writeFileSync(path, text);

--- a/crux/lib/backfill-sources/llm-calls.ts
+++ b/crux/lib/backfill-sources/llm-calls.ts
@@ -5,6 +5,11 @@
  * the response, return `(parsedResult, costUsd)`. On any error we log a
  * warning and return a "no support" / fallback result with cost 0 — the
  * pipeline keeps running rather than halting on a single transient failure.
+ *
+ * Dual-judge: when enabled, the local vLLM server is queried with the same
+ * prompt in parallel with Haiku/Sonnet. The vLLM result is returned
+ * alongside the primary result for offline comparison only — it never
+ * influences accept/reject decisions or DB writes.
  */
 
 import { createLlmClient, streamingCreate, extractText, MODELS } from '../llm.ts';
@@ -18,20 +23,76 @@ import {
   parseRankingResponse,
 } from './prompts.ts';
 import type { RankCandidate } from './types.ts';
+import { callVllm, loadVllmConfig, type VllmConfig } from './vllm-client.ts';
+
+let _vllmConfig: VllmConfig | null = null;
+function vllmConfig(): VllmConfig {
+  if (!_vllmConfig) _vllmConfig = loadVllmConfig();
+  return _vllmConfig;
+}
+
+/** Parallel vLLM observation for a quote-extraction call (or null if disabled/failed). */
+export interface VllmQuoteObservation {
+  raw_text: string;
+  quotes: string[];
+  duration_ms: number;
+}
+
+/** Parallel vLLM observation for an entailment call. */
+export interface VllmEntailmentObservation {
+  raw_text: string;
+  /** null when the model's output couldn't be parsed as {"supports": bool}. */
+  supports: boolean | null;
+  duration_ms: number;
+}
 
 /** Haiku: extract up to 3 verbatim supporting passages, or [] if none. */
 export async function extractSupportingQuotes(
   claim: string,
   entityName: string,
   content: string,
-): Promise<{ quotes: string[]; cost: number }> {
+): Promise<{
+  quotes: string[];
+  cost: number;
+  rawText: string;
+  durationMs: number;
+  vllm: VllmQuoteObservation | null;
+}> {
   const prompt = buildQuoteExtractionPrompt(claim, entityName, content);
+  const [haiku, vllm] = await Promise.all([
+    callHaikuQuotes(prompt),
+    callVllm(prompt, 400, vllmConfig()),
+  ]);
+  return {
+    quotes: haiku.quotes,
+    cost: haiku.cost,
+    rawText: haiku.rawText,
+    durationMs: haiku.durationMs,
+    vllm: vllm
+      ? {
+          raw_text: vllm.text,
+          quotes: parseQuoteResponse(vllm.text) ?? [],
+          duration_ms: vllm.durationMs,
+        }
+      : null,
+  };
+}
+
+async function callHaikuQuotes(
+  prompt: string,
+): Promise<{ quotes: string[]; cost: number; rawText: string; durationMs: number }> {
+  const started = Date.now();
   try {
     const { text, cost } = await callLlm(MODELS.haiku, prompt, 400);
-    return { quotes: parseQuoteResponse(text) ?? [], cost };
+    return {
+      quotes: parseQuoteResponse(text) ?? [],
+      cost,
+      rawText: text,
+      durationMs: Date.now() - started,
+    };
   } catch (err: unknown) {
     console.warn(`  Quote extraction failed (${errMessage(err)})`);
-    return { quotes: [], cost: 0 };
+    return { quotes: [], cost: 0, rawText: '', durationMs: Date.now() - started };
   }
 }
 
@@ -41,15 +102,49 @@ export async function verifyEntailment(
   quotes: string[],
   sourceUrl?: string,
   sourceTitle?: string,
-): Promise<{ supports: boolean; cost: number }> {
+): Promise<{
+  supports: boolean;
+  cost: number;
+  rawText: string;
+  durationMs: number;
+  vllm: VllmEntailmentObservation | null;
+}> {
   const prompt = buildEntailmentPrompt(claim, quotes, sourceUrl, sourceTitle);
+  const [sonnet, vllm] = await Promise.all([
+    callSonnetEntailment(prompt),
+    callVllm(prompt, 50, vllmConfig()),
+  ]);
+  return {
+    supports: sonnet.supports,
+    cost: sonnet.cost,
+    rawText: sonnet.rawText,
+    durationMs: sonnet.durationMs,
+    vllm: vllm
+      ? {
+          raw_text: vllm.text,
+          supports: parseEntailmentResponse(vllm.text),
+          duration_ms: vllm.durationMs,
+        }
+      : null,
+  };
+}
+
+async function callSonnetEntailment(
+  prompt: string,
+): Promise<{ supports: boolean; cost: number; rawText: string; durationMs: number }> {
+  const started = Date.now();
   try {
     const { text, cost } = await callLlm(MODELS.sonnet, prompt, 50);
     const supports = parseEntailmentResponse(text);
-    return { supports: supports === true, cost };
+    return {
+      supports: supports === true,
+      cost,
+      rawText: text,
+      durationMs: Date.now() - started,
+    };
   } catch (err: unknown) {
     console.warn(`  Entailment check failed (${errMessage(err)})`);
-    return { supports: false, cost: 0 };
+    return { supports: false, cost: 0, rawText: '', durationMs: Date.now() - started };
   }
 }
 
@@ -57,6 +152,10 @@ export async function verifyEntailment(
  * Haiku: pick the single matching source that best directly supports the
  * claim. Returns the index plus the call's USD cost. On error or unparseable
  * output, falls back to index 0 so the caller still gets an answer.
+ *
+ * Dual-judge is intentionally NOT applied here — ranking only fires when
+ * multiple candidates pass verification (rare), and the comparison signal
+ * we care about is on the per-source accept/reject decision.
  */
 export async function rankMatchingSources(
   claim: string,

--- a/crux/lib/backfill-sources/process-record.ts
+++ b/crux/lib/backfill-sources/process-record.ts
@@ -19,7 +19,12 @@ import { rankMatchingSources } from './llm-calls.ts';
 import { extractMatchTerms } from './match-terms.ts';
 import { verifySource } from './verify-source.ts';
 import type { RejectionReason, VerifyResult } from './verify-source.ts';
-import type { CostBreakdown, MissingSourceRecord, RankCandidate } from './types.ts';
+import type {
+  CandidateRecord,
+  CostBreakdown,
+  MissingSourceRecord,
+  RankCandidate,
+} from './types.ts';
 
 export interface ProcessOptions {
   dryRun: boolean;
@@ -28,8 +33,15 @@ export interface ProcessOptions {
 }
 
 export type ProcessResult =
-  | { matched: true; url: string; provider?: string; quotes?: string[]; cost: CostBreakdown }
-  | { matched: false; reason: string; cost: CostBreakdown };
+  | {
+      matched: true;
+      url: string;
+      provider?: string;
+      quotes?: string[];
+      cost: CostBreakdown;
+      candidates: CandidateRecord[];
+    }
+  | { matched: false; reason: string; cost: CostBreakdown; candidates: CandidateRecord[] };
 
 /**
  * Run the full pipeline for one record. Caller is responsible for the actual
@@ -49,7 +61,13 @@ export async function processRecord(
   const selfSource = selfSourcingUrl(record);
   if (selfSource) {
     console.log(`  ✓ Self-sourced (value is a URL): ${selfSource}`);
-    return { matched: true, url: selfSource, provider: 'self-sourced', cost };
+    return {
+      matched: true,
+      url: selfSource,
+      provider: 'self-sourced',
+      cost,
+      candidates: [],
+    };
   }
 
   const entityName = (record.entity_name ?? '').trim();
@@ -59,13 +77,18 @@ export async function processRecord(
 
   const sources = await fetchCandidateSources(record, cost);
   if (sources === null) {
-    return { matched: false, reason: 'search failed', cost };
+    return { matched: false, reason: 'search failed', cost, candidates: [] };
   }
 
   const matches = await verifyAllSources(sources, claim, entityName, mentionTargets, cost, options);
 
   if (matches.accepted.length === 0) {
-    return { matched: false, reason: matches.rejectionSummary, cost };
+    return {
+      matched: false,
+      reason: matches.rejectionSummary,
+      cost,
+      candidates: matches.candidates,
+    };
   }
 
   const chosen = await pickBestMatch(matches.accepted, record, matchTerms, cost);
@@ -79,6 +102,7 @@ export async function processRecord(
     provider: chosen.provider,
     quotes: chosen.quotes,
     cost,
+    candidates: matches.candidates,
   };
 }
 
@@ -127,6 +151,7 @@ async function fetchCandidateSources(
 interface VerifyAllResult {
   accepted: RankCandidate[];
   rejectionSummary: string;
+  candidates: CandidateRecord[];
 }
 
 async function verifyAllSources(
@@ -138,12 +163,14 @@ async function verifyAllSources(
   options: ProcessOptions,
 ): Promise<VerifyAllResult> {
   const accepted: RankCandidate[] = [];
+  const candidates: CandidateRecord[] = [];
   const rejectionCounts: Partial<Record<RejectionReason, number>> = {};
 
   for (const source of sources) {
     const result = await verifySource(source, claim, entityName, mentionTargets);
     cost.quoteExtractCost += result.cost.quoteExtractCost;
     cost.entailmentCost += result.cost.entailmentCost;
+    candidates.push(result.record);
 
     if (options.debug) logVerifyResult(source.url, result);
 
@@ -154,10 +181,15 @@ async function verifyAllSources(
     }
   }
 
-  return { accepted, rejectionSummary: summarizeRejections(rejectionCounts) };
+  return {
+    accepted,
+    rejectionSummary: summarizeRejections(rejectionCounts),
+    candidates,
+  };
 }
 
 const REJECTION_LABELS: Record<RejectionReason, string> = {
+  'invalid-url': 'invalid URL',
   'self-domain': 'self domain',
   'placeholder-url': 'placeholder URL',
   'too-short': 'content too short',

--- a/crux/lib/backfill-sources/report.ts
+++ b/crux/lib/backfill-sources/report.ts
@@ -186,7 +186,9 @@ function serializeOutcome({ record, outcome }: RecordOutcome) {
       // Verbatim quotes Sonnet judged as supporting the claim — included so a
       // human can spot-check for false positives without re-running.
       quotes: outcome.quotes ?? [],
+      yaml_write: outcome.yaml_write ?? null,
       cost_usd: totalOf(outcome.cost),
+      candidates: outcome.candidates,
     };
   }
   if (outcome.kind === 'no-match') {
@@ -195,6 +197,7 @@ function serializeOutcome({ record, outcome }: RecordOutcome) {
       outcome: 'no-match' as const,
       reason: outcome.reason,
       cost_usd: totalOf(outcome.cost),
+      candidates: outcome.candidates,
     };
   }
   return { ...base, outcome: 'skipped' as const, reason: outcome.reason, cost_usd: 0 };

--- a/crux/lib/backfill-sources/types.ts
+++ b/crux/lib/backfill-sources/types.ts
@@ -41,10 +41,105 @@ export interface CostBreakdown {
   rankCost: number;
 }
 
+/**
+ * Per-source detail captured during verification. One CandidateRecord per
+ * URL the pipeline considered for a record — both rejected and accepted —
+ * so reports can be triaged after the fact without re-running the search.
+ *
+ * Both judges' observations are stored when the dual-judge wrapper is
+ * enabled; vLLM fields are null when it's disabled or unreachable. The
+ * Haiku-side fields drive every accept/reject and DB write; the vLLM
+ * fields exist only for offline comparison.
+ */
+export interface CandidateRecord {
+  url: string;
+  provider?: string;
+  title?: string;
+  decision: 'accepted' | 'rejected';
+  /** Set when decision === 'rejected'. */
+  rejection_reason: string | null;
+  /** Slots the entity-mention check reported as missing (debug aid). */
+  missing_slots?: string[][];
+  /** sha256 of the exact page text passed to the judges. The text itself is
+   *  written under that hash to BACKFILL_CONTENT_CACHE_DIR (default
+   *  `dev/backfill-content-cache/`) so any candidate can be replayed
+   *  byte-for-byte after the run. Null when no LLM call was made (cheap
+   *  pre-checks rejected the candidate before content ever reached a model). */
+  content_sha256: string | null;
+  /** Length of the page text passed to the judges (chars). */
+  content_chars: number | null;
+  /** Quote-extraction stage observations. Both judges saw the same prompt
+   *  (built from claim + entity + content); raw responses captured verbatim. */
+  quote_extraction: {
+    haiku: {
+      raw_text: string;
+      quotes: string[];
+      duration_ms: number;
+    };
+    vllm: {
+      raw_text: string;
+      quotes: string[];
+      verified_quotes: string[];
+      duration_ms: number;
+    } | null;
+    /** The subset of haiku.quotes that actually appear verbatim in the page. */
+    haiku_verified_quotes: string[];
+  } | null;
+  /** Entailment stage observations. Only populated when quote-extraction
+   *  produced verbatim quotes (otherwise verification rejected before this
+   *  stage). The verified_quotes that drove this call are reproducible from
+   *  the quote_extraction.haiku_verified_quotes field. */
+  entailment: {
+    sonnet: {
+      raw_text: string;
+      supports: boolean;
+      duration_ms: number;
+    };
+    vllm: {
+      raw_text: string;
+      decision: 'supports' | 'no-support' | 'unparseable';
+      duration_ms: number;
+    } | null;
+  } | null;
+}
+
+/**
+ * YAML write outcome for one record's dual-write mirror.
+ *
+ *   wrote            — source: <url> appended to the right entity in YAML
+ *   skipped-existing — entity/stakeholder already had a non-empty source
+ *   not-found        — entity/stakeholder couldn't be located in YAML
+ *   no-yaml-target   — entity sid wasn't in the index (legacy thing: file)
+ *   not-applicable   — record's table isn't YAML-mirrored (no write needed)
+ *   error            — read or write IO failure (see error string)
+ */
+export type YamlWriteStatusReport =
+  | 'wrote'
+  | 'skipped-existing'
+  | 'not-found'
+  | 'no-yaml-target'
+  | 'not-applicable'
+  | 'error';
+
+export interface YamlWriteRecordReport {
+  status: YamlWriteStatusReport;
+  filepath: string | null;
+  error?: string;
+}
+
 /** Per-record outcome captured for the summary + JSON report. */
 export type Outcome =
-  | { kind: 'matched'; url: string; provider?: string; quotes?: string[]; updated?: boolean; cost: CostBreakdown }
-  | { kind: 'no-match'; reason: string; cost: CostBreakdown }
+  | {
+      kind: 'matched';
+      url: string;
+      provider?: string;
+      quotes?: string[];
+      updated?: boolean;
+      yaml_write?: YamlWriteRecordReport;
+      cost: CostBreakdown;
+      candidates: CandidateRecord[];
+    }
+  | { kind: 'no-match'; reason: string; cost: CostBreakdown; candidates: CandidateRecord[] }
   | { kind: 'skipped'; reason: string };
 
 export interface RecordOutcome {

--- a/crux/lib/backfill-sources/verify-source.ts
+++ b/crux/lib/backfill-sources/verify-source.ts
@@ -16,10 +16,11 @@
  */
 
 import { MIN_CONTENT_LENGTH } from './config.ts';
+import { rememberContent } from './content-cache.ts';
 import { contentMentionsEntity, isSelfDomain } from './entity-mention.ts';
 import { extractSupportingQuotes, verifyEntailment } from './llm-calls.ts';
 import { verifyQuoteInContent } from './prompts.ts';
-import type { RankCandidate } from './types.ts';
+import type { CandidateRecord, RankCandidate } from './types.ts';
 
 export type RejectionReason =
   | 'invalid-url'
@@ -77,11 +78,12 @@ export interface VerifyCost {
 }
 
 export type VerifyResult =
-  | { kind: 'accepted'; candidate: RankCandidate; cost: VerifyCost }
+  | { kind: 'accepted'; candidate: RankCandidate; cost: VerifyCost; record: CandidateRecord }
   | {
       kind: 'rejected';
       reason: RejectionReason;
       cost: VerifyCost;
+      record: CandidateRecord;
       /** Extra context for debug logs (e.g. missing entity slots, fabricated quotes). */
       detail?: { missingSlots?: string[][]; haikuQuotes?: string[]; verifiedQuotes?: string[] };
     };
@@ -105,60 +107,124 @@ export async function verifySource(
   mentionTargets: string[][],
 ): Promise<VerifyResult> {
   const cost: VerifyCost = { quoteExtractCost: 0, entailmentCost: 0 };
+  const record: CandidateRecord = {
+    url: source.url,
+    provider: source.provider,
+    title: source.title,
+    decision: 'rejected',
+    rejection_reason: null,
+    content_sha256: null,
+    content_chars: null,
+    quote_extraction: null,
+    entailment: null,
+  };
 
   if (!isHttpUrl(source.url)) {
-    return { kind: 'rejected', reason: 'invalid-url', cost };
+    record.rejection_reason = 'invalid-url';
+    return { kind: 'rejected', reason: 'invalid-url', cost, record };
   }
 
   if (isSelfDomain(source.url)) {
-    return { kind: 'rejected', reason: 'self-domain', cost };
+    record.rejection_reason = 'self-domain';
+    return { kind: 'rejected', reason: 'self-domain', cost, record };
   }
 
   if (isPlaceholderUrl(source.url)) {
-    return { kind: 'rejected', reason: 'placeholder-url', cost };
+    record.rejection_reason = 'placeholder-url';
+    return { kind: 'rejected', reason: 'placeholder-url', cost, record };
   }
 
   if (source.content.length < MIN_CONTENT_LENGTH) {
-    return { kind: 'rejected', reason: 'too-short', cost };
+    record.rejection_reason = 'too-short';
+    return { kind: 'rejected', reason: 'too-short', cost, record };
   }
 
   const missingSlots = mentionTargets.filter(
     variants => !variants.some(v => contentMentionsEntity(source.content, v, source.url)),
   );
   if (missingSlots.length > 0) {
-    return { kind: 'rejected', reason: 'no-entity-mention', cost, detail: { missingSlots } };
+    record.rejection_reason = 'no-entity-mention';
+    record.missing_slots = missingSlots;
+    return { kind: 'rejected', reason: 'no-entity-mention', cost, record, detail: { missingSlots } };
   }
+
+  // Persist the exact text the judges saw before any LLM call so the
+  // call can be replayed byte-for-byte after the run.
+  record.content_sha256 = rememberContent(source.content);
+  record.content_chars = source.content.length;
 
   const extracted = await extractSupportingQuotes(claim, entityName, source.content);
   cost.quoteExtractCost = extracted.cost;
+  const haikuVerified = extracted.quotes.filter(q => verifyQuoteInContent(q, source.content));
+  record.quote_extraction = {
+    haiku: {
+      raw_text: extracted.rawText,
+      quotes: extracted.quotes,
+      duration_ms: extracted.durationMs,
+    },
+    haiku_verified_quotes: haikuVerified,
+    vllm: extracted.vllm
+      ? {
+          raw_text: extracted.vllm.raw_text,
+          quotes: extracted.vllm.quotes,
+          verified_quotes: extracted.vllm.quotes.filter(q => verifyQuoteInContent(q, source.content)),
+          duration_ms: extracted.vllm.duration_ms,
+        }
+      : null,
+  };
   if (extracted.quotes.length === 0) {
-    return { kind: 'rejected', reason: 'no-quote', cost };
+    record.rejection_reason = 'no-quote';
+    return { kind: 'rejected', reason: 'no-quote', cost, record };
   }
 
-  const verifiedQuotes = extracted.quotes.filter(q => verifyQuoteInContent(q, source.content));
-  if (verifiedQuotes.length === 0) {
+  if (haikuVerified.length === 0) {
+    record.rejection_reason = 'quote-fabricated';
     return {
       kind: 'rejected',
       reason: 'quote-fabricated',
       cost,
+      record,
       detail: { haikuQuotes: extracted.quotes },
     };
   }
 
-  const entailment = await verifyEntailment(claim, verifiedQuotes, source.url, source.title);
+  const entailment = await verifyEntailment(claim, haikuVerified, source.url, source.title);
   cost.entailmentCost = entailment.cost;
+  record.entailment = {
+    sonnet: {
+      raw_text: entailment.rawText,
+      supports: entailment.supports,
+      duration_ms: entailment.durationMs,
+    },
+    vllm: entailment.vllm
+      ? {
+          raw_text: entailment.vllm.raw_text,
+          decision:
+            entailment.vllm.supports === true
+              ? 'supports'
+              : entailment.vllm.supports === false
+                ? 'no-support'
+                : 'unparseable',
+          duration_ms: entailment.vllm.duration_ms,
+        }
+      : null,
+  };
   if (!entailment.supports) {
-    return { kind: 'rejected', reason: 'entailment-failed', cost, detail: { verifiedQuotes } };
+    record.rejection_reason = 'entailment-failed';
+    return { kind: 'rejected', reason: 'entailment-failed', cost, record, detail: { verifiedQuotes: haikuVerified } };
   }
 
+  record.decision = 'accepted';
+  record.rejection_reason = null;
   return {
     kind: 'accepted',
     cost,
+    record,
     candidate: {
       url: source.url,
       snippet: source.content.slice(0, 600),
       provider: source.provider,
-      quotes: verifiedQuotes,
+      quotes: haikuVerified,
     },
   };
 }

--- a/crux/lib/backfill-sources/vllm-client.ts
+++ b/crux/lib/backfill-sources/vllm-client.ts
@@ -1,0 +1,76 @@
+/**
+ * Minimal OpenAI-compatible client for the local vLLM server used as a
+ * second judge alongside Haiku. The vLLM result is recorded for offline
+ * comparison only — Haiku's result still drives every accept/reject and
+ * every DB write. Failures here must never break the pipeline.
+ */
+
+const DEFAULT_BASE_URL = 'http://localhost:8000/v1';
+const DEFAULT_MODEL = '/root/model-gptq';
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export interface VllmConfig {
+  enabled: boolean;
+  baseUrl: string;
+  model: string;
+  timeoutMs: number;
+}
+
+export function loadVllmConfig(): VllmConfig {
+  const enabled = process.env.BACKFILL_DUAL_JUDGE !== '0';
+  return {
+    enabled,
+    baseUrl: process.env.VLLM_BASE_URL ?? DEFAULT_BASE_URL,
+    model: process.env.VLLM_MODEL ?? DEFAULT_MODEL,
+    timeoutMs: Number(process.env.VLLM_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS),
+  };
+}
+
+export interface VllmResult {
+  text: string;
+  durationMs: number;
+}
+
+export async function callVllm(
+  prompt: string,
+  maxTokens: number,
+  config: VllmConfig,
+): Promise<VllmResult | null> {
+  if (!config.enabled) return null;
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), config.timeoutMs);
+  const started = Date.now();
+  try {
+    const res = await fetch(`${config.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: config.model,
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: maxTokens,
+        temperature: 0,
+        // vLLM honors OpenAI's JSON-mode hint and constrains output to a
+        // single valid JSON object — prevents unescaped inner quotes from
+        // breaking our `extractJsonObject` parser (seen on quotes that
+        // legitimately contain `"`).
+        response_format: { type: 'json_object' },
+      }),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) {
+      console.warn(`  [vllm] HTTP ${res.status} (${(Date.now() - started) | 0}ms)`);
+      return null;
+    }
+    const body = await res.json() as {
+      choices?: { message?: { content?: string } }[];
+    };
+    const text = body.choices?.[0]?.message?.content ?? '';
+    return { text, durationMs: Date.now() - started };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`  [vllm] call failed: ${msg}`);
+    return null;
+  } finally {
+    clearTimeout(t);
+  }
+}

--- a/crux/lib/backfill-sources/yaml-pr.ts
+++ b/crux/lib/backfill-sources/yaml-pr.ts
@@ -1,0 +1,209 @@
+/**
+ * End-of-run helper: take the set of YAML files we mutated this run and
+ * commit/push/PR them on a fresh branch off origin/main — without ever
+ * touching the operator's working tree or current branch.
+ *
+ * Approach: snapshot the touched YAMLs from the operator's tree, then do
+ * all git work inside a temporary `git worktree` checked out at origin/main.
+ * The worktree gets removed at the end (success or failure), so the
+ * operator's working state is preserved exactly as they had it.
+ *
+ * Refuses to run when:
+ *   - the current branch is `main` (we'd auto-commit into the merge target)
+ *   - no touched YAMLs exist (nothing to commit)
+ */
+
+import { execSync } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+export interface OpenYamlPrInput {
+  touchedPaths: string[];
+  /** ISO timestamp suffix for the branch name. */
+  runStartedAt: string;
+  /** Stat block printed in the PR body for context. */
+  summary: {
+    matched: number;
+    factsWritten: number;
+    stakeholdersWritten: number;
+  };
+}
+
+export type YamlPrResult =
+  | { kind: 'opened'; branch: string; prUrl: string }
+  | { kind: 'refused'; reason: string }
+  | { kind: 'error'; error: string };
+
+export function openYamlPr(input: OpenYamlPrInput): YamlPrResult {
+  if (input.touchedPaths.length === 0) {
+    return { kind: 'refused', reason: 'no YAML files touched this run' };
+  }
+
+  const currentBranch = trySh('git rev-parse --abbrev-ref HEAD');
+  if (!currentBranch) {
+    return { kind: 'error', error: 'failed to read current branch' };
+  }
+  if (currentBranch === 'main') {
+    return { kind: 'refused', reason: 'refusing to auto-commit on main' };
+  }
+
+  return runYamlPrFlow(input);
+}
+
+function runYamlPrFlow(input: OpenYamlPrInput): YamlPrResult {
+  // Use an explicit refspec so this works even in shallow / single-branch
+  // clones where the default fetch refspec doesn't include `main`.
+  try {
+    sh('git fetch origin main:refs/remotes/origin/main');
+  } catch (err) {
+    return { kind: 'error', error: `git fetch origin main failed: ${errMsg(err)}` };
+  }
+
+  // Snapshot each touched YAML's content from the operator's working tree.
+  // We pass the bytes through to the worktree below so the operator's tree
+  // is never modified.
+  const snapshot = new Map<string, string>();
+  for (const p of input.touchedPaths) {
+    try {
+      snapshot.set(p, readFileSync(p, 'utf-8'));
+    } catch (err) {
+      return { kind: 'error', error: `failed to snapshot ${p}: ${errMsg(err)}` };
+    }
+  }
+
+  const branchName = makeBranchName(input.runStartedAt);
+  const worktreePath = join(tmpdir(), `lw-yaml-pr-${process.pid}-${Date.now()}`);
+
+  try {
+    sh(`git worktree add -b ${shellEscape(branchName)} ${shellEscape(worktreePath)} origin/main`);
+  } catch (err) {
+    return { kind: 'error', error: `git worktree add failed: ${errMsg(err)}` };
+  }
+
+  try {
+    return finishInWorktree(input, snapshot, branchName, worktreePath);
+  } finally {
+    try {
+      sh(`git worktree remove --force ${shellEscape(worktreePath)}`);
+    } catch (err) {
+      try { rmSync(worktreePath, { recursive: true, force: true }); } catch { /* ignore */ }
+      process.stderr.write(
+        `[yaml-pr] WARNING: failed to clean up worktree ${worktreePath}: ${errMsg(err)}\n`,
+      );
+    }
+  }
+}
+
+function finishInWorktree(
+  input: OpenYamlPrInput,
+  snapshot: Map<string, string>,
+  branchName: string,
+  worktreePath: string,
+): YamlPrResult {
+  // Write each touched path's snapshot into the worktree, overwriting
+  // origin/main's version. Then stage explicitly.
+  for (const [p, content] of snapshot) {
+    const dest = join(worktreePath, p);
+    try {
+      mkdirSync(dirname(dest), { recursive: true });
+      writeFileSync(dest, content, 'utf-8');
+    } catch (err) {
+      return { kind: 'error', error: `failed to write ${p} in worktree: ${errMsg(err)}` };
+    }
+  }
+
+  for (const p of input.touchedPaths) {
+    try {
+      sh(`git -C ${shellEscape(worktreePath)} add -- ${shellEscape(p)}`);
+    } catch (err) {
+      return { kind: 'error', error: `git add ${p} failed: ${errMsg(err)}` };
+    }
+  }
+
+  const commitMsg = buildCommitMessage(input);
+  try {
+    sh(`git -C ${shellEscape(worktreePath)} commit -m ${shellEscape(commitMsg)}`);
+  } catch (err) {
+    return { kind: 'error', error: `git commit failed: ${errMsg(err)}` };
+  }
+
+  try {
+    sh(`git -C ${shellEscape(worktreePath)} push -u origin ${shellEscape(branchName)}`);
+  } catch (err) {
+    return { kind: 'error', error: `git push failed: ${errMsg(err)}` };
+  }
+
+  const prBody = buildPrBody(input);
+  let prUrl: string;
+  try {
+    prUrl = sh(
+      `cd ${shellEscape(worktreePath)} && ` +
+      `gh pr create --head ${shellEscape(branchName)} ` +
+      `--title ${shellEscape(`auto: backfill source URLs (${input.summary.matched} matches)`)} ` +
+      `--body ${shellEscape(prBody)}`,
+    ).trim();
+  } catch (err) {
+    return { kind: 'error', error: `gh pr create failed: ${errMsg(err)}` };
+  }
+
+  // Merging is handled by the `auto-merge-backfill.yml` cron workflow,
+  // which polls every 20 minutes and merges any open backfill PR whose CI
+  // is green. We don't call `gh pr merge --auto` here because the repo
+  // has `allow_auto_merge: false` and the cron is the simpler path.
+
+  return { kind: 'opened', branch: branchName, prUrl };
+}
+
+function makeBranchName(isoTs: string): string {
+  const slug = isoTs.replace(/[:.]/g, '-').replace(/Z$/, '');
+  return `claude/backfill-sources-yaml-${slug}`;
+}
+
+function buildCommitMessage(input: OpenYamlPrInput): string {
+  return [
+    `auto: backfill source URLs (${input.summary.matched} matches)`,
+    '',
+    `facts written:               ${input.summary.factsWritten}`,
+    `policy stakeholders written: ${input.summary.stakeholdersWritten}`,
+    '',
+    'Auto-generated by `crux tb backfill-sources --apply`.',
+  ].join('\n');
+}
+
+function buildPrBody(input: OpenYamlPrInput): string {
+  return [
+    '## Summary',
+    '',
+    'Auto-generated PR mirroring source-URL writes from `crux tb backfill-sources` into YAML so the next sync from YAML → PG does not wipe them.',
+    '',
+    `- Matched records this run: **${input.summary.matched}**`,
+    `- \`facts\` YAML writes:        **${input.summary.factsWritten}**`,
+    `- \`policy_stakeholders\` writes: **${input.summary.stakeholdersWritten}**`,
+    `- YAML files touched:        **${input.touchedPaths.length}**`,
+    '',
+    '## Test plan',
+    '- [ ] CI green',
+    '- [ ] Spot-check a few changed YAMLs for sane `source:` values',
+  ].join('\n');
+}
+
+function sh(cmd: string): string {
+  return execSync(cmd, { encoding: 'utf-8' }).toString();
+}
+
+function trySh(cmd: string): string | null {
+  try {
+    return sh(cmd).trim();
+  } catch {
+    return null;
+  }
+}
+
+function shellEscape(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/crux/lib/backfill-sources/yaml-pr.ts
+++ b/crux/lib/backfill-sources/yaml-pr.ts
@@ -9,7 +9,6 @@
  * operator's working state is preserved exactly as they had it.
  *
  * Refuses to run when:
- *   - the current branch is `main` (we'd auto-commit into the merge target)
  *   - no touched YAMLs exist (nothing to commit)
  */
 
@@ -38,14 +37,6 @@ export type YamlPrResult =
 export function openYamlPr(input: OpenYamlPrInput): YamlPrResult {
   if (input.touchedPaths.length === 0) {
     return { kind: 'refused', reason: 'no YAML files touched this run' };
-  }
-
-  const currentBranch = trySh('git rev-parse --abbrev-ref HEAD');
-  if (!currentBranch) {
-    return { kind: 'error', error: 'failed to read current branch' };
-  }
-  if (currentBranch === 'main') {
-    return { kind: 'refused', reason: 'refusing to auto-commit on main' };
   }
 
   return runYamlPrFlow(input);

--- a/crux/lib/backfill-sources/yaml-target-resolvers.ts
+++ b/crux/lib/backfill-sources/yaml-target-resolvers.ts
@@ -1,0 +1,113 @@
+/**
+ * Build sid → YAML-file maps for the two table types we dual-write to.
+ *
+ * Facts (FactBase): one file per entity in packages/factbase/data/fb-entities/.
+ *   Two header formats coexist: `entity: sid_xxx` (current, ~538 files) and
+ *   the legacy `thing: { id: <slug> }` (~13 files). The legacy ones don't
+ *   carry the sid in the header — we skip them and let the caller fall back
+ *   to PG-only writes for those (rare).
+ *
+ * Policy stakeholders (TableBase entities): each `data/entities/*.yaml` is
+ *   a YAML array of entity objects, one of which may have `stableId: sid_xxx`.
+ *   We scan all 17-ish files and build the index in one pass.
+ *
+ * Both indexes are built once at the start of an apply run (cheap — ~550
+ *   YAML headers parsed) and reused per-record. No mutation, no caching
+ *   across runs.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+const FACTBASE_DIR_DEFAULT = 'packages/factbase/data/fb-entities';
+const ENTITIES_DIR_DEFAULT = 'data/entities';
+
+export interface FactbaseEntityIndex {
+  /** Map from FactBase entity sid (sid_xxx) → absolute YAML file path. */
+  sidToFilepath: Map<string, string>;
+  /** Number of files we couldn't index (legacy `thing:` format or parse fail). */
+  unindexedCount: number;
+}
+
+export interface PolicyEntityIndex {
+  /** Map from TableBase entity sid (sid_xxx) → absolute YAML file path. */
+  sidToFilepath: Map<string, string>;
+  /** Number of YAML files that failed to parse. */
+  parseFailureCount: number;
+}
+
+/**
+ * Scan fb-entities/*.yaml; return sid → filepath map.
+ *
+ * Only the first line of each file is read for the common `entity: sid_xxx`
+ * shape; legacy `thing:` files require a full parse, which we skip (the
+ * write path will fall back to PG-only for those).
+ */
+export function buildFactbaseEntityIndex(
+  factbaseDir: string = FACTBASE_DIR_DEFAULT,
+): FactbaseEntityIndex {
+  const sidToFilepath = new Map<string, string>();
+  let unindexedCount = 0;
+
+  const files = readdirSync(factbaseDir).filter(f => f.endsWith('.yaml'));
+  for (const file of files) {
+    const filepath = join(factbaseDir, file);
+    try {
+      const content = readFileSync(filepath, 'utf-8');
+      const firstLine = content.split('\n', 1)[0];
+      const m = firstLine.match(/^entity:\s*(sid_[A-Za-z0-9]+)\s*$/);
+      if (m) {
+        sidToFilepath.set(m[1], filepath);
+      } else {
+        unindexedCount++;
+      }
+    } catch {
+      unindexedCount++;
+    }
+  }
+
+  return { sidToFilepath, unindexedCount };
+}
+
+/**
+ * Scan data/entities/*.yaml; return policy entity sid → filepath map.
+ *
+ * Each file is a YAML array of entity objects. We parse the whole array
+ * (cheap — these files are small and there are only ~17 of them) and index
+ * every object that has both `type: policy` and `stableId: sid_xxx`.
+ *
+ * Non-policy types are skipped — only policy entities have `stakeholders:`
+ * arrays, so indexing the rest would be dead weight.
+ */
+export function buildPolicyEntityIndex(
+  entitiesDir: string = ENTITIES_DIR_DEFAULT,
+): PolicyEntityIndex {
+  const sidToFilepath = new Map<string, string>();
+  let parseFailureCount = 0;
+
+  const files = readdirSync(entitiesDir).filter(f => f.endsWith('.yaml'));
+  for (const file of files) {
+    const filepath = join(entitiesDir, file);
+    try {
+      const content = readFileSync(filepath, 'utf-8');
+      const parsed = parseYaml(content);
+      if (!Array.isArray(parsed)) continue;
+      for (const entity of parsed) {
+        if (
+          entity &&
+          typeof entity === 'object' &&
+          entity.type === 'policy' &&
+          typeof entity.stableId === 'string' &&
+          entity.stableId.startsWith('sid_')
+        ) {
+          sidToFilepath.set(entity.stableId, filepath);
+        }
+      }
+    } catch {
+      parseFailureCount++;
+    }
+  }
+
+  return { sidToFilepath, parseFailureCount };
+}

--- a/crux/lib/backfill-sources/yaml-write-fact.ts
+++ b/crux/lib/backfill-sources/yaml-write-fact.ts
@@ -1,0 +1,88 @@
+/**
+ * Mirror a fact's `source: <url>` into its FactBase YAML file, alongside the
+ * PG write that already happened in the apply path.
+ *
+ * Wraps the existing `updateFactMetaById` from `crux/lib/factbase-writer.ts`,
+ * which preserves YAML comments + formatting and never overwrites a
+ * pre-existing source unless explicitly asked.
+ */
+
+import {
+  readEntityDocument,
+  updateFactMetaById,
+  writeEntityDocument,
+} from '../factbase-writer.ts';
+import type { FactbaseEntityIndex } from './yaml-target-resolvers.ts';
+
+export type YamlWriteStatus =
+  | 'wrote'
+  | 'skipped-existing'
+  | 'not-found'
+  | 'no-yaml-target'
+  | 'error';
+
+export interface YamlWriteOutcome {
+  status: YamlWriteStatus;
+  filepath: string | null;
+  error?: string;
+}
+
+const PROVENANCE_NOTE = '[auto-discovered by tb backfill-sources]';
+
+export interface WriteFactSourceInput {
+  entitySid: string;
+  factId: string;
+  url: string;
+  index: FactbaseEntityIndex;
+}
+
+/**
+ * Resolve the YAML file for `entitySid`, find the fact by `factId`, and
+ * write `source: url` if no existing source is set. Caller writes nothing
+ * to PG here — the apply path already did.
+ *
+ * Returns `no-yaml-target` when the entity isn't in the index (legacy
+ * `thing:` format file we skipped during scan, or sid not present at all).
+ * Caller treats that as a soft warning, not a hard error.
+ */
+export function writeFactSourceToYaml(input: WriteFactSourceInput): YamlWriteOutcome {
+  const { entitySid, factId, url, index } = input;
+  const filepath = index.sidToFilepath.get(entitySid) ?? null;
+  if (!filepath) {
+    return { status: 'no-yaml-target', filepath: null };
+  }
+
+  let doc;
+  try {
+    doc = readEntityDocument(filepath);
+  } catch (err) {
+    return {
+      status: 'error',
+      filepath,
+      error: `read failed: ${errMsg(err)}`,
+    };
+  }
+
+  const status = updateFactMetaById(doc, factId, {
+    source: url,
+    notes: PROVENANCE_NOTE,
+  });
+
+  if (status === 'not-found') return { status: 'not-found', filepath };
+  if (status === 'skipped-existing') return { status: 'skipped-existing', filepath };
+
+  try {
+    writeEntityDocument(filepath, doc);
+  } catch (err) {
+    return {
+      status: 'error',
+      filepath,
+      error: `write failed: ${errMsg(err)}`,
+    };
+  }
+  return { status: 'wrote', filepath };
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/crux/lib/backfill-sources/yaml-write-stakeholder.ts
+++ b/crux/lib/backfill-sources/yaml-write-stakeholder.ts
@@ -1,0 +1,140 @@
+/**
+ * Mirror a policy_stakeholders row's `source: <url>` into the policy entity's
+ * YAML file (`data/entities/*.yaml`).
+ *
+ * Each policy entity in those files has a `stakeholders:` array; each item is
+ * keyed structurally by `name` + `position` (the same composite key the PG
+ * sync uses to dedupe). We locate the file via the policy entity's stableId,
+ * walk to the matching stakeholder, and set `source: <url>` on it — without
+ * touching any other field on the entity or the file.
+ *
+ * Uses the `yaml` package's Document API (parseDocument + isMap/isSeq) to
+ * preserve comments, anchors, and existing field order — same approach as
+ * `factbase-writer.updateFactMetaById`.
+ */
+
+import { readFileSync, writeFileSync, renameSync } from 'node:fs';
+import { isMap, isSeq, parseDocument } from 'yaml';
+import type { YamlWriteOutcome } from './yaml-write-fact.ts';
+import type { PolicyEntityIndex } from './yaml-target-resolvers.ts';
+
+export interface WriteStakeholderSourceInput {
+  policyEntitySid: string;
+  stakeholderName: string;
+  /** Position string from PG (e.g. "support", "oppose", "mixed"). Used for
+   *  disambiguation when a policy has the same name listed twice in two
+   *  different positions — first writer wins by name; second match by
+   *  position breaks the tie. */
+  position: string | null;
+  url: string;
+  index: PolicyEntityIndex;
+}
+
+/**
+ * Find the right policy entity in the file, find the right stakeholder
+ * within its `stakeholders` list, and set `source: <url>` if no source is
+ * already present.
+ *
+ * Returns `no-yaml-target` if the policy stableId isn't indexed (entity
+ * doesn't exist in YAML, or scan didn't reach it). Returns `not-found` when
+ * the file is found but the stakeholder name+position pair isn't there.
+ * Returns `skipped-existing` when a non-empty `source` is already set.
+ */
+export function writeStakeholderSourceToYaml(
+  input: WriteStakeholderSourceInput,
+): YamlWriteOutcome {
+  const { policyEntitySid, stakeholderName, position, url, index } = input;
+  const filepath = index.sidToFilepath.get(policyEntitySid) ?? null;
+  if (!filepath) {
+    return { status: 'no-yaml-target', filepath: null };
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(filepath, 'utf-8');
+  } catch (err) {
+    return { status: 'error', filepath, error: `read failed: ${errMsg(err)}` };
+  }
+
+  const doc = parseDocument(raw);
+  const root = doc.contents;
+  if (!isSeq(root)) {
+    return { status: 'error', filepath, error: 'root node is not a sequence' };
+  }
+
+  // Find the policy entity by stableId.
+  let entityNode: unknown = null;
+  for (const item of root.items) {
+    if (!isMap(item)) continue;
+    const sid = String(item.get('stableId') ?? '');
+    if (sid === policyEntitySid) {
+      entityNode = item;
+      break;
+    }
+  }
+  if (!entityNode || !isMap(entityNode)) {
+    return { status: 'not-found', filepath };
+  }
+
+  const stakeholders = entityNode.get('stakeholders', true);
+  if (!isSeq(stakeholders)) {
+    return { status: 'not-found', filepath };
+  }
+
+  // Match priority:
+  //   1. exact name + position match (when position is provided)
+  //   2. exact name match (single occurrence)
+  // Multiple-occurrence-no-position is treated as not-found to avoid
+  // guessing wrong.
+  const nameMatches: { node: ReturnType<typeof asMap>; pos: string | null }[] = [];
+  for (const item of stakeholders.items) {
+    const m = asMap(item);
+    if (!m) continue;
+    const name = String(m.get('name') ?? '');
+    if (name !== stakeholderName) continue;
+    const pos = m.get('position');
+    nameMatches.push({ node: m, pos: typeof pos === 'string' ? pos : null });
+  }
+
+  if (nameMatches.length === 0) return { status: 'not-found', filepath };
+
+  let target = nameMatches[0].node;
+  if (nameMatches.length > 1) {
+    if (!position) return { status: 'not-found', filepath };
+    const byPos = nameMatches.find(m => m.pos === position);
+    if (!byPos) return { status: 'not-found', filepath };
+    target = byPos.node;
+  }
+
+  if (!target) return { status: 'not-found', filepath };
+
+  const existingSource = target.get('source');
+  if (typeof existingSource === 'string' && existingSource.trim() !== '') {
+    return { status: 'skipped-existing', filepath };
+  }
+
+  target.set('source', url);
+
+  // Atomic write: temp file + rename. `lineWidth: 120` matches the
+  // convention used elsewhere in the codebase (extract-structured-data,
+  // political-data, factbase-migrate) — the yaml package's default 80
+  // would re-fold lines that those writers left unwrapped, producing
+  // noisy diffs every time we touch one source field.
+  try {
+    const out = doc.toString({ lineWidth: 120 });
+    const tmp = filepath + '.tmp';
+    writeFileSync(tmp, out, 'utf-8');
+    renameSync(tmp, filepath);
+  } catch (err) {
+    return { status: 'error', filepath, error: `write failed: ${errMsg(err)}` };
+  }
+  return { status: 'wrote', filepath };
+}
+
+function asMap(node: unknown) {
+  return isMap(node) ? node : null;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/crux/lib/backfill-sources/yaml-write.ts
+++ b/crux/lib/backfill-sources/yaml-write.ts
@@ -1,0 +1,82 @@
+/**
+ * Per-record dispatcher: given a matched record + the chosen source URL,
+ * write the URL into the appropriate YAML file when the record's table is
+ * one of the YAML-mirrored ones.
+ *
+ * The PG write happens elsewhere (see `updateRecordSource` in fetch.ts) —
+ * this file only handles the YAML half of the dual-write.
+ *
+ * Tables we touch:
+ *   - facts                → packages/factbase/data/fb-entities/<slug>.yaml
+ *   - policy_stakeholders  → data/entities/<file>.yaml under stakeholders[]
+ *
+ * Every other table is `not-applicable` and the caller can move on.
+ */
+
+import type { MissingSourceRecord } from './types.ts';
+import { writeFactSourceToYaml } from './yaml-write-fact.ts';
+import { writeStakeholderSourceToYaml } from './yaml-write-stakeholder.ts';
+import type {
+  FactbaseEntityIndex,
+  PolicyEntityIndex,
+} from './yaml-target-resolvers.ts';
+import type { YamlWriteOutcome } from './yaml-write-fact.ts';
+
+export interface YamlIndexes {
+  facts: FactbaseEntityIndex;
+  policies: PolicyEntityIndex;
+}
+
+export type YamlWriteRecordOutcome =
+  | (YamlWriteOutcome & { applicable: true })
+  | { status: 'not-applicable'; filepath: null; applicable: false };
+
+export function writeRecordToYaml(
+  record: MissingSourceRecord,
+  url: string,
+  indexes: YamlIndexes,
+): YamlWriteRecordOutcome {
+  if (record.record_table === 'facts') {
+    const entitySid = String(record.entity_id ?? '');
+    const factId = String(record.fact_id ?? '');
+    if (!entitySid || !factId) {
+      return {
+        applicable: true,
+        status: 'error',
+        filepath: null,
+        error: 'missing entity_id or fact_id on facts record',
+      };
+    }
+    return {
+      applicable: true,
+      ...writeFactSourceToYaml({ entitySid, factId, url, index: indexes.facts }),
+    };
+  }
+
+  if (record.record_table === 'policy_stakeholders') {
+    const policySid = String(record.policy_entity_id ?? '');
+    const name = String(record.stakeholder_display_name ?? '');
+    const positionRaw = record.position;
+    const position = typeof positionRaw === 'string' ? positionRaw : null;
+    if (!policySid || !name) {
+      return {
+        applicable: true,
+        status: 'error',
+        filepath: null,
+        error: 'missing policy_entity_id or stakeholder_display_name',
+      };
+    }
+    return {
+      applicable: true,
+      ...writeStakeholderSourceToYaml({
+        policyEntitySid: policySid,
+        stakeholderName: name,
+        position,
+        url,
+        index: indexes.policies,
+      }),
+    };
+  }
+
+  return { applicable: false, status: 'not-applicable', filepath: null };
+}

--- a/crux/lib/factbase-writer.ts
+++ b/crux/lib/factbase-writer.ts
@@ -169,10 +169,18 @@ export function updateFactMetaById(
       wrote = true;
     }
     // If we're skipping the source-write, drop the backfill-provenance note
-    // too — a note without a fresh source URL would be misleading.
+    // too — a note without a fresh source URL would be misleading. Also
+    // never overwrite a non-empty existing notes field unless the caller
+    // explicitly opted into overwriting (same flag that gates source replacement).
+    // Human notes are higher-trust than auto-generated provenance.
     if (updates.notes !== undefined && !skippedForSource) {
-      item.set('notes', updates.notes);
-      wrote = true;
+      const existingNotes = item.get('notes');
+      const hasExistingNotes =
+        typeof existingNotes === 'string' && existingNotes.trim() !== '';
+      if (!hasExistingNotes || options.overwriteExisting) {
+        item.set('notes', updates.notes);
+        wrote = true;
+      }
     }
 
     if (wrote) return 'updated';
@@ -184,9 +192,14 @@ export function updateFactMetaById(
 
 /**
  * Write a YAML document back to file atomically (write to temp, rename).
+ *
+ * `lineWidth: 120` matches the convention used elsewhere in the codebase
+ * (extract-structured-data, political-data, factbase-migrate). Without it,
+ * the yaml package's default 80-char folding would reformat long unrelated
+ * string literals and produce noisy diffs even for single-field edits.
  */
 export function writeEntityDocument(filepath: string, doc: Document): void {
-  const content = doc.toString();
+  const content = doc.toString({ lineWidth: 120 });
   const tmpPath = filepath + '.tmp';
   writeFileSync(tmpPath, content, 'utf-8');
   renameSync(tmpPath, filepath);

--- a/crux/lib/factbase-writer.ts
+++ b/crux/lib/factbase-writer.ts
@@ -184,8 +184,7 @@ export function updateFactMetaById(
     }
 
     if (wrote) return 'updated';
-    if (skippedForSource) return 'skipped-existing';
-    return 'updated';  // caller asked for nothing — treat as no-op success
+    return 'skipped-existing';
   }
   return 'not-found';
 }

--- a/crux/lib/job-handlers/index.ts
+++ b/crux/lib/job-handlers/index.ts
@@ -72,6 +72,48 @@ const handlers: Record<string, JobHandler> = {
     }
   },
 
+  'backfill-sources': async (params, ctx) => {
+    const limit = typeof params.limit === 'number' ? String(params.limit) : '100';
+    const maxCost =
+      typeof params.maxCost === 'number' ? String(params.maxCost) : '5';
+    const args = [
+      '--import',
+      'tsx/esm',
+      '--no-warnings',
+      'crux/crux.mjs',
+      'tb',
+      'backfill-sources',
+      '--apply',
+      `--limit=${limit}`,
+      `--max-cost=${maxCost}`,
+    ];
+    if (typeof params.table === 'string' && params.table.length > 0) {
+      args.push(`--table=${params.table}`);
+    }
+
+    try {
+      const output = execFileSync('node', args, {
+        cwd: ctx.projectRoot,
+        encoding: 'utf-8',
+        timeout: 60 * 60 * 1000, // 1h — full prod sweep is ~30-50 min
+        stdio: ['pipe', 'pipe', 'pipe'],
+        maxBuffer: 16 * 1024 * 1024,
+      });
+
+      // Tail of stdout is enough to summarise outcomes; the full report is
+      // written to dev/reports/backfill-unmatched-*.json on the worker pod.
+      const tail = output.slice(-2000);
+      return { success: true, data: { limit, maxCost, table: params.table ?? null, output: tail } };
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        data: { limit, maxCost, table: params.table ?? null },
+        error: error.slice(0, 500),
+      };
+    }
+  },
+
   // Content-modifying handlers (lazy — depend on full monorepo)
   'page-improve': lazyHandler(async () =>
     (await import('./page-improve.ts')).handlePageImprove),

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -1663,7 +1663,7 @@
       position: support
       role: Senate cosponsor
       importance: high
-      source: https://exportcompliancedaily.com/article/2026/02/18/key-senate-democrat-backs-bill-to-require-security-features-on-exported-chips-2602170048?BC=bc_699b3afa6753b
+      source: https://exportcompliancedaily.com/article/2026/02/18/key-senate-democrat-backs-bill-to-require-security-features-on-exported-chips-2602170048
     - name: Rep. Bill Huizenga
       entityId: sid_cYPfKeUa36
       position: support

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -37,7 +37,8 @@
     - name: China
       position: mixed
       importance: medium
-      reason: Pursues its own parallel AI safety evaluation approach through domestic institutions rather than joining the international AISI network
+      reason: Pursues its own parallel AI safety evaluation approach through domestic institutions rather than joining the
+        international AISI network
   lastUpdated: 2025-12
 - id: california-sb1047
   stableId: sid_XcGTez1oFw
@@ -1656,11 +1657,13 @@
       position: support
       role: Primary Senate sponsor
       importance: high
+      source: https://govtrack.us/congress/bills/119/s1705
     - name: Sen. Elizabeth Warren
       entityId: sid_OyPBrUIpeS
       position: support
       role: Senate cosponsor
       importance: high
+      source: https://exportcompliancedaily.com/article/2026/02/18/key-senate-democrat-backs-bill-to-require-security-features-on-exported-chips-2602170048?BC=bc_699b3afa6753b
     - name: Rep. Bill Huizenga
       entityId: sid_cYPfKeUa36
       position: support
@@ -2091,10 +2094,12 @@
       position: support
       importance: high
       reason: Co-hosted the summit with South Korea; led the Bletchley-to-Seoul AI safety summit series
+      source: https://aiseoulsummit.kr/aigf/press/?mod=document&uid=46
     - name: South Korea
       position: support
       importance: high
       reason: Host country; positioned itself as bridge between Western and Asian AI governance approaches
+      source: https://industry.gov.au/publications/seoul-declaration-countries-attending-ai-seoul-summit-21-22-may-2024
     - name: OpenAI
       entityId: sid_1LcLlMGLbw
       position: support
@@ -4142,7 +4147,8 @@
     - name: Academic AI safety researchers
       position: support
       importance: high
-      reason: 88 researchers from 11 countries authored the consensus; represents broad scientific agreement on safety research priorities
+      reason: 88 researchers from 11 countries authored the consensus; represents broad scientific agreement on safety
+        research priorities
     - name: AI safety organizations (MIRI, ARC, CAIS)
       position: support
       importance: high
@@ -4154,7 +4160,8 @@
     - name: AI industry (major labs)
       position: mixed
       importance: medium
-      reason: Generally supportive of research priorities but consensus remains voluntary with no binding commitments on industry
+      reason: Generally supportive of research priorities but consensus remains voluntary with no binding commitments on
+        industry
   tags:
     - international-consensus
     - ai-safety-research
@@ -4567,7 +4574,8 @@
     - name: Former OpenAI employees
       position: support
       importance: high
-      reason: Public letter from former employees highlighted restrictive NDAs preventing safety disclosures; directly motivated the legislation
+      reason: Public letter from former employees highlighted restrictive NDAs preventing safety disclosures; directly
+        motivated the legislation
     - name: American Civil Liberties Union (ACLU)
       entityId: sid_7DpEvy5wQr
       position: support
@@ -4581,7 +4589,8 @@
     - name: Major AI companies
       position: oppose
       importance: high
-      reason: Some companies have used restrictive NDAs and non-disparagement clauses that would be curtailed by the legislation
+      reason: Some companies have used restrictive NDAs and non-disparagement clauses that would be curtailed by the
+        legislation
     - name: Bipartisan Senate sponsors
       position: support
       importance: high
@@ -5049,7 +5058,8 @@
     - name: European Union
       position: support
       importance: high
-      reason: Signed the convention alongside individual EU member states; complements the EU AI Act with an international treaty framework
+      reason: Signed the convention alongside individual EU member states; complements the EU AI Act with an international
+        treaty framework
     - name: United Kingdom
       position: support
       importance: medium
@@ -5057,12 +5067,14 @@
     - name: United States
       position: support
       importance: medium
-      reason: Participated as observer state in negotiations; signed the convention in September 2024 alongside the EU, UK, and Israel
+      reason: Participated as observer state in negotiations; signed the convention in September 2024 alongside the EU, UK,
+        and Israel
     - name: Access Now
       entityId: sid_DHWH2M0Ega
       position: mixed
       importance: medium
-      reason: Supports the human rights framing but criticized the national security exemption as too broad, potentially undermining protections
+      reason: Supports the human rights framing but criticized the national security exemption as too broad, potentially
+        undermining protections
     - name: European Digital Rights (EDRi)
       entityId: sid_7h0u4ulMdb
       position: mixed
@@ -5717,6 +5729,7 @@
       position: oppose
       importance: medium
       reason: Called executive order unconstitutional
+      source: https://aclu.org/press-releases/aclu-statement-on-president-trumps-unilateral-attack-on-state-regulation-of-artificial-intelligence
   description: "Executive order signed December 11, 2025 directing federal agencies to challenge state AI laws deemed
     inconsistent with federal policy. Does NOT itself overturn state law — only Congress or courts can do that.
     Established DOJ AI Litigation Task Force (Jan 9, 2026). Triggered bipartisan opposition: 36 state AGs formed
@@ -5928,7 +5941,8 @@
       entityId: sid_LNfQiSo5us
       position: support
       importance: high
-      reason: Lead sponsor; views AI liability as essential consumer protection analogous to product liability for physical goods
+      reason: Lead sponsor; views AI liability as essential consumer protection analogous to product liability for physical
+        goods
     - name: Senator Josh Hawley (R-MO)
       entityId: sid_C-3CLLkSFI
       position: support
@@ -5937,7 +5951,8 @@
     - name: Technology industry (TechNet, BSA)
       position: oppose
       importance: high
-      reason: Oppose expanded liability standards as potentially chilling AI innovation and creating legal uncertainty for developers
+      reason: Oppose expanded liability standards as potentially chilling AI innovation and creating legal uncertainty for
+        developers
     - name: Trial Lawyers Association
       position: support
       importance: medium
@@ -5981,7 +5996,8 @@
     - name: AI safety research community
       position: support
       importance: high
-      reason: Supports mandatory evaluation of dangerous capabilities including self-replication, scheming, and autonomous decision-making
+      reason: Supports mandatory evaluation of dangerous capabilities including self-replication, scheming, and autonomous
+        decision-making
     - name: Senator Josh Hawley (R-MO)
       entityId: sid_C-3CLLkSFI
       position: support
@@ -5996,11 +6012,13 @@
       entityId: sid_IZ04n3ZvIZ
       position: mixed
       importance: high
-      reason: Would gain new mandate and authority for AI evaluation but faces significant implementation burden within 90-day timeline
+      reason: Would gain new mandate and authority for AI evaluation but faces significant implementation burden within 90-day
+        timeline
     - name: AI industry (frontier labs)
       position: mixed
       importance: high
-      reason: Some labs support external evaluation in principle but oppose mandatory participation and the scale of penalties for non-compliance
+      reason: Some labs support external evaluation in principle but oppose mandatory participation and the scale of penalties
+        for non-compliance
   tags:
     - ai-evaluation
     - mandatory-testing
@@ -6041,19 +6059,23 @@
     - name: Global South nations
       position: support
       importance: high
-      reason: 61 countries signed the declaration; developing nations view inclusive AI governance as essential to avoid being left behind
+      reason: 61 countries signed the declaration; developing nations view inclusive AI governance as essential to avoid being
+        left behind
     - name: India (PM Modi)
       position: support
       importance: high
-      reason: Co-chaired the summit with France; positioned India as a bridge between developed and developing world on AI governance
+      reason: Co-chaired the summit with France; positioned India as a bridge between developed and developing world on AI
+        governance
     - name: United States
       position: oppose
       importance: high
-      reason: Refused to sign the declaration on inclusive and sustainable AI; prioritizes unilateral AI leadership over multilateral commitments
+      reason: Refused to sign the declaration on inclusive and sustainable AI; prioritizes unilateral AI leadership over
+        multilateral commitments
     - name: United Kingdom
       position: oppose
       importance: high
-      reason: Joined the US in refusing to sign the declaration despite having hosted the previous AI Safety Summit at Bletchley Park
+      reason: Joined the US in refusing to sign the declaration despite having hosted the previous AI Safety Summit at
+        Bletchley Park
   tags:
     - international
     - summit
@@ -6092,23 +6114,28 @@
     - name: China
       position: support
       importance: high
-      reason: Strongly supported the resolution; aligned with developing countries seeking multilateral AI governance through the UN system
+      reason: Strongly supported the resolution; aligned with developing countries seeking multilateral AI governance through
+        the UN system
     - name: UN Secretary-General
       position: support
       importance: high
-      reason: Championed the initiative through the High-level Advisory Body on AI; framed it as essential for inclusive governance
+      reason: Championed the initiative through the High-level Advisory Body on AI; framed it as essential for inclusive
+        governance
     - name: Global South coalition
       position: support
       importance: high
-      reason: Developing nations backed the resolution as a way to ensure their voice in AI governance, countering Western-dominated forums like the G7
+      reason: Developing nations backed the resolution as a way to ensure their voice in AI governance, countering
+        Western-dominated forums like the G7
     - name: United States
       position: oppose
       importance: high
-      reason: Explicitly rejected "centralized control and global governance" of AI at UN Security Council; views UN governance as potentially constraining US AI leadership
+      reason: Explicitly rejected "centralized control and global governance" of AI at UN Security Council; views UN
+        governance as potentially constraining US AI leadership
     - name: European Union
       position: mixed
       importance: medium
-      reason: Supported the scientific panel and dialogue framework but preferred its own AI Act as the primary governance mechanism
+      reason: Supported the scientific panel and dialogue framework but preferred its own AI Act as the primary governance
+        mechanism
   clusters:
     - governance
   lastUpdated: 2026-04
@@ -6141,7 +6168,8 @@
     - name: Utah tech industry (Silicon Slopes)
       position: support
       importance: high
-      reason: Supports the lighter-touch approach as business-friendly; narrower disclosure requirements reduce compliance burden compared to other states
+      reason: Supports the lighter-touch approach as business-friendly; narrower disclosure requirements reduce compliance
+        burden compared to other states
     - name: Utah State Legislature
       position: support
       importance: high
@@ -6149,7 +6177,8 @@
     - name: Consumer advocacy groups
       position: mixed
       importance: medium
-      reason: Concerned the narrowed disclosure requirements are too weak; only requiring disclosure when consumers explicitly ask limits practical transparency
+      reason: Concerned the narrowed disclosure requirements are too weak; only requiring disclosure when consumers explicitly
+        ask limits practical transparency
     - name: AI companies operating in Utah
       position: support
       importance: medium
@@ -6185,7 +6214,8 @@
     - name: Civil rights organizations
       position: support
       importance: high
-      reason: Advocate for extending anti-discrimination protections to AI-driven employment decisions under the Illinois Human Rights Act
+      reason: Advocate for extending anti-discrimination protections to AI-driven employment decisions under the Illinois
+        Human Rights Act
     - name: Labor unions
       position: support
       importance: high
@@ -6197,7 +6227,8 @@
     - name: Business and employer groups
       position: oppose
       importance: medium
-      reason: Concerned about compliance costs and legal uncertainty around proving AI systems do not discriminate in employment decisions
+      reason: Concerned about compliance costs and legal uncertainty around proving AI systems do not discriminate in
+        employment decisions
   tags:
     - state-legislation
     - employment
@@ -6242,7 +6273,8 @@
     - name: Content creators and artists
       position: support
       importance: medium
-      reason: HB 1876 establishes ownership rights over AI-generated content, providing legal clarity for creators using AI tools
+      reason: HB 1876 establishes ownership rights over AI-generated content, providing legal clarity for creators using AI
+        tools
     - name: AI companies
       position: mixed
       importance: medium
@@ -6326,7 +6358,8 @@
     - name: Health insurance companies
       position: mixed
       importance: medium
-      reason: Required to disclose AI use in coverage decisions; compliance adds operational burden but aligns with transparency trends
+      reason: Required to disclose AI use in coverage decisions; compliance adds operational burden but aligns with
+        transparency trends
   tags:
     - state-legislation
     - healthcare
@@ -6367,7 +6400,8 @@
     - name: Child safety advocates
       position: support
       importance: medium
-      reason: Concerned about vulnerable youth relying on AI chatbots for mental health support instead of qualified professionals
+      reason: Concerned about vulnerable youth relying on AI chatbots for mental health support instead of qualified
+        professionals
     - name: AI companion chatbot companies
       position: oppose
       importance: medium
@@ -6415,7 +6449,8 @@
     - name: AI companion chatbot companies
       position: mixed
       importance: high
-      reason: Some accept disclosure requirements as reasonable while others view the regulation as potentially restricting product design and user experience
+      reason: Some accept disclosure requirements as reasonable while others view the regulation as potentially restricting
+        product design and user experience
   tags:
     - state-legislation
     - ai-chatbots
@@ -6469,7 +6504,8 @@
     - name: AI chatbot companies
       position: oppose
       importance: medium
-      reason: Concerned about compliance requirements and potential restrictions on chatbot product features in Washington state
+      reason: Concerned about compliance requirements and potential restrictions on chatbot product features in Washington
+        state
   tags:
     - state-legislation
     - ai-chatbots
@@ -6528,7 +6564,8 @@
     - name: Technology platforms
       position: mixed
       importance: medium
-      reason: Generally support combating deepfakes but concerned about potential liability exposure and content moderation obligations
+      reason: Generally support combating deepfakes but concerned about potential liability exposure and content moderation
+        obligations
   tags:
     - deepfakes
     - civil-remedies
@@ -6571,11 +6608,13 @@
       entityId: sid_enf2UNKyDx
       position: support
       importance: high
-      reason: Author of the discussion draft; frames it as a comprehensive federal approach to AI governance combining multiple policy areas
+      reason: Author of the discussion draft; frames it as a comprehensive federal approach to AI governance combining
+        multiple policy areas
     - name: Content creators and artists
       position: support
       importance: high
-      reason: Support the anti-fair-use provision for AI training on copyrighted works and the NO FAKES Act digital likeness protections
+      reason: Support the anti-fair-use provision for AI training on copyrighted works and the NO FAKES Act digital likeness
+        protections
     - name: Child safety advocates
       position: support
       importance: high
@@ -6583,11 +6622,13 @@
     - name: State legislators
       position: oppose
       importance: medium
-      reason: Oppose broad federal preemption of state AI laws that would override existing and emerging state-level regulations
+      reason: Oppose broad federal preemption of state AI laws that would override existing and emerging state-level
+        regulations
     - name: AI industry
       position: mixed
       importance: high
-      reason: Support federal preemption over state patchwork but oppose the anti-fair-use copyright provision that would restrict AI training data
+      reason: Support federal preemption over state patchwork but oppose the anti-fair-use copyright provision that would
+        restrict AI training data
   tags:
     - federal-legislation
     - comprehensive-framework
@@ -6898,8 +6939,8 @@
   type: approach
   title: Voluntary AI Commitments Enforcement
   description: >-
-    An analysis of non-binding AI safety pledges made by leading AI companies, their
-    enforcement mechanisms, compliance records, and limitations as a governance approach.
+    An analysis of non-binding AI safety pledges made by leading AI companies, their enforcement mechanisms, compliance
+    records, and limitations as a governance approach.
   tags:
     - ai-governance
     - voluntary-commitments

--- a/packages/factbase/data/fb-entities/andrej-karpathy.yaml
+++ b/packages/factbase/data/fb-entities/andrej-karpathy.yaml
@@ -8,8 +8,10 @@ facts:
 
   - id: f_JOFyWsItEQ
     property: notable-for
-    value: "Former Director of AI at Tesla, former OpenAI researcher; founded Eureka
-      Labs; influential AI educator and researcher"
+    value: "Former Director of AI at Tesla, former OpenAI researcher; founded Eureka Labs; influential AI educator and
+      researcher"
+    source: https://en.wikipedia.org/wiki/Andrej_Karpathy
+    notes: "[auto-discovered by tb backfill-sources]"
 
   - id: f_v81HDaRKqg
     property: education
@@ -22,6 +24,8 @@ facts:
   - id: f_PPWIIFBj8w
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Andrej_Karpathy"
+    source: https://en.wikipedia.org/wiki/Andrej_Karpathy
+    notes: "[auto-discovered by tb backfill-sources]"
   - id: f_Bnn6IEgLq8
     property: website
     value: https://karpathy.ai/

--- a/packages/factbase/data/fb-entities/andrew-ng.yaml
+++ b/packages/factbase/data/fb-entities/andrew-ng.yaml
@@ -3,19 +3,26 @@ facts:
   - id: f_eOS7s8epzw
     property: born-year
     value: 1976
+    source: https://en.wikipedia.org/wiki/Andrew_Ng
+    notes: "[auto-discovered by tb backfill-sources]"
 
   - id: f_Rg89IN7s7w
     property: notable-for
-    value: "Founder of DeepLearning.AI and Coursera; former head of Google Brain and
-      Baidu AI; leading AI educator"
+    value: "Founder of DeepLearning.AI and Coursera; former head of Google Brain and Baidu AI; leading AI educator"
+    source: https://cs.stanford.edu/people/ang
+    notes: "[auto-discovered by tb backfill-sources]"
 
   - id: f_CUnXLL3M8Q
     property: education
     value: "PhD in Computer Science, UC Berkeley"
+    source: https://en.wikipedia.org/wiki/Andrew_Ng
+    notes: "[auto-discovered by tb backfill-sources]"
 
   - id: f_r4CmuKqadQ
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Andrew_Ng"
+    source: https://en.wikipedia.org/wiki/Andrew_Ng
+    notes: "[auto-discovered by tb backfill-sources]"
 
   - id: f_PomBL98jGQ
     property: website

--- a/packages/factbase/data/fb-entities/buck-shlegeris.yaml
+++ b/packages/factbase/data/fb-entities/buck-shlegeris.yaml
@@ -13,3 +13,4 @@ facts:
     value: "AI safety research; Redwood Research leadership"
     asOf: "2026-03"
     notes: "Migrated from experts.yaml"
+    source: https://bshlgrs.github.io

--- a/packages/factbase/data/fb-entities/california-sb1047.yaml
+++ b/packages/factbase/data/fb-entities/california-sb1047.yaml
@@ -9,9 +9,10 @@ facts:
     notes: Migrated from old entity system
   - id: f_LtdOUHqrg1
     property: compute-threshold
-    value: 1e26
+    value: 1e+26
     asOf: 2024-02
     notes: Training compute threshold for covered models as defined in the bill text
+    source: https://leginfo.legislature.ca.gov/faces/billCompareClient.xhtml?bill_id=202320240SB1047&showamends=false
   - id: f_zcML9r8ngl
     property: cost-threshold
     value: 100000000

--- a/packages/factbase/data/fb-entities/jared-kaplan.yaml
+++ b/packages/factbase/data/fb-entities/jared-kaplan.yaml
@@ -2,8 +2,9 @@ entity: sid_x16GL4gP2A
 facts:
   - id: f_clGvV7hzcA
     property: notable-for
-    value: "Co-founder of Anthropic; Johns Hopkins physics professor; co-author of
-      neural scaling laws research"
+    value: "Co-founder of Anthropic; Johns Hopkins physics professor; co-author of neural scaling laws research"
+    source: https://en.wikipedia.org/wiki/Jared_Kaplan
+    notes: "[auto-discovered by tb backfill-sources]"
 
   - id: f_h7OOErJfYQ
     property: education
@@ -19,13 +20,12 @@ facts:
     value: 0.8
     asOf: "2026-01"
     source: https://fortune.com/2026/01/27/anthropic-billionaire-cofounders-ceo-dario-amodei-giving-away-80-percent-of-wealth-fighting-inequality-ai-revolution/
-    notes: "All seven Anthropic co-founders pledged to donate 80% of their equity
-      per Fortune's January 2026 reporting. Pledge is not legally binding."
+    notes: "All seven Anthropic co-founders pledged to donate 80% of their equity per Fortune's January 2026 reporting.
+      Pledge is not legally binding."
 
   - id: f_FoEx38QdKF
     property: ea-alignment-estimate
-    value: [0.15, 0.3]
+    value: [ 0.15, 0.3 ]
     asOf: "2026-04"
-    notes: "Editorial estimate. Scaling laws pioneer and safety-motivated
-      co-founder; no documented EA pledge or EA Forum activity. Low confidence
-      of EA-aligned cause-area giving."
+    notes: "Editorial estimate. Scaling laws pioneer and safety-motivated co-founder; no documented EA pledge or EA Forum
+      activity. Low confidence of EA-aligned cause-area giving."

--- a/packages/factbase/data/fb-entities/max-tegmark.yaml
+++ b/packages/factbase/data/fb-entities/max-tegmark.yaml
@@ -2,10 +2,9 @@ entity: sid_3KjUCZCV8w
 facts:
   - id: f_oLpabpFPtg
     property: description
-    value: Swedish-American physicist at MIT, co-founder of the Future of Life
-      Institute, and prominent AI safety advocate known for his work on the
-      Mathematical Universe Hypothesis and efforts to promote safe artificial
-      intelligence development.
+    value: Swedish-American physicist at MIT, co-founder of the Future of Life Institute, and prominent AI safety advocate
+      known for his work on the Mathematical Universe Hypothesis and efforts to promote safe artificial intelligence
+      development.
     asOf: 2026-03
     notes: Migrated from old entity system
   - id: f_9YtgMVLJ37
@@ -15,17 +14,16 @@ facts:
     notes: From Wikidata Q2076321
   - id: f_cneepuZr0c
     property: education
-    value: Royal Institute of Technology; Stockholm School of Economics; University
-      of California, Berkeley
+    value: Royal Institute of Technology; Stockholm School of Economics; University of California, Berkeley
     source: https://www.wikidata.org/wiki/Q2076321
     notes: From Wikidata Q2076321
   - id: f_mT6tN2pQ3v
     property: notable-for
-    value: "Co-founded Future of Life Institute; developed 23 Asilomar AI
-      Principles; organized 2023 AI pause letter with 30,000+ signatories;
-      author of Life 3.0 (NYT bestseller); TIME 100 Most Influential in AI 2023"
+    value: "Co-founded Future of Life Institute; developed 23 Asilomar AI Principles; organized 2023 AI pause letter with
+      30,000+ signatories; author of Life 3.0 (NYT bestseller); TIME 100 Most Influential in AI 2023"
     asOf: 2026-03
     notes: Enriched from wiki page
+    source: https://futureoflife.org/person/max-tegmark
   - id: f_mTcY8fL9kA
     property: born-year
     value: 1967
@@ -34,9 +32,8 @@ facts:
 
   - id: f_mTfB4gN5mD
     property: education
-    value: "B.A. Economics, Stockholm School of Economics; B.Sc. Physics, Royal
-      Institute of Technology; M.A. Physics, UC Berkeley (1992); Ph.D. Physics,
-      UC Berkeley (1994)"
+    value: "B.A. Economics, Stockholm School of Economics; B.Sc. Physics, Royal Institute of Technology; M.A. Physics, UC
+      Berkeley (1992); Ph.D. Physics, UC Berkeley (1994)"
     source: https://en.wikipedia.org/wiki/Max_Tegmark
     notes: Enriched from wiki page
   - id: f_AGyF3JFynu

--- a/packages/factbase/data/fb-entities/max-tegmark.yaml
+++ b/packages/factbase/data/fb-entities/max-tegmark.yaml
@@ -22,7 +22,7 @@ facts:
     value: "Co-founded Future of Life Institute; developed 23 Asilomar AI Principles; organized 2023 AI pause letter with
       30,000+ signatories; author of Life 3.0 (NYT bestseller); TIME 100 Most Influential in AI 2023"
     asOf: 2026-03
-    notes: Enriched from wiki page
+    notes: Enriched from Future of Life profile page
     source: https://futureoflife.org/person/max-tegmark
   - id: f_mTcY8fL9kA
     property: born-year


### PR DESCRIPTION
## Summary

Production-ready upgrades to `crux tb backfill-sources` (single squashed commit; supersedes #4870).

**What it does**
- Finds FactBase records missing source URLs, LLM-searches the web, judges hits, then writes the source URL to both PG and YAML.
- Opens an auto-PR for the YAML half so the next YAML→PG sync doesn't wipe the writes.
- A GitHub Actions cron auto-merges those auto-PRs once their CI is green.

**Key parts**
- **Dual-judge**: Haiku (quote extraction) + Sonnet (entailment) run in parallel. Local vLLM model is observation-only. Toggle: `BACKFILL_DUAL_JUDGE`.
- **Content cache**: sha256-keyed page text under `dev/backfill-content-cache/` for byte-exact replay.
- **YAML dual-write**: `--apply` mirrors source URLs to YAML for `facts` and `policy_stakeholders` (the two tables wiped by YAML→PG sync).
- **Auto-PR**: on `--apply`, branches off `origin/main` in a temp worktree, commits the touched YAMLs, opens a PR named `claude/backfill-sources-yaml-<ts>`. Disable with `--no-yaml-pr`.
- **Auto-merge cron** (`.github/workflows/auto-merge-backfill.yml`): every 20 min, merges any open `claude/backfill-sources-yaml-*` PR targeting `main` once CI is green.
- **Groundskeeper cron** (`apps/groundskeeper/src/tasks/backfill-sources-enqueue.ts`): schedules daily runs.

## Why

Last prod run matched 178 records but only ~25 persisted. The rest were clobbered when the next YAML→PG sync rebuilt those tables from YAML (which didn't have the new URLs yet). Dual-write fixes that.

## Test plan

- [ ] CI green
- [ ] Local dry-run: `pnpm crux tb backfill-sources --dry-run --limit=3`
- [ ] Local apply with `--no-yaml-pr` against an imported prod DB; spot-check the YAML diff
- [ ] Confirm `BACKFILL_DUAL_JUDGE=0` cleanly disables vLLM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated backfill-sources task with scheduled enqueueing and cost controls
  * Enabled automatic PR creation for YAML-based fact and stakeholder updates
  * Introduced dual-judge verification against local models for observation comparison
  * Enhanced verification pipeline to track candidate records and detailed write outcomes
  * Implemented automatic YAML synchronization for fact sources and stakeholder metadata

* **Tests**
  * Added comprehensive test coverage for YAML write operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4890)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->