### PR TITLE
fix(worker): give backfill-sources a 3h timeout + kill child on timeout

### DIFF
--- a/crux/lib/job-handlers/index.ts
+++ b/crux/lib/job-handlers/index.ts
@@ -106,11 +106,8 @@ const handlers: Record<string, JobHandler> = {
       const { stdout: output } = await execFileAsync('node', args, {
         cwd: ctx.projectRoot,
         encoding: 'utf-8',
-        // 3h — a full sweep (up to 200 records/table through search + LLM
-        // verification) can run long. On timeout execFile sends killSignal to
-        // the child, so the spawned process is actually terminated (the worker
-        // backstop in run.ts is set slightly higher, at 3h5m, so this fires
-        // first and does the cleanup rather than being abandoned).
+        // 3h — a full sweep can run long. killSignal ensures the child is
+        // actually terminated on timeout (worker backstop in run.ts is 3h5m).
         timeout: 3 * 60 * 60 * 1000,
         killSignal: 'SIGKILL',
         maxBuffer: 16 * 1024 * 1024,

--- a/crux/lib/job-handlers/index.ts
+++ b/crux/lib/job-handlers/index.ts
@@ -84,9 +84,9 @@ const handlers: Record<string, JobHandler> = {
   },
 
   'backfill-sources': async (params, ctx) => {
-    const limit = typeof params.limit === 'number' ? String(params.limit) : '100';
+    const limit = typeof params.limit === 'number' ? String(params.limit) : '200';
     const maxCost =
-      typeof params.maxCost === 'number' ? String(params.maxCost) : '5';
+      typeof params.maxCost === 'number' ? String(params.maxCost) : '100';
     const args = [
       '--import',
       'tsx/esm',
@@ -106,7 +106,13 @@ const handlers: Record<string, JobHandler> = {
       const { stdout: output } = await execFileAsync('node', args, {
         cwd: ctx.projectRoot,
         encoding: 'utf-8',
-        timeout: 60 * 60 * 1000, // 1h — full prod sweep is ~30-50 min
+        // 3h — a full sweep (up to 200 records/table through search + LLM
+        // verification) can run long. On timeout execFile sends killSignal to
+        // the child, so the spawned process is actually terminated (the worker
+        // backstop in run.ts is set slightly higher, at 3h5m, so this fires
+        // first and does the cleanup rather than being abandoned).
+        timeout: 3 * 60 * 60 * 1000,
+        killSignal: 'SIGKILL',
         maxBuffer: 16 * 1024 * 1024,
       });
 

--- a/crux/worker/run.ts
+++ b/crux/worker/run.ts
@@ -132,12 +132,8 @@ function startHealthServer(): void {
   healthServer = createServer((req, res) => {
     if (req.url === '/healthz' || req.url === '/health') {
       const now = Date.now();
-      // Check if ANY individual job has been running past its own handler
-      // timeout (plus a grace window) — not just time since last completion.
-      // The threshold is per-job-type so a legitimately long job (e.g.
-      // backfill-sources, ~3h) isn't flagged "stuck" and liveness-restarted
-      // mid-run. The grace keeps the watchdog above the handler timeout so the
-      // handler's own timeout/child-kill fires first on a real hang.
+      // Stuck if any in-flight job has run past its own handler timeout (+grace),
+      // so a legitimately long job like backfill-sources isn't restarted mid-run.
       let isStuck = false;
       for (const [, { start, type }] of jobStartTimes) {
         if (now - start > handlerTimeoutMs(type) + STUCK_GRACE_MS) { isStuck = true; break; }
@@ -243,27 +239,21 @@ function startHeartbeat(): void {
 // Memory watchdog
 // ---------------------------------------------------------------------------
 
-// Most handlers should finish quickly; a 15-min cap catches anything wedged.
 const DEFAULT_HANDLER_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 
-// Per-type overrides for handlers that legitimately run long. backfill-sources
-// sweeps up to 200 records/table through search + LLM verification — a full run
-// is ~30-50 min and can reach a few hours, so it needs a much higher ceiling
-// than the default (it was being killed mid-run at 15 min — every nightly run
-// failed). This is the worker-side backstop; the handler's own child-process
-// timeout fires slightly earlier and is what actually kills the spawned child.
+// Per-type overrides for handlers that legitimately run long. The handler's own
+// child-process timeout fires slightly earlier and kills the child; this is the
+// worker-side backstop.
 const HANDLER_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
-  'backfill-sources': 3 * 60 * 60 * 1000 + 5 * 60 * 1000, // 3h5m backstop (handler kills child at 3h)
+  'backfill-sources': 3 * 60 * 60 * 1000 + 5 * 60 * 1000, // 3h5m (child killed at 3h)
 };
 
 function handlerTimeoutMs(jobType: string): number {
   return HANDLER_TIMEOUT_OVERRIDES_MS[jobType] ?? DEFAULT_HANDLER_TIMEOUT_MS;
 }
 
-// The health watchdog flags a job "stuck" once it runs past its handler timeout
-// plus this grace, so the handler's own timeout/child-kill fires first on a real
-// hang and the watchdog only trips if that cleanup itself wedged. (Historically
-// the watchdog used a flat 20 min = the old 15-min default + 5-min grace.)
+// Grace above the handler timeout before the watchdog flags a job "stuck",
+// so the handler's own timeout fires first on a real hang.
 const STUCK_GRACE_MS = 5 * 60 * 1000; // 5 minutes
 
 const MAX_RSS_MB = parseInt(process.env.WORKER_MAX_RSS_MB ?? '768', 10);

--- a/crux/worker/run.ts
+++ b/crux/worker/run.ts
@@ -239,7 +239,22 @@ function startHeartbeat(): void {
 // Memory watchdog
 // ---------------------------------------------------------------------------
 
-const HANDLER_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
+// Most handlers should finish quickly; a 15-min cap catches anything wedged.
+const DEFAULT_HANDLER_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
+
+// Per-type overrides for handlers that legitimately run long. backfill-sources
+// sweeps up to 200 records/table through search + LLM verification — a full run
+// is ~30-50 min and can reach a few hours, so it needs a much higher ceiling
+// than the default (it was being killed mid-run at 15 min — every nightly run
+// failed). This is the worker-side backstop; the handler's own child-process
+// timeout fires slightly earlier and is what actually kills the spawned child.
+const HANDLER_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
+  'backfill-sources': 3 * 60 * 60 * 1000 + 5 * 60 * 1000, // 3h5m backstop (handler kills child at 3h)
+};
+
+function handlerTimeoutMs(jobType: string): number {
+  return HANDLER_TIMEOUT_OVERRIDES_MS[jobType] ?? DEFAULT_HANDLER_TIMEOUT_MS;
+}
 
 const MAX_RSS_MB = parseInt(process.env.WORKER_MAX_RSS_MB ?? '768', 10);
 
@@ -524,14 +539,15 @@ async function executeJob(job: ClaimedJob, config: WorkerConfig): Promise<void> 
     // Execute the handler with timeout
     const context: JobHandlerContext = { workerId, projectRoot, verbose };
     let handlerTimer: ReturnType<typeof setTimeout> | undefined;
+    const timeoutMs = handlerTimeoutMs(jobType);
 
     try {
       const result = await Promise.race([
         handler(jobParams, context),
         new Promise<never>((_, reject) => {
           handlerTimer = setTimeout(
-            () => reject(new Error(`Handler timed out after ${HANDLER_TIMEOUT_MS / 1000}s`)),
-            HANDLER_TIMEOUT_MS,
+            () => reject(new Error(`Handler timed out after ${timeoutMs / 1000}s`)),
+            timeoutMs,
           );
         }),
       ]);

--- a/crux/worker/run.ts
+++ b/crux/worker/run.ts
@@ -100,7 +100,7 @@ function parseConfig(): WorkerConfig {
 
 let shuttingDown = false;
 const activeJobIds = new Set<number>();
-const jobStartTimes = new Map<number, number>(); // jobId -> start timestamp
+const jobStartTimes = new Map<number, { start: number; type: string }>(); // jobId -> start timestamp + type
 
 for (const sig of ['SIGTERM', 'SIGINT'] as const) {
   process.on(sig, () => {
@@ -131,12 +131,16 @@ function startHealthServer(): void {
 
   healthServer = createServer((req, res) => {
     if (req.url === '/healthz' || req.url === '/health') {
-      const stuckThresholdMs = 20 * 60 * 1000; // 20 minutes
       const now = Date.now();
-      // Check if ANY individual job has been running too long (not just time since last completion)
+      // Check if ANY individual job has been running past its own handler
+      // timeout (plus a grace window) — not just time since last completion.
+      // The threshold is per-job-type so a legitimately long job (e.g.
+      // backfill-sources, ~3h) isn't flagged "stuck" and liveness-restarted
+      // mid-run. The grace keeps the watchdog above the handler timeout so the
+      // handler's own timeout/child-kill fires first on a real hang.
       let isStuck = false;
-      for (const [, startTime] of jobStartTimes) {
-        if (now - startTime > stuckThresholdMs) { isStuck = true; break; }
+      for (const [, { start, type }] of jobStartTimes) {
+        if (now - start > handlerTimeoutMs(type) + STUCK_GRACE_MS) { isStuck = true; break; }
       }
       const status = shuttingDown ? 'shutting_down' : isStuck ? 'stuck' : 'ok';
       const statusCode = (status === 'ok') ? 200 : 503;
@@ -255,6 +259,12 @@ const HANDLER_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
 function handlerTimeoutMs(jobType: string): number {
   return HANDLER_TIMEOUT_OVERRIDES_MS[jobType] ?? DEFAULT_HANDLER_TIMEOUT_MS;
 }
+
+// The health watchdog flags a job "stuck" once it runs past its handler timeout
+// plus this grace, so the handler's own timeout/child-kill fires first on a real
+// hang and the watchdog only trips if that cleanup itself wedged. (Historically
+// the watchdog used a flat 20 min = the old 15-min default + 5-min grace.)
+const STUCK_GRACE_MS = 5 * 60 * 1000; // 5 minutes
 
 const MAX_RSS_MB = parseInt(process.env.WORKER_MAX_RSS_MB ?? '768', 10);
 
@@ -633,7 +643,7 @@ async function runWorker(config: WorkerConfig): Promise<void> {
       // C1: Track job immediately before async dispatch to close SIGTERM race window.
       // If SIGTERM arrives between claim and executeJob, the handler sees the job as in-flight.
       activeJobIds.add(outcome.id);
-      jobStartTimes.set(outcome.id, Date.now());
+      jobStartTimes.set(outcome.id, { start: Date.now(), type: outcome.type });
       dispatched++;
       const slot = executeJob(outcome, config)
         .catch((err: unknown) => {


### PR DESCRIPTION
## Problem

The nightly `backfill-sources` job has **failed every night since May 25** with `Handler timed out after 900s`.

Root cause: the worker wraps every handler in a single 15-min `Promise.race` (`run.ts` `HANDLER_TIMEOUT_MS`), but a full backfill sweep runs ~30–50 min (the handler's own child timeout was already set to 1h with a comment saying so). So the worker killed it mid-run every time. Before May 25 the nightly backlog was small enough to finish in ~2 min; once the new worker image went live and the backlog grew, every run hit the 15-min wall.

Two compounding issues:
1. **Wrong cap** — 15 min is far too short for this job, but right for everything else.
2. **Leak on timeout** — the `Promise.race` only abandons the handler promise; the spawned child kept running (still spending search/LLM cost) for up to 45 more min, then the job retried 3×, each spawning a fresh child.

## Fix

- **`crux/worker/run.ts`** — handler timeout is now per-job-type. Default stays 15 min; `backfill-sources` gets a **3h5m** worker-side backstop.
- **`crux/lib/job-handlers/index.ts`** — the handler's own child-process timeout goes **1h → 3h** with `killSignal: 'SIGKILL'`, so the child is *actually terminated* on timeout. It fires at 3h, just under the 3h5m backstop, so it does the cleanup rather than being abandoned.
- **`crux/lib/job-handlers/index.ts`** — defaults raised to **`limit=200`** (per table) and **`max-cost=$100`** so a realistic nightly backlog fits in one run.

## Verification

- `node crux/build.mjs` — builds clean.
- `vitest run crux/lib/job-handlers/job-handlers.test.ts` — 20/20 pass.
- A 200-record/table sweep at ~5s/record finishes well inside 3h; `$100` gives ample cost headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Enhanced background job timeout management with configurable limits per job type
  - Extended execution time allowance for source backfill operations to prevent premature termination during long-running syncs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/quantified-uncertainty/longterm-wiki/pull/4922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->