### PR TITLE
fix(worker): async child exec so /healthz stays alive during long jobs

### DIFF
--- a/crux/lib/job-handlers/index.ts
+++ b/crux/lib/job-handlers/index.ts
@@ -13,8 +13,19 @@
  * require(esm) cycle detection is strict.
  */
 
-import { execFileSync } from 'child_process';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import type { JobHandler } from './types.ts';
+
+// Async (non-blocking) child execution. We deliberately avoid execFileSync:
+// the worker is a single Node process that also serves the /healthz liveness
+// endpoint, and a synchronous spawn blocks the event loop for the whole job.
+// On a multi-minute job that starves /healthz, Kubernetes' liveness probe
+// fails and restarts the pod mid-job (the job is then re-claimed and
+// eventually exhausts its retries). promisify(execFile) keeps the event loop
+// free so /healthz keeps answering. On non-zero exit the returned promise
+// rejects with an Error carrying .stdout/.stderr.
+const execFileAsync = promisify(execFile);
 
 // ---------------------------------------------------------------------------
 // Lazy handler loaders — each returns the handler on first call, then caches
@@ -50,14 +61,14 @@ const handlers: Record<string, JobHandler> = {
     }
 
     try {
-      const output = execFileSync('node', [
+      const { stdout: output } = await execFileAsync('node', [
         '--import', 'tsx/esm', '--no-warnings',
         'crux/crux.mjs', 'citations', 'verify', pageId, '--json',
       ], {
         cwd: ctx.projectRoot,
         encoding: 'utf-8',
         timeout: 5 * 60 * 1000,
-        stdio: ['pipe', 'pipe', 'pipe'],
+        maxBuffer: 16 * 1024 * 1024,
       });
 
       try {
@@ -92,11 +103,10 @@ const handlers: Record<string, JobHandler> = {
     }
 
     try {
-      const output = execFileSync('node', args, {
+      const { stdout: output } = await execFileAsync('node', args, {
         cwd: ctx.projectRoot,
         encoding: 'utf-8',
         timeout: 60 * 60 * 1000, // 1h — full prod sweep is ~30-50 min
-        stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 16 * 1024 * 1024,
       });
 


### PR DESCRIPTION
## Problem

A `backfill-sources --limit=50` job (~250 records, several minutes) **crashes the worker pods**: they restart mid-job, the job gets re-claimed, and after `max_retries` it fails. Observed live: 2 of 3 worker pods restarted, job stuck on retry 2/3.

Not OOM (`exit 0`). Root cause: the `citation-verify` and `backfill-sources` handlers spawn `crux.mjs` with **`execFileSync`** — a synchronous call that blocks the worker's single Node event loop for the whole job. The worker also serves the `/healthz` liveness endpoint from that same loop, so a long job starves it. The Kubernetes liveness probe (period 30s, timeout 5s, failureThreshold 3 → ~90s) then declares the pod dead and restarts it.

Small jobs (`--limit=3`, ~55s) finish before the 90s threshold, which is why they looked fine.

## Fix

Swap `execFileSync` → `promisify(execFile)` (non-blocking). The event loop stays free to answer `/healthz` while the child runs. Same args / cwd / timeout / maxBuffer; non-zero exit still rejects with an Error carrying stdout/stderr, so the existing try/catch is unchanged.

## Test

- `crux/lib/job-handlers/job-handlers.test.ts` — 20/20 pass.
- After deploy: re-run `backfill-sources --limit=50 --max-cost=10` and confirm pods don't restart and the job completes in one attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
