### PR TITLE
fix(auto-merge-backfill): accept StatusContext entries (Vercel/CodeRabbit)

### DIFF
--- a/.github/workflows/auto-merge-backfill.yml
+++ b/.github/workflows/auto-merge-backfill.yml
@@ -64,15 +64,21 @@ jobs:
           fi
 
           # Filter to PRs that are MERGEABLE and have all checks passing.
-          # statusCheckRollup is an array of {conclusion, status, name}; we
-          # require every entry to be conclusion=SUCCESS (or status=COMPLETED
-          # with no failures). Empty rollup => no checks ran => skip (don't
-          # merge a PR that hasn't been validated).
+          # statusCheckRollup mixes two shapes:
+          #   - CheckRun entries (GitHub Actions jobs) use `.conclusion`
+          #     with values like SUCCESS / FAILURE / NEUTRAL / SKIPPED.
+          #   - StatusContext entries (external services e.g. Vercel,
+          #     CodeRabbit) use `.state` (SUCCESS / FAILURE / PENDING)
+          #     and leave `.conclusion` null.
+          # We accept either shape's "passed" signal, and reject the PR if
+          # ANY entry is in a non-passing state. Empty rollup => no checks
+          # ran => skip (don't merge a PR that hasn't been validated).
           ELIGIBLE=$(echo "$PRS" | jq -c '[.[] |
             select(.mergeable == "MERGEABLE") |
             select((.statusCheckRollup | length) > 0) |
             select([.statusCheckRollup[] |
               (.conclusion == "SUCCESS" or .conclusion == "NEUTRAL" or .conclusion == "SKIPPED")
+              or .state == "SUCCESS"
             ] | all)
           ]')
 


### PR DESCRIPTION
## Summary

The auto-merge cron's eligibility filter excludes every PR that has a passing Vercel or CodeRabbit status, because those services report results as **StatusContext** entries (using `.state`) while the filter only inspected `.conclusion` (used by GitHub Actions **CheckRun** entries).

Observed on PR #4892: 19 CheckRun entries all green + 2 StatusContext entries with `state: "SUCCESS"`, but the 21:05 UTC run reported `0 PR(s) eligible to merge`.

## Fix

Filter accepts either shape's success signal. Failure / pending entries still block.

```diff
-(.conclusion == "SUCCESS" or .conclusion == "NEUTRAL" or .conclusion == "SKIPPED")
+(.conclusion == "SUCCESS" or .conclusion == "NEUTRAL" or .conclusion == "SKIPPED")
+or .state == "SUCCESS"
```

## Test plan

- [ ] Once merged, the next cron tick should pick up PR #4892 (all checks green, includes Vercel/CodeRabbit StatusContext entries).
- [ ] Sanity-check that a PR with a *failing* StatusContext would still be excluded (state != "SUCCESS" → filter returns false).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-visible changes in this release. This update includes internal workflow automation improvements to enhance the reliability of automatic merge processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->