### PR TITLE
main → production: backfill report JSONL streaming (OOM fix)

### DIFF
--- a/crux/commands/backfill-sources.ts
+++ b/crux/commands/backfill-sources.ts
@@ -21,7 +21,12 @@ import { addCost, emptyCost, totalOf } from '../lib/backfill-sources/cost.ts';
 import { fetchMissingSources, updateRecordSource } from '../lib/backfill-sources/fetch.ts';
 import { extractMatchTerms } from '../lib/backfill-sources/match-terms.ts';
 import { processRecord } from '../lib/backfill-sources/process-record.ts';
-import { buildSummaryLines, writeOutcomesJson } from '../lib/backfill-sources/report.ts';
+import {
+  buildSummaryLines,
+  openOutcomeJsonl,
+  appendOutcomeJsonl,
+  closeOutcomeJsonl,
+} from '../lib/backfill-sources/report.ts';
 import type {
   CostBreakdown,
   MissingSourceRecord,
@@ -99,15 +104,7 @@ async function backfillSourcesCommand(args: string[], rawOptions: CommandOptions
     verbose: parsed.verbose,
   });
 
-  const outcomeStatus = writeOutcomesJson({
-    path: parsed.unmatchedOut,
-    outcomes: run.outcomes,
-    mode: parsed.apply ? 'apply' : 'dry-run',
-    totalRecords: records.length,
-    searched: run.searched,
-    matched: run.matched,
-  });
-  if (outcomeStatus) lines.push(outcomeStatus);
+  if (run.outcomeStatus) lines.push(run.outcomeStatus);
 
   if (parsed.apply) {
     lines.push(
@@ -232,6 +229,8 @@ interface RunTotals {
   touchedYamlPaths: Set<string>;
   factsYamlWritten: number;
   stakeholdersYamlWritten: number;
+  /** Status line for the JSONL outcome file (path + counts, or write error). */
+  outcomeStatus: string;
 }
 
 async function processAllRecords(
@@ -252,6 +251,17 @@ async function processAllRecords(
     touchedYamlPaths: new Set<string>(),
     factsYamlWritten: 0,
     stakeholdersYamlWritten: 0,
+    outcomeStatus: '',
+  };
+
+  // Stream outcomes to a JSONL file as each record finishes. We keep only a
+  // light copy in memory (candidates stripped) for the end-of-run summary —
+  // the heavy candidate payloads live only in the file, one line at a time.
+  const mode = parsed.apply ? 'apply' : 'dry-run';
+  const jsonlOk = openOutcomeJsonl(parsed.unmatchedOut, mode);
+  const recordOutcome = (o: RecordOutcome): void => {
+    if (jsonlOk) appendOutcomeJsonl(parsed.unmatchedOut, o);
+    run.outcomes.push(stripCandidates(o));
   };
 
   // Build YAML target indexes once per apply-run. In dry-run we skip this
@@ -275,11 +285,11 @@ async function processAllRecords(
 
     if (extractMatchTerms(record).length === 0) {
       run.noTerms++;
-      run.outcomes.push({ record, outcome: { kind: 'skipped', reason: 'no search terms' } });
+      recordOutcome({ record, outcome: { kind: 'skipped', reason: 'no search terms' } });
       continue;
     }
     if (isTestRecord(record)) {
-      run.outcomes.push({ record, outcome: { kind: 'skipped', reason: 'test record' } });
+      recordOutcome({ record, outcome: { kind: 'skipped', reason: 'test record' } });
       continue;
     }
     if (totalOf(run.totalBreakdown) >= parsed.maxCost) {
@@ -288,7 +298,7 @@ async function processAllRecords(
         console.warn(`\n[budget] Reached $${totalOf(run.totalBreakdown).toFixed(4)} / $${parsed.maxCost.toFixed(2)} cap — stopping remaining records`);
       }
       run.budgetSkipped++;
-      run.outcomes.push({ record, outcome: { kind: 'skipped', reason: 'budget cap' } });
+      recordOutcome({ record, outcome: { kind: 'skipped', reason: 'budget cap' } });
       continue;
     }
 
@@ -299,7 +309,7 @@ async function processAllRecords(
     addCost(run.totalBreakdown, result.cost);
 
     if (!result.matched) {
-      run.outcomes.push({
+      recordOutcome({
         record,
         outcome: {
           kind: 'no-match',
@@ -346,7 +356,7 @@ async function processAllRecords(
       }
     }
 
-    run.outcomes.push({
+    recordOutcome({
       record,
       outcome: {
         kind: 'matched',
@@ -361,7 +371,32 @@ async function processAllRecords(
     });
   }
 
+  const unmatched = run.searched - run.matched;
+  const skipped = run.noTerms + run.budgetSkipped;
+  run.outcomeStatus = jsonlOk
+    ? closeOutcomeJsonl(parsed.unmatchedOut, {
+        records: records.length,
+        searched: run.searched,
+        matched: run.matched,
+        unmatched,
+        skipped,
+      })
+    : `  Outcomes write skipped: ${parsed.unmatchedOut} not writable`;
+
   return run;
+}
+
+/**
+ * Strip the heavy `candidates` payload before keeping an outcome in memory for
+ * the end-of-run summary. The full outcome (with candidates) is already written
+ * to the JSONL file; the summary only needs the light fields, so dropping
+ * candidates keeps memory flat across large batches.
+ */
+function stripCandidates(o: RecordOutcome): RecordOutcome {
+  if (o.outcome.kind === 'matched' || o.outcome.kind === 'no-match') {
+    return { record: o.record, outcome: { ...o.outcome, candidates: [] } };
+  }
+  return o;
 }
 
 /** Drop seed/test records that pollute the dataset. */

--- a/crux/commands/backfill-sources.ts
+++ b/crux/commands/backfill-sources.ts
@@ -372,7 +372,10 @@ async function processAllRecords(
   }
 
   const unmatched = run.searched - run.matched;
-  const skipped = run.noTerms + run.budgetSkipped;
+  // Count skips from the recorded outcomes rather than summing per-reason
+  // counters: that way test-record skips (which don't have a dedicated
+  // counter) are included, matching every line actually written to the file.
+  const skipped = run.outcomes.filter((o) => o.outcome.kind === 'skipped').length;
   run.outcomeStatus = jsonlOk
     ? closeOutcomeJsonl(parsed.unmatchedOut, {
         records: records.length,

--- a/crux/lib/backfill-sources/__tests__/report.test.ts
+++ b/crux/lib/backfill-sources/__tests__/report.test.ts
@@ -1,5 +1,46 @@
 import { describe, it, expect } from 'vitest';
-import { splitProviders } from '../report.ts';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  splitProviders,
+  openOutcomeJsonl,
+  appendOutcomeJsonl,
+  closeOutcomeJsonl,
+} from '../report.ts';
+import type { CostBreakdown, RecordOutcome } from '../types.ts';
+
+const ZERO_COST: CostBreakdown = {
+  searchCost: 0,
+  factExtractionCost: 0,
+  quoteExtractCost: 0,
+  entailmentCost: 0,
+  rankCost: 0,
+};
+
+function rec(id: string): RecordOutcome['record'] {
+  return {
+    record_id: id,
+    record_table: 'facts',
+    entity_id: 'sid_x',
+    entity_name: 'Acme',
+    description: `desc ${id}`,
+  };
+}
+
+// A candidate carrying a chunky payload — the kind of thing that, accumulated
+// across hundreds of records, OOM'd the old bulk-JSON writer.
+function bigCandidate(url: string) {
+  return {
+    url,
+    decision: 'rejected' as const,
+    rejection_reason: 'no support',
+    content_sha256: null,
+    content_chars: 5000,
+    quote_extraction: null,
+    entailment: null,
+  };
+}
 
 describe('splitProviders', () => {
   it('splits a multi-provider tag into a sorted array', () => {
@@ -21,5 +62,76 @@ describe('splitProviders', () => {
   it('trims and dedupes entries', () => {
     expect(splitProviders(' exa + exa ')).toEqual(['exa']);
     expect(splitProviders('exa++perplexity')).toEqual(['exa', 'perplexity']);
+  });
+});
+
+describe('streaming JSONL outcome file', () => {
+  it('writes meta + one line per record + summary, preserving candidates', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-jsonl-'));
+    const path = join(dir, 'out.jsonl');
+    try {
+      expect(openOutcomeJsonl(path, 'apply')).toBe(true);
+
+      appendOutcomeJsonl(path, {
+        record: rec('1'),
+        outcome: {
+          kind: 'matched',
+          url: 'https://example.com/a',
+          provider: 'exa+perplexity',
+          quotes: ['q1'],
+          cost: ZERO_COST,
+          candidates: [bigCandidate('https://example.com/a')],
+        },
+      });
+      appendOutcomeJsonl(path, {
+        record: rec('2'),
+        outcome: {
+          kind: 'no-match',
+          reason: 'no support',
+          cost: ZERO_COST,
+          candidates: [bigCandidate('https://example.com/b')],
+        },
+      });
+      appendOutcomeJsonl(path, {
+        record: rec('3'),
+        outcome: { kind: 'skipped', reason: 'no search terms' },
+      });
+
+      const status = closeOutcomeJsonl(path, {
+        records: 3, searched: 2, matched: 1, unmatched: 1, skipped: 1,
+      });
+      expect(status).toContain('1 matched');
+      expect(status).toContain('1 no-match');
+
+      const lines = readFileSync(path, 'utf-8').trim().split('\n');
+      const parsed = lines.map((l) => JSON.parse(l));
+
+      // meta header, 3 record lines, summary trailer
+      expect(parsed[0]).toMatchObject({ type: 'meta', mode: 'apply' });
+      expect(parsed[1]).toMatchObject({ outcome: 'matched', record_id: '1', url: 'https://example.com/a' });
+      expect(parsed[1].providers).toEqual(['exa', 'perplexity']);
+      // the heavy candidate payload IS preserved in the file
+      expect(parsed[1].candidates[0].url).toBe('https://example.com/a');
+      expect(parsed[2]).toMatchObject({ outcome: 'no-match', record_id: '2', reason: 'no support' });
+      expect(parsed[3]).toMatchObject({ outcome: 'skipped', record_id: '3' });
+      expect(parsed[4]).toMatchObject({ type: 'summary', totals: { matched: 1, unmatched: 1, skipped: 1 } });
+      expect(lines.length).toBe(5);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns false when the target dir is not writable (run still proceeds)', () => {
+    // Put a regular file where a parent directory is expected: mkdir of a path
+    // *under* a file fails fast with ENOTDIR, exercising the guard. (Don't use
+    // /proc — Node's recursive mkdirSync blocks indefinitely there.)
+    const dir = mkdtempSync(join(tmpdir(), 'bf-jsonl-'));
+    try {
+      const blocker = join(dir, 'not-a-dir');
+      writeFileSync(blocker, 'x');
+      expect(openOutcomeJsonl(join(blocker, 'out.jsonl'), 'dry-run')).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/crux/lib/backfill-sources/report.ts
+++ b/crux/lib/backfill-sources/report.ts
@@ -1,11 +1,17 @@
 /**
  * Build the human-readable run summary and persist the per-record outcome
- * JSON file. The summary lines go to stdout via the command's CommandResult;
- * the JSON gets written to disk so a human can spot-check matched URLs and
+ * file. The summary lines go to stdout via the command's CommandResult; the
+ * outcomes get written to disk so a human can spot-check matched URLs and
  * triage no-match reasons after the fact.
+ *
+ * The outcome file is JSONL (one record per line), written incrementally as
+ * each record finishes — see openOutcomeJsonl/appendOutcomeJsonl. This keeps
+ * memory flat regardless of batch size: we never hold every record's results
+ * (let alone a single giant pretty-printed JSON string of all of them) in
+ * memory at once, which previously OOM'd large backfill runs.
  */
 
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, writeFileSync, appendFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { humanizeClaim } from './humanize-claim.ts';
 import { totalOf } from './cost.ts';
@@ -95,55 +101,57 @@ function formatOutcomeLine({ record, outcome }: RecordOutcome): string {
 // Per-record JSON outcome file
 // ---------------------------------------------------------------------------
 
-export interface OutcomeFileInput {
-  path: string;
-  outcomes: RecordOutcome[];
-  mode: 'apply' | 'dry-run';
-  totalRecords: number;
+export interface OutcomeJsonlTotals {
+  records: number;
   searched: number;
   matched: number;
+  unmatched: number;
+  skipped: number;
 }
 
 /**
- * Write the run's per-record outcomes to a JSON file for post-hoc analysis.
+ * Open (truncate) the JSONL outcome file and write a `meta` header line.
  *
- * Matched items include the chosen URL + the verified quotes so a human can
- * spot-check for false positives without re-running the pipeline. Unmatched
- * + skipped items include the rejection reason for triage.
- *
- * Returns a status line for the summary block. The write is wrapped in a
- * try/catch so a write failure (read-only fs, missing dir perms) doesn't
- * derail the command — we surface the error in the summary instead.
+ * Returns true if the file is writable. If it isn't (read-only fs, missing
+ * perms) the caller simply skips the per-record writes — the run still
+ * completes; the file is for post-hoc triage only, never load-bearing.
  */
-export function writeOutcomesJson(input: OutcomeFileInput): string {
-  if (input.outcomes.length === 0) return '';
-
-  const items = input.outcomes.map(serializeOutcome);
-  const noMatchCount = items.filter(o => o.outcome === 'no-match').length;
-  const skippedCount = items.filter(o => o.outcome === 'skipped').length;
-
+export function openOutcomeJsonl(path: string, mode: 'apply' | 'dry-run'): boolean {
   try {
-    mkdirSync(dirname(input.path), { recursive: true });
+    mkdirSync(dirname(path), { recursive: true });
     writeFileSync(
-      input.path,
-      JSON.stringify(
-        {
-          generated_at: new Date().toISOString(),
-          mode: input.mode,
-          totals: {
-            records: input.totalRecords,
-            searched: input.searched,
-            matched: input.matched,
-            unmatched: noMatchCount,
-            skipped: skippedCount,
-          },
-          items,
-        },
-        null,
-        2,
-      ),
+      path,
+      JSON.stringify({ type: 'meta', generated_at: new Date().toISOString(), mode }) + '\n',
     );
-    return `  Outcomes written: ${input.path} (${items.length} items: ${input.matched} matched, ${noMatchCount} no-match, ${skippedCount} skipped)`;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Append one record's outcome as a single JSONL line.
+ *
+ * Matched items include the chosen URL + verified quotes so a human can
+ * spot-check for false positives; unmatched/skipped items carry the reason.
+ * Best-effort: a mid-run write failure is swallowed so it can't abort the run.
+ */
+export function appendOutcomeJsonl(path: string, outcome: RecordOutcome): void {
+  try {
+    appendFileSync(path, JSON.stringify(serializeOutcome(outcome)) + '\n');
+  } catch {
+    // Triage-only file — never derail the run on a write failure.
+  }
+}
+
+/**
+ * Append the trailing `summary` line with the run totals, and return a status
+ * line for the human-readable summary block.
+ */
+export function closeOutcomeJsonl(path: string, totals: OutcomeJsonlTotals): string {
+  try {
+    appendFileSync(path, JSON.stringify({ type: 'summary', totals }) + '\n');
+    return `  Outcomes written: ${path} (${totals.searched + totals.skipped} items: ${totals.matched} matched, ${totals.unmatched} no-match, ${totals.skipped} skipped)`;
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     return `  Outcomes write FAILED: ${msg}`;


### PR DESCRIPTION
## main → production: backfill report JSONL streaming (OOM fix)

Deploys the worker fix for the large-run OOM in the backfill-sources job.

**Commits**
- `8f41d2c16` stream per-record outcomes to a JSONL file (meta + line-per-record + summary) instead of buffering everything and pretty-printing one giant JSON string — keeps worker memory flat regardless of batch size.
- `13bae34ac` count `skipped` from recorded outcomes so test-record skips are included in the totals (CodeRabbit finding).

**Why deploy:** merging to `production` triggers `worker-docker.yml` (touches `crux/lib/**`), rebuilding and redeploying the worker that runs the job.

**Verification on the PR to main (#4916):** all checks green — 6/6 report tests pass with no hang, build passes, CodeRabbit review completed and thread resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
