### PR TITLE
main → production: backfill report writes to temp dir (EACCES fix)

### DIFF
--- a/crux/commands/backfill-sources.ts
+++ b/crux/commands/backfill-sources.ts
@@ -14,6 +14,8 @@
  *   pnpm crux tb backfill-sources --table=facts --apply  # Only facts
  */
 
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { DEFAULT_MAX_COST, PER_RECORD_BUDGET } from '../lib/backfill-sources/config.ts';
 import { addCost, emptyCost, totalOf } from '../lib/backfill-sources/cost.ts';
 import { fetchMissingSources, updateRecordSource } from '../lib/backfill-sources/fetch.ts';
@@ -165,8 +167,12 @@ function parseOptions(o: CommandOptions): ParsedOptions | { error: string } {
     maxCost,
     verbose: !!o.verbose,
     debug: !!o.debug,
+    // Default into the OS temp dir, not dev/reports under the repo: the worker
+    // container runs as a non-root user on a read-only repo and can't create
+    // dev/reports. Pass --unmatched-out to write somewhere specific (e.g. a dev
+    // checkout where you want the report committed/inspected).
     unmatchedOut: (o.unmatchedOut as string | undefined)
-      ?? `dev/reports/backfill-unmatched-${new Date().toISOString().replace(/[:.]/g, '-')}.json`,
+      ?? join(tmpdir(), `backfill-unmatched-${new Date().toISOString().replace(/[:.]/g, '-')}.json`),
     skipYamlPr: !!o.noYamlPr,
   };
 }

--- a/crux/lib/job-handlers/index.ts
+++ b/crux/lib/job-handlers/index.ts
@@ -101,7 +101,8 @@ const handlers: Record<string, JobHandler> = {
       });
 
       // Tail of stdout is enough to summarise outcomes; the full report is
-      // written to dev/reports/backfill-unmatched-*.json on the worker pod.
+      // written to backfill-unmatched-*.json in the OS temp dir on the worker
+      // pod (override with --unmatched-out).
       const tail = output.slice(-2000);
       return { success: true, data: { limit, maxCost, table: params.table ?? null, output: tail } };
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- 3 commits ahead of production (last sync: PR #4904)
- **#4912**: backfill-sources now writes its "unmatched records" report to the OS temp dir instead of `dev/reports/`, fixing the `EACCES: permission denied, mkdir 'dev/reports'` error logged on every worker run. Plus a stale-comment fixup.

## Test plan
- [ ] After merge: worker redeploys with the new image SHA
- [ ] Next backfill-sources run no longer logs the `Outcomes write FAILED: EACCES` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
