### PR TITLE
fix(auto-merge-backfill): enqueue directly via merge queue API

### DIFF
--- a/.github/workflows/auto-merge-backfill.yml
+++ b/.github/workflows/auto-merge-backfill.yml
@@ -50,7 +50,7 @@ jobs:
             --base main \
             --limit 200 \
             --search "head:claude/backfill-sources-yaml-" \
-            --json number,headRefName,baseRefName,mergeable,statusCheckRollup,title)
+            --json number,headRefName,headRefOid,baseRefName,mergeable,statusCheckRollup,title,id)
 
           # Defense-in-depth: re-filter by baseRefName == "main" in case the
           # --base flag is ever loosened or the search syntax changes.
@@ -85,20 +85,45 @@ jobs:
           ELIGIBLE_COUNT=$(echo "$ELIGIBLE" | jq 'length')
           echo "$ELIGIBLE_COUNT PR(s) eligible to merge"
 
+          # The repo has a merge queue enabled and "Allow auto-merge" is
+          # intentionally OFF, so `gh pr merge --merge` cannot be used
+          # (it falls back to enabling auto-merge, which the repo
+          # rejects). Instead we add the PR directly to the merge queue
+          # via the GraphQL `enqueuePullRequest` mutation, which only
+          # needs the `pull-requests: write` permission this workflow
+          # already grants. `expectedHeadOid` gives optimistic
+          # concurrency: if a new commit landed on the PR branch since
+          # we listed it, GitHub rejects rather than enqueuing a stale
+          # SHA. Branch cleanup is handled by the repo's "Automatically
+          # delete head branches" setting after the queue finishes.
           echo "$ELIGIBLE" | jq -c '.[]' | while read -r pr; do
             NUM=$(echo "$pr" | jq -r '.number')
             BRANCH=$(echo "$pr" | jq -r '.headRefName')
             TITLE=$(echo "$pr" | jq -r '.title')
-            echo "::group::Merging PR #$NUM ($BRANCH): $TITLE"
-            # `--delete-branch` is intentionally omitted: it's rejected by
-            # `gh pr merge` when the repo has a merge queue ("Cannot use
-            # `-d` or `--delete-branch` when merge queue enabled"). The
-            # repo's "Automatically delete head branches" setting handles
-            # cleanup after the queue finishes the merge.
-            if gh pr merge "$NUM" --repo "$GITHUB_REPOSITORY" --merge; then
-              echo "✓ Merged PR #$NUM"
+            PR_ID=$(echo "$pr" | jq -r '.id')
+            HEAD_OID=$(echo "$pr" | jq -r '.headRefOid')
+            echo "::group::Enqueuing PR #$NUM ($BRANCH): $TITLE"
+            ENQUEUE_OUT=$(gh api graphql \
+              -f query='mutation($prId: ID!, $headOid: GitObjectID!) {
+                enqueuePullRequest(input: {
+                  pullRequestId: $prId,
+                  expectedHeadOid: $headOid
+                }) {
+                  mergeQueueEntry { position }
+                }
+              }' \
+              -f prId="$PR_ID" \
+              -f headOid="$HEAD_OID" 2>&1) && RC=0 || RC=$?
+            if [ "$RC" -eq 0 ]; then
+              echo "✓ PR #$NUM added to merge queue"
+            elif echo "$ENQUEUE_OUT" | grep -qiE "already in|merge queue is not enabled|MERGE_QUEUE"; then
+              # PR is already in the queue (we re-list open PRs every run, so
+              # any PR queued on a previous run will re-appear here until the
+              # queue finishes merging it). Not an error.
+              echo "PR #$NUM already in merge queue — skipping"
             else
-              echo "::warning::Failed to merge PR #$NUM — will retry next run"
+              echo "::warning::Failed to enqueue PR #$NUM — will retry next run"
+              echo "$ENQUEUE_OUT"
             fi
             echo "::endgroup::"
           done


### PR DESCRIPTION
## Summary
- Replace  (broken: repo has `Allow auto-merge` off + merge queue on) with the GraphQL `enqueuePullRequest` mutation, matching the pattern already used in `.github/workflows/auto-enqueue.yml`.
- `expectedHeadOid` provides optimistic concurrency so stale SHAs are rejected.
- Treat "already in queue" as a no-op (not a warning) so re-runs don't spam misleading failures while a PR is still being processed by the queue.

## Test plan
- [ ] Manual: trigger the workflow via `workflow_dispatch` while at least one eligible backfill PR exists and confirm it gets enqueued.
- [ ] Manual: re-trigger while the same PR is still in the queue and confirm the second run logs "already in merge queue — skipping" instead of a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated PR merge workflow to use GitHub's native merge queue feature instead of direct merge commands.
  * Enhanced PR discovery to support merge queue operations.
  * Improved error handling for merge queue integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->