### PR TITLE
fix(backfill-sources): write unmatched report to temp dir, not dev/reports

### DIFF
--- a/crux/commands/backfill-sources.ts
+++ b/crux/commands/backfill-sources.ts
@@ -14,6 +14,8 @@
  *   pnpm crux tb backfill-sources --table=facts --apply  # Only facts
  */
 
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { DEFAULT_MAX_COST, PER_RECORD_BUDGET } from '../lib/backfill-sources/config.ts';
 import { addCost, emptyCost, totalOf } from '../lib/backfill-sources/cost.ts';
 import { fetchMissingSources, updateRecordSource } from '../lib/backfill-sources/fetch.ts';
@@ -165,8 +167,12 @@ function parseOptions(o: CommandOptions): ParsedOptions | { error: string } {
     maxCost,
     verbose: !!o.verbose,
     debug: !!o.debug,
+    // Default into the OS temp dir, not dev/reports under the repo: the worker
+    // container runs as a non-root user on a read-only repo and can't create
+    // dev/reports. Pass --unmatched-out to write somewhere specific (e.g. a dev
+    // checkout where you want the report committed/inspected).
     unmatchedOut: (o.unmatchedOut as string | undefined)
-      ?? `dev/reports/backfill-unmatched-${new Date().toISOString().replace(/[:.]/g, '-')}.json`,
+      ?? join(tmpdir(), `backfill-unmatched-${new Date().toISOString().replace(/[:.]/g, '-')}.json`),
     skipYamlPr: !!o.noYamlPr,
   };
 }

--- a/crux/lib/job-handlers/index.ts
+++ b/crux/lib/job-handlers/index.ts
@@ -101,7 +101,8 @@ const handlers: Record<string, JobHandler> = {
       });
 
       // Tail of stdout is enough to summarise outcomes; the full report is
-      // written to dev/reports/backfill-unmatched-*.json on the worker pod.
+      // written to backfill-unmatched-*.json in the OS temp dir on the worker
+      // pod (override with --unmatched-out).
       const tail = output.slice(-2000);
       return { success: true, data: { limit, maxCost, table: params.table ?? null, output: tail } };
     } catch (err: unknown) {


### PR DESCRIPTION
## Problem

Every `backfill-sources` run in the worker container logs:

```
Outcomes write FAILED: EACCES: permission denied, mkdir 'dev/reports'
```

The job writes an "unmatched records" report. The default path was `dev/reports/…` under the repo root, but the worker runs as a non-root user on a read-only `/repo`, so it can't create that directory. The job still completes (the write is wrapped in try/catch) — but the report is never saved.

## Fix

Default the report path to the OS temp dir instead of `dev/reports/`. `--unmatched-out` still overrides, for dev checkouts where you want the report committed/inspected.

## Verified

Ran in the actual prod worker image (`sha-a477cfee`) as user `worker`:

```
worker
WROTE: /tmp/wtest-….json ok
```

Temp-dir write succeeds where `dev/reports` failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default output location for unmatched-output reports in the backfill-sources command. Reports now write to the system temporary directory with timestamped filenames when no custom path is specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->