### PR TITLE
fix(worker): add missing npm deps + COPY data/ so crux.mjs loads

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -79,6 +79,11 @@ COPY apps/wiki-server/src/api-types.ts ./apps/wiki-server/src/api-types.ts
 # file is pure data so copying it is cheap.
 COPY apps/web/src/data/entity-type-names.ts ./apps/web/src/data/entity-type-names.ts
 
+# crux/lib/visual-detection.ts value-imports VISUAL_COMPONENT_NAMES from
+# data/schema.ts. visual-detection is pulled into crux.mjs's static graph
+# via commands/visual.ts. data/ also holds YAML the wiki-server reads.
+COPY data/ ./data/
+
 # NOTE: No other apps/wiki-server/ or apps/web/ files needed — all other
 # imports are type-only (erased by tsx). The crux.mjs static-import graph
 # is verified by `npm run docker:smoke` and `crux/validate/validate-worker-image.ts`.

--- a/docker/worker/package.json
+++ b/docker/worker/package.json
@@ -5,12 +5,22 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
     "@longterm-wiki/url-utils": "file:./packages/url-utils",
+    "@mdx-js/mdx": "^3.1.0",
     "dotenv": "^17.2.4",
     "gray-matter": "^4.0.3",
+    "hono": "^4.12.4",
     "js-yaml": "^4.1.0",
     "pino": "^10.3.1",
     "playwright": "^1.55.1",
+    "proper-lockfile": "^4.1.2",
+    "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
+    "remark-mdx": "^3.1.0",
+    "remark-mdx-frontmatter": "^5.0.0",
+    "remark-parse": "^11.0.0",
     "tsx": "4.19.0",
+    "unified": "^11.0.5",
     "yaml": "^2.7.0",
     "zod": "^3.25.76"
   }


### PR DESCRIPTION
## Summary

PR #4901 fixed the wiki-server *route* imports leaking into the worker image. But the worker's `crux.mjs` static-import graph also pulls in:

- **10 npm packages** that aren't in `docker/worker/package.json` (the first one prod hit was `proper-lockfile`)
- **`data/schema.ts`** which isn't copied into the image

So after #4901 deployed and we enqueued a real backfill-sources job, it failed with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'proper-lockfile'
  imported from /repo/crux/pr-patrol/state.ts
```

This PR adds the missing 10 packages (versions matching the monorepo root) and adds `COPY data/ ./data/` to `Dockerfile.worker`.

## Verified

Built `Dockerfile.worker` locally with this diff and ran `crux/crux.mjs jobs types`:

```
Registered Job Types
  • ping
  • citation-verify
  • backfill-sources
  • page-improve
  • page-create
  • batch-commit
  • auto-update-digest
  • claim-sourcing
  • resource-ingest
  • resource-enrich
  • resource-verify
11 types registered. Workers can handle these job types.
```

Also confirmed `crux.mjs tb backfill-sources --dry-run` reaches the actual handler code (fails only on missing prod env, not on imports).

## Why each package is needed

| Package | Pulled in by |
|---|---|
| `proper-lockfile` | `crux/pr-patrol/state.ts` ← `crux/commands/pr-patrol.ts` |
| `hono` | `crux/commands/tablebase-scaffold.ts` |
| `@mdx-js/mdx`, `remark-*`, `unified` | `crux/validate/validate-mdx-compile.ts`, `crux/lib/content/block-ir.ts`, `crux/authoring/page-improver/phases/validate.ts` |
| `data/` | `crux/lib/visual-detection.ts` value-imports from `data/schema.ts` |

## Test plan

- [ ] After merge to production: enqueue a small `backfill-sources` job and confirm `status='completed'`
- [ ] Verify worker image size didn't balloon (the new deps total ~3MB)

## Follow-up

The real fix is to lazy-load CLI-only commands in `crux.mjs` (today every command is eagerly imported, dragging the kitchen sink into the worker). That's a bigger refactor — separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated worker container to include data directory in runtime environment
  * Added new dependencies to worker service including web framework, markdown processing, and file management libraries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->