### PR TITLE
chore(tablebase): clear 5 inapplicable funding-round enrichment tasks

### DIFF
--- a/.tablebase-completed.txt
+++ b/.tablebase-completed.txt
@@ -253,3 +253,8 @@ TtMfWVwzhlNz
 MkjveX73BlxG
 V8RUVIwNDDzp
 vxn346nLVmfw
+yhb9n-YNX1-8
+s077EO-OgdPX
+Qm1zG2i1r49h
+K9puR5EJxaSY
+tHo6NDpvuIwb


### PR DESCRIPTION
## Summary

Processed 5 tasks from the funding-round enrichment queue. All 5 entities were inapplicable for VC-style funding rounds and are now marked done to clear the queue:

| Entity | Reason skipped |
|--------|---------------|
| EA Global | Conference series run by CEA (nonprofit) — no VC funding rounds |
| Anthropic Long-Term Benefit Trust | Governance trust / oversight body — not a company with funding rounds |
| NIST and AI Safety | US government agency — no VC funding rounds |
| Compute Supply Chain Actors | Conceptual category entity — not a specific company |
| IBBIS | Swiss nonprofit foundation (CHE-182.748.080) — no VC funding rounds |

No new data records were submitted. Only `.tablebase-completed.txt` is updated to prevent these tasks from re-appearing in future enrichment runs.

## Test plan

- [x] Gate passed (69/69 checks, 2 advisory warnings — pre-existing)
- [x] No code changes — only task completion tracking file updated

https://claude.ai/code/session_01EXPQSArmuDeLcyt8ByV99Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXPQSArmuDeLcyt8ByV99Z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal tablebase configuration data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->