### PR TITLE
auto: backfill source URLs (3 matches)

### DIFF
--- a/packages/factbase/data/fb-entities/robin-hanson.yaml
+++ b/packages/factbase/data/fb-entities/robin-hanson.yaml
@@ -36,6 +36,7 @@ facts:
     value: "B.S. Physics, UC Irvine (1981); M.S. Physics and M.A. Conceptual Foundations of Science, University of Chicago
       (1984); Ph.D. Social Science, Caltech (1997)"
     notes: Enriched from wiki page
+    source: https://brainpreservation.org/team/robin-hanson
   - id: f_nkemfq398n
     property: wikipedia-url
     value: https://en.wikipedia.org/wiki/Robin_Hanson

--- a/packages/factbase/data/fb-entities/sam-mccandlish.yaml
+++ b/packages/factbase/data/fb-entities/sam-mccandlish.yaml
@@ -3,6 +3,8 @@ facts:
   - id: f_ZN4oC3AUWw
     property: notable-for
     value: "Co-founder of Anthropic; co-author of neural scaling laws research; formerly at OpenAI"
+    source: https://nextomoro.com/sam-mccandlish
+    notes: "[auto-discovered by tb backfill-sources]"
 
   - id: f_jof2ov99Qe
     property: education
@@ -15,13 +17,12 @@ facts:
     value: 0.8
     asOf: "2026-01"
     source: https://fortune.com/2026/01/27/anthropic-billionaire-cofounders-ceo-dario-amodei-giving-away-80-percent-of-wealth-fighting-inequality-ai-revolution/
-    notes: "All seven Anthropic co-founders pledged to donate 80% of their equity
-      per Fortune's January 2026 reporting. Pledge is not legally binding."
+    notes: "All seven Anthropic co-founders pledged to donate 80% of their equity per Fortune's January 2026 reporting.
+      Pledge is not legally binding."
 
   - id: f_ZVloKY5FkQ
     property: ea-alignment-estimate
-    value: [0.15, 0.3]
+    value: [ 0.15, 0.3 ]
     asOf: "2026-04"
-    notes: "Editorial estimate. Alignment researcher; no publicly documented EA
-      pledge or EA community ties. Low confidence of EA-aligned cause-area
-      giving."
+    notes: "Editorial estimate. Alignment researcher; no publicly documented EA pledge or EA community ties. Low confidence
+      of EA-aligned cause-area giving."


### PR DESCRIPTION
## Summary

Auto-generated PR mirroring source-URL writes from `crux tb backfill-sources` into YAML so the next sync from YAML → PG does not wipe them.

- Matched records this run: **3**
- `facts` YAML writes:        **2**
- `policy_stakeholders` writes: **0**
- YAML files touched:        **2**

## Test plan
- [ ] CI green
- [ ] Spot-check a few changed YAMLs for sane `source:` values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Expanded provenance documentation for Robin Hanson with additional source attribution for education-related facts.
  * Enriched Sam McCandlish entity data by adding source URLs and detailed notes across multiple categories, including notable-for attribution, equity pledge clarifications, and alignment estimate details with improved formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->