### PR TITLE
auto: backfill source URLs (2 matches)

### DIFF
--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -6552,6 +6552,7 @@
       position: support
       importance: high
       reason: Lead sponsor; champions the bill as essential protection for victims of nonconsensual intimate imagery
+      source: https://durbin.senate.gov/newsroom/press-releases/durbin-graham-klobuchar-hawley-introduce-defiance-act-to-hold-accountable-those-responsible-for-the-proliferation-of-nonconsensual-sexually-explicit-deepfake-images-and-videos
     - name: Senator Lindsey Graham (R-SC)
       entityId: sid_iSc4TztRuB
       position: support
@@ -6561,6 +6562,7 @@
       position: support
       importance: high
       reason: Passed unanimously January 13, 2026, reflecting rare complete bipartisan agreement on deepfake civil remedies
+      source: https://judiciary.senate.gov/press/dem/releases/durbin-successfully-passes-bill-to-combat-nonconsensual-sexually-explicit-deepfake-images
     - name: Technology platforms
       position: mixed
       importance: medium
@@ -6610,6 +6612,7 @@
       importance: high
       reason: Author of the discussion draft; frames it as a comprehensive federal approach to AI governance combining
         multiple policy areas
+      source: https://blackburn.senate.gov/2025/12/technology/blackburn-unveils-national-policy-framework-for-artificial-intelligence
     - name: Content creators and artists
       position: support
       importance: high

--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -6612,7 +6612,7 @@
       importance: high
       reason: Author of the discussion draft; frames it as a comprehensive federal approach to AI governance combining
         multiple policy areas
-      source: https://blackburn.senate.gov/2025/12/technology/blackburn-unveils-national-policy-framework-for-artificial-intelligence
+      source: https://www.blackburn.senate.gov/index.php/2026/3/technology/blackburn-releases-discussion-draft-of-national-policy-framework-for-artificial-intelligence/
     - name: Content creators and artists
       position: support
       importance: high

--- a/packages/factbase/data/fb-entities/jensen-huang.yaml
+++ b/packages/factbase/data/fb-entities/jensen-huang.yaml
@@ -3,6 +3,8 @@ facts:
   - id: f_QNd3zfa3yw
     property: born-year
     value: 1963
+    source: https://en.wikipedia.org/wiki/Jensen_Huang
+    notes: "[auto-discovered by tb backfill-sources]"
 
   - id: f_uWhqL9PqsQ
     property: notable-for
@@ -14,7 +16,6 @@ facts:
 
   - id: f_jELY7QhUGw
     property: education
-    value: Oregon State University; Stanford University; Aloha High School; Oneida
-      Baptist Institute
+    value: Oregon State University; Stanford University; Aloha High School; Oneida Baptist Institute
     source: https://www.wikidata.org/wiki/Q305177
     notes: From Wikidata Q305177


### PR DESCRIPTION
## Summary

Auto-generated PR mirroring source-URL writes from `crux tb backfill-sources` into YAML so the next sync from YAML → PG does not wipe them.

- Matched records this run: **2**
- `facts` YAML writes:        **1**
- `policy_stakeholders` writes: **1**
- YAML files touched:        **2**

## Test plan
- [ ] CI green
- [ ] Spot-check a few changed YAMLs for sane `source:` values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added missing source URLs to stakeholder entries in legislative record data to improve traceability and citation completeness.
  * Augmented biographical records with an additional Wikipedia source and cleaned up formatting for clearer, more consistent display and better accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->