### PR TITLE
chore: mark 5 non-applicable funding-round tasks as done

### DIFF
--- a/.tablebase-completed.txt
+++ b/.tablebase-completed.txt
@@ -253,3 +253,8 @@ TtMfWVwzhlNz
 MkjveX73BlxG
 V8RUVIwNDDzp
 vxn346nLVmfw
+yhb9n-YNX1-8
+s077EO-OgdPX
+Qm1zG2i1r49h
+K9puR5EJxaSY
+tHo6NDpvuIwb


### PR DESCRIPTION
## Summary

- Processed 5 funding-round enrichment tasks from the queue
- All 5 entities are non-companies without venture funding rounds — marked done to prevent re-queuing

## Entities processed

| Entity | Reason for no data |
|--------|-------------------|
| EA Global | Conference series run by CEA — not a startup |
| Anthropic Long-Term Benefit Trust | Governance structure, not a fundraising entity |
| NIST and AI Safety | US government agency |
| Compute Supply Chain Actors | Conceptual category entity |
| IBBIS | Philanthropically-funded nonprofit, no VC rounds |

## Changes

Only `.tablebase-completed.txt` updated with 5 task IDs.

https://claude.ai/code/session_01Kih1ouYMqodiG4GhRwqN8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kih1ouYMqodiG4GhRwqN8G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tablebase completion data with five new entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->