### PR TITLE
fix(auto-merge-backfill): drop --delete-branch (incompatible with merge queue)

### DIFF
--- a/.github/workflows/auto-merge-backfill.yml
+++ b/.github/workflows/auto-merge-backfill.yml
@@ -90,7 +90,12 @@ jobs:
             BRANCH=$(echo "$pr" | jq -r '.headRefName')
             TITLE=$(echo "$pr" | jq -r '.title')
             echo "::group::Merging PR #$NUM ($BRANCH): $TITLE"
-            if gh pr merge "$NUM" --repo "$GITHUB_REPOSITORY" --merge --delete-branch; then
+            # `--delete-branch` is intentionally omitted: it's rejected by
+            # `gh pr merge` when the repo has a merge queue ("Cannot use
+            # `-d` or `--delete-branch` when merge queue enabled"). The
+            # repo's "Automatically delete head branches" setting handles
+            # cleanup after the queue finishes the merge.
+            if gh pr merge "$NUM" --repo "$GITHUB_REPOSITORY" --merge; then
               echo "✓ Merged PR #$NUM"
             else
               echo "::warning::Failed to merge PR #$NUM — will retry next run"


### PR DESCRIPTION
## Summary

The repo has a merge queue enabled. `gh pr merge --merge --delete-branch` errors with:

> `Cannot use \`-d\` or \`--delete-branch\` when merge queue enabled`

So every backfill auto-PR has been failing the merge step since the queue was turned on. Observed on PR #4892 in cron run [25974183098](https://github.com/quantified-uncertainty/longterm-wiki/actions/runs/25974183098/job/76351337126):

```
Found 1 open auto-backfill PR(s)
1 PR(s) eligible to merge
X Cannot use \`-d\` or \`--delete-branch\` when merge queue enabled
##[warning]Failed to merge PR #4892 — will retry next run
```

## Fix

Drop the `--delete-branch` flag. The repo's "Automatically delete head branches" setting deletes the branch after the queue finishes.

## Test plan

- [ ] Once merged, the next cron tick should successfully enqueue PR #4892.
- [ ] Confirm the branch is auto-deleted post-merge.