### PR TITLE
fix(worker): resolve ERR_MODULE_NOT_FOUND in worker container

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -73,8 +73,15 @@ COPY packages/ ./packages/
 # See QUA-746.
 COPY apps/wiki-server/src/api-types.ts ./apps/wiki-server/src/api-types.ts
 
-# NOTE: No other apps/wiki-server/ files needed — all other imports are type-only (erased by tsx)
-# NOTE: No content/, data/, apps/web/ needed — worker is stateless
+# crux/lib/research-playbooks.ts, crux/lib/rules/frontmatter-schema.ts, and
+# crux/wiki-server/sync-things.ts all import entity-type vocab as runtime
+# values (ENTITY_TYPE_ALIASES, ALL_ENTITY_TYPE_NAMES, OLD_TYPE_MAP). The
+# file is pure data so copying it is cheap.
+COPY apps/web/src/data/entity-type-names.ts ./apps/web/src/data/entity-type-names.ts
+
+# NOTE: No other apps/wiki-server/ or apps/web/ files needed — all other
+# imports are type-only (erased by tsx). The crux.mjs static-import graph
+# is verified by `npm run docker:smoke` and `crux/validate/validate-worker-image.ts`.
 # NOTE: Only stateless handlers (claim-verification, ping) work in this image.
 # citation-verify shells out to crux CLI (needs full monorepo deps).
 # page-improve/page-create/batch-commit need git. Both stay on GHA.

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -59,6 +59,75 @@ export const PageIdSchema = z.string().min(1).max(200);
 // Record Source-Checks
 // ---------------------------------------------------------------------------
 
+/**
+ * Allowed lifecycle states for a URL suggestion.
+ * Mirrored in the PG CHECK constraint — migrations 0176 (initial set) and
+ * 0198 (added 'applied'). Keep in sync.
+ *
+ * Lives here (not next to the route) because the worker container only
+ * COPIES this file from apps/wiki-server/, and the apply-suggestions
+ * CLI imports the constant as a runtime value (not type-only).
+ */
+export const VALID_SUGGESTION_STATUSES = [
+  "pending",
+  "approved",
+  "rejected",
+  "auto_verified",
+  "applied",
+] as const;
+export type SuggestionStatus = (typeof VALID_SUGGESTION_STATUSES)[number];
+
+/**
+ * Files in `apps/wiki-server/src/routes/tablebase/` that are NOT mounted
+ * routes — helpers, schemas, test-d files. Consumed by the route detector
+ * and the two tablebase validators. Mirrors the worker-container reality
+ * (only `api-types.ts` is copied out of `apps/wiki-server/`) so the lazy
+ * route detector + the validators load without ERR_MODULE_NOT_FOUND.
+ *
+ * Keep in sync with `apps/wiki-server/src/routes/tablebase/mount-registry.ts`.
+ */
+export const TABLEBASE_NON_ROUTE_FILES: readonly string[] = [
+  "index.ts",
+  "mount-registry.ts",
+  "sync-factory.ts",
+  "sync-factory.test-d.ts",
+  "sourcing-schema.ts",
+  "audit-log.ts",
+  "write-inline-verdicts.ts",
+  "entity-profile-descriptions.ts",
+  "system-card-benchmark-linker.ts",
+  "benchmark-shared.ts",
+  "policy-stakeholders-schema.ts",
+];
+
+/**
+ * Risk-domain enum for the third-party-evaluation tablebase route.
+ * Mirrors the CHECK constraint in migration 0206. Lives here so the
+ * crux third-party-eval extractor (which imports this as a value, not
+ * type) loads inside the worker container.
+ *
+ * Keep in sync with `apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts`.
+ */
+export const VALID_RISK_DOMAINS = [
+  "cbrn",
+  "biological",
+  "chemical",
+  "radiological",
+  "nuclear",
+  "cyber",
+  "autonomy",
+  "agent-security",
+  "persuasion",
+  "scheming",
+  "deception",
+  "jailbreak",
+  "safeguard-efficacy",
+  "evaluation-awareness",
+  "misuse",
+  "misc",
+] as const;
+export type RiskDomain = (typeof VALID_RISK_DOMAINS)[number];
+
 export const VALID_RECORD_TYPES = [
   "grant",
   "personnel",

--- a/apps/wiki-server/src/routes/sourcing/url-suggestions.ts
+++ b/apps/wiki-server/src/routes/sourcing/url-suggestions.ts
@@ -25,22 +25,18 @@ import {
   dbError,
   notFoundError,
 } from "../shared/utils.js";
+import {
+  VALID_SUGGESTION_STATUSES,
+  type SuggestionStatus,
+} from "../../api-types.js";
 
 const MAX_BATCH = 200;
 
-/**
- * Allowed lifecycle states for a URL suggestion.
- * Mirrored in the PG CHECK constraint — migrations 0176 (initial set) and
- * 0198 (added 'applied'). Keep in sync.
- */
-export const VALID_SUGGESTION_STATUSES = [
-  "pending",
-  "approved",
-  "rejected",
-  "auto_verified",
-  "applied",
-] as const;
-export type SuggestionStatus = (typeof VALID_SUGGESTION_STATUSES)[number];
+// Re-export so the small set of importers that read these from the route
+// file continue to work; the canonical definition now lives in api-types
+// where the worker container can reach it.
+export { VALID_SUGGESTION_STATUSES };
+export type { SuggestionStatus };
 
 const VALID_STATUSES = VALID_SUGGESTION_STATUSES;
 

--- a/apps/wiki-server/src/routes/tablebase/mount-registry.ts
+++ b/apps/wiki-server/src/routes/tablebase/mount-registry.ts
@@ -182,16 +182,6 @@ export const TABLEBASE_MANUAL_MOUNTS = [
  * added. Update this list when adding a new non-route module next to the
  * real routes.
  */
-export const TABLEBASE_NON_ROUTE_FILES: readonly string[] = [
-  "index.ts",
-  "mount-registry.ts",
-  "sync-factory.ts",
-  "sync-factory.test-d.ts",
-  "sourcing-schema.ts",
-  "audit-log.ts",
-  "write-inline-verdicts.ts",
-  "entity-profile-descriptions.ts",
-  "system-card-benchmark-linker.ts",
-  "benchmark-shared.ts",
-  "policy-stakeholders-schema.ts",
-];
+// Canonical definition lives in api-types.ts so the worker container can
+// reach it; re-exported here for code that already imports from this file.
+export { TABLEBASE_NON_ROUTE_FILES } from "../../api-types.js";

--- a/apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts
+++ b/apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts
@@ -41,26 +41,11 @@ const MAX_PAGE_SIZE = 200;
 
 const RECORD_TYPE = "third-party-evaluation" as const;
 
-// Mirror the CHECK constraint in migration 0206. Source-of-truth for the
-// same vocab also referenced by validate-third-party-eval-refs.ts.
-export const VALID_RISK_DOMAINS = [
-  "cbrn",
-  "biological",
-  "chemical",
-  "radiological",
-  "nuclear",
-  "cyber",
-  "autonomy",
-  "agent-security",
-  "persuasion",
-  "scheming",
-  "deception",
-  "jailbreak",
-  "safeguard-efficacy",
-  "evaluation-awareness",
-  "misuse",
-  "misc",
-] as const;
+// Canonical definition lives in api-types.ts so the worker container can
+// reach it; re-imported here both for local use and to keep the existing
+// re-export shape for old call sites.
+import { VALID_RISK_DOMAINS } from "../../api-types.js";
+export { VALID_RISK_DOMAINS };
 
 export const VALID_SOURCE_FORMATS = [
   "pdf",

--- a/crux/commands/resources.ts
+++ b/crux/commands/resources.ts
@@ -15,7 +15,10 @@ import { classifyCommand } from '../resource-enrichment/classify.ts';
 import { deepEnrichCommand } from '../resource-enrichment/enrich.ts';
 import { crossReferenceCommand } from '../resource-enrichment/cross-reference.ts';
 import { fetchWaybackCommand } from '../resource-enrichment/fetch-wayback.ts';
-import { archivePdfsCommand } from '../resource-enrichment/archive-pdfs.ts';
+// archive-pdfs is lazy-loaded below: it pulls in @aws-sdk/client-s3 which
+// is too heavy to bundle into the worker container (the worker never
+// runs archive-pdfs, only the local CLI does). Static-importing it
+// breaks crux.mjs load in the worker image with ERR_MODULE_NOT_FOUND.
 import { enrichCrossrefCommand } from '../resource-enrichment/enrich-crossref.ts';
 import { discoverForumsCommand } from '../resource-enrichment/discover-forums.ts';
 import { enrichRandDatesCommand } from '../resource-enrichment/enrich-rand-dates.ts';
@@ -156,7 +159,10 @@ commands['deep-enrich'] = deepEnrichCommand;
 
 commands['cross-reference'] = crossReferenceCommand;
 commands['fetch-wayback'] = fetchWaybackCommand;
-commands['archive-pdfs'] = archivePdfsCommand;
+commands['archive-pdfs'] = async (args, options) => {
+  const { archivePdfsCommand } = await import('../resource-enrichment/archive-pdfs.ts');
+  return archivePdfsCommand(args, options);
+};
 commands['enrich-crossref'] = enrichCrossrefCommand;
 commands['discover-forums'] = discoverForumsCommand;
 commands['enrich-rand-dates'] = enrichRandDatesCommand;

--- a/crux/commands/sourcing-apply-suggestions.ts
+++ b/crux/commands/sourcing-apply-suggestions.ts
@@ -34,10 +34,13 @@ import {
   storeVerdict as storeVerdictRpc,
   getVerdictByRecord,
 } from '../lib/wiki-server/sourcing-client.ts';
+// Import the constant + type from api-types (already copied into the
+// worker container image); the routes/* file is not bundled, so importing
+// from there breaks the worker at runtime (ERR_MODULE_NOT_FOUND).
 import {
   VALID_SUGGESTION_STATUSES,
   type SuggestionStatus,
-} from '../../apps/wiki-server/src/routes/sourcing/url-suggestions.ts';
+} from '../../apps/wiki-server/src/api-types.ts';
 import { createLlmClient } from '../lib/llm.ts';
 import {
   fetchSourceContent,

--- a/crux/lib/deploy-tasks/detect.ts
+++ b/crux/lib/deploy-tasks/detect.ts
@@ -2,7 +2,10 @@ import { execFileSync } from "child_process";
 import { readFileSync } from "fs";
 import { basename } from "path";
 
-import { TABLEBASE_NON_ROUTE_FILES } from "../../../apps/wiki-server/src/routes/tablebase/mount-registry.ts";
+// Import from api-types (worker container copies this file). The route
+// file mount-registry.ts is NOT in the worker image and importing from
+// it causes ERR_MODULE_NOT_FOUND on crux.mjs load.
+import { TABLEBASE_NON_ROUTE_FILES } from "../../../apps/wiki-server/src/api-types.ts";
 
 import type {
   DeployTask,

--- a/crux/third-party-evals/extract-eval-report.ts
+++ b/crux/third-party-evals/extract-eval-report.ts
@@ -19,10 +19,11 @@ import { fetchSource } from "../lib/search/source-fetcher.ts";
 import { parseJsonResponse } from "../lib/anthropic.ts";
 import { escapeXml } from "../lib/prompt-utils.ts";
 
-import {
-  VALID_RISK_DOMAINS,
-  type ThirdPartyEvaluationSyncItem,
-} from "../../apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts";
+// VALID_RISK_DOMAINS is imported from api-types (which the worker
+// container copies). ThirdPartyEvaluationSyncItem is type-only so it
+// can stay attached to the route file (tsx erases type-only imports).
+import { VALID_RISK_DOMAINS } from "../../apps/wiki-server/src/api-types.ts";
+import type { ThirdPartyEvaluationSyncItem } from "../../apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts";
 import type { InlineSourcing } from "../lib/wiki-server/inline-sourcing.ts";
 
 export const EXTRACTOR_VERSION = "third-party-eval-extractor@1.0";

--- a/crux/validate/validate-tablebase-completeness.ts
+++ b/crux/validate/validate-tablebase-completeness.ts
@@ -21,7 +21,7 @@
 import { readdirSync, readFileSync } from "fs";
 import { join, basename } from "path";
 import { getColors } from "../lib/output.ts";
-import { TABLEBASE_NON_ROUTE_FILES } from "../../apps/wiki-server/src/routes/tablebase/mount-registry.ts";
+import { TABLEBASE_NON_ROUTE_FILES } from "../../apps/wiki-server/src/api-types.ts";
 
 const ROUTES_DIR = "apps/wiki-server/src/routes/tablebase";
 const c = getColors(process.env.CI === "true");

--- a/crux/validate/validate-tablebase-registry.ts
+++ b/crux/validate/validate-tablebase-registry.ts
@@ -30,7 +30,7 @@
 import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { getColors } from "../lib/output.ts";
-import { TABLEBASE_NON_ROUTE_FILES } from "../../apps/wiki-server/src/routes/tablebase/mount-registry.ts";
+import { TABLEBASE_NON_ROUTE_FILES } from "../../apps/wiki-server/src/api-types.ts";
 
 const ROUTES_DIR = "apps/wiki-server/src/routes/tablebase";
 const REGISTRY_PATH = "crux/tablebase/table-registry.ts";

--- a/crux/validate/validate-third-party-eval-refs.ts
+++ b/crux/validate/validate-third-party-eval-refs.ts
@@ -80,18 +80,41 @@ interface DriftFinding {
 
 /**
  * Extract a `as const` string-array literal exported from the route file.
- * Hand-rolled scanner — looking for the named export and reading the
+ * Hand-rolled scanner — looks for the named export and reads the
  * comma-separated quoted strings up to the closing `]`. Defensive against
  * formatting changes (whitespace, multi-line layout).
+ *
+ * If the route file does not declare the constant directly but re-exports
+ * it from `api-types.ts` (the canonical home for constants the worker
+ * container imports — moved there to avoid pulling route files into the
+ * worker image), fall back to reading `api-types.ts`.
  */
 function extractRouteVocab(source: string, name: string): string[] | null {
   const re = new RegExp(
     `export\\s+const\\s+${name}\\s*=\\s*\\[([\\s\\S]*?)\\]\\s*as\\s+const\\s*;`,
     "m",
   );
-  const m = source.match(re);
-  if (!m) return null;
-  const body = m[1];
+  const direct = source.match(re);
+  if (direct) {
+    const body = direct[1];
+    const stringRe = /['"]([^'"\n]+?)['"]/g;
+    const out: string[] = [];
+    let mm: RegExpExecArray | null;
+    while ((mm = stringRe.exec(body))) out.push(mm[1]);
+    return out;
+  }
+
+  // Re-export path: `import { NAME } from "../../api-types.js"; export { NAME };`
+  const reExportRe = new RegExp(
+    `import\\s*\\{[^}]*\\b${name}\\b[^}]*\\}\\s*from\\s*['"]\\.\\.\\/\\.\\.\\/api-types(?:\\.js)?['"]`,
+  );
+  if (!reExportRe.test(source)) return null;
+  const apiTypesPath = path.join(REPO_ROOT, "apps/wiki-server/src/api-types.ts");
+  if (!existsSync(apiTypesPath)) return null;
+  const apiTypesSrc = readFileSync(apiTypesPath, "utf-8");
+  const m2 = apiTypesSrc.match(re);
+  if (!m2) return null;
+  const body = m2[1];
   const stringRe = /['"]([^'"\n]+?)['"]/g;
   const out: string[] = [];
   let mm: RegExpExecArray | null;


### PR DESCRIPTION
## Summary

- Move shared constants used by both wiki-server routes **and** worker-container code into `apps/wiki-server/src/api-types.ts` — the single wiki-server file the worker image already copies.
- Lazy-load `archive-pdfs` so the AWS SDK stops being a hard dependency of the worker image.
- Add the missing `COPY apps/web/src/data/entity-type-names.ts` to `Dockerfile.worker` (value-imported by several crux files).
- Split a value/type import that was pulling a route file into the worker.

## Why

The worker container's `crux.mjs` static-import graph was reaching into `apps/wiki-server/src/routes/**` for runtime values. Those files are not in the worker image, so the spawn (`node --import tsx/esm crux.mjs …`) dies with `ERR_MODULE_NOT_FOUND` before any handler runs.

Concretely, the `backfill-sources` cron at 2026-05-18 02:00 UTC failed with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/repo/apps/wiki-server/src/routes/sourcing/url-suggestions.ts'
imported from /repo/crux/commands/sourcing-apply-suggestions.ts
```

Same class of failure as QUA-605 / QUA-598. After this fix, the only wiki-server file the worker container needs is `api-types.ts` (already copied), so the missing-COPY validator that QUA-605 added stays green.

## Test plan

- [ ] `pnpm crux:build` — typecheck the moved constants
- [ ] `pnpm test` (crux + wiki-server)
- [ ] Build the worker image locally and run `docker run … crux.mjs` to confirm it loads without `ERR_MODULE_NOT_FOUND`
- [ ] After merge: watch prod jobs table for the next `backfill-sources` cron tick — expect `status=completed` instead of the previous failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed module loading errors in worker environment by consolidating API constants to a shared source and updating import paths accordingly.
  * Updated Docker worker configuration to include required runtime data files.
  * Prevented unnecessary AWS SDK dependencies from being bundled into worker container via lazy-loading.

* **Chores**
  * Centralized canonical definitions for suggestion statuses and risk domains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->