### PR TITLE
main → production: ship worker deps + data/ fix (part 2)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -79,6 +79,11 @@ COPY apps/wiki-server/src/api-types.ts ./apps/wiki-server/src/api-types.ts
 # file is pure data so copying it is cheap.
 COPY apps/web/src/data/entity-type-names.ts ./apps/web/src/data/entity-type-names.ts
 
+# crux/lib/visual-detection.ts value-imports VISUAL_COMPONENT_NAMES from
+# data/schema.ts. visual-detection is pulled into crux.mjs's static graph
+# via commands/visual.ts. data/ also holds YAML the wiki-server reads.
+COPY data/ ./data/
+
 # NOTE: No other apps/wiki-server/ or apps/web/ files needed — all other
 # imports are type-only (erased by tsx). The crux.mjs static-import graph
 # is verified by `npm run docker:smoke` and `crux/validate/validate-worker-image.ts`.

--- a/docker/worker/package.json
+++ b/docker/worker/package.json
@@ -5,12 +5,22 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
     "@longterm-wiki/url-utils": "file:./packages/url-utils",
+    "@mdx-js/mdx": "^3.1.0",
     "dotenv": "^17.2.4",
     "gray-matter": "^4.0.3",
+    "hono": "^4.12.4",
     "js-yaml": "^4.1.0",
     "pino": "^10.3.1",
     "playwright": "^1.55.1",
+    "proper-lockfile": "^4.1.2",
+    "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
+    "remark-mdx": "^3.1.0",
+    "remark-mdx-frontmatter": "^5.0.0",
+    "remark-parse": "^11.0.0",
     "tsx": "4.19.0",
+    "unified": "^11.0.5",
     "yaml": "^2.7.0",
     "zod": "^3.25.76"
   }


### PR DESCRIPTION
## Summary
- 2 commits ahead of production (last sync: PR #4902 earlier today)
- **#4903 (worker container fix part 2)**: adds 10 missing npm packages + `COPY data/` to the worker image so `crux.mjs` can load. Without this, the previous worker fix shipped a half-broken image — `backfill-sources` still failed with `Cannot find package 'proper-lockfile'`.

## Test plan
- [ ] After merge: confirm `worker` deployment redeploys with the new image SHA
- [ ] Enqueue a small `backfill-sources` test job and verify `status='completed'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
