### PR TITLE
fix(resources): make /api/resources/rows dynamic to fix Vercel deploy

### DIFF
--- a/apps/web/src/app/api/resources/rows/route.ts
+++ b/apps/web/src/app/api/resources/rows/route.ts
@@ -14,7 +14,12 @@ import type { ResourceRow } from "../../../resources/resources-table";
  * Statically generated at build time so the 17MB+ dataset is served as a
  * separate cacheable fetch rather than embedded in the page HTML.
  */
-export const dynamic = "force-static";
+// Changed from "force-static" to "force-dynamic" (2026-05-31): the static build
+// baked the entire ~19.4MB JSON into an ISR fallback file, which exceeds Vercel's
+// 19.07MB limit and broke production deploys (FALLBACK_BODY_TOO_LARGE). Nothing in
+// the app currently fetches this endpoint, so serving it on-demand is safe. Revert
+// to "force-static" once the payload is shrunk/paginated if static caching is wanted.
+export const dynamic = "force-dynamic";
 
 export function GET(): NextResponse<ResourceRow[]> {
   const resources = getAllResources();


### PR DESCRIPTION
## Problem

Production deploys on Vercel were failing with `FALLBACK_BODY_TOO_LARGE`. The build itself compiled fine — it died at the deploy step.

The route `apps/web/src/app/api/resources/rows/route.ts` is `force-static`, so Next.js bakes the **entire** resources dataset into a single prerendered ISR fallback file. That file has grown to **~19.4 MB**, just over Vercel's **19.07 MB** limit.

## Fix

Switch the route from `force-static` to `force-dynamic` so the response is computed on demand instead of prebaked into an oversized static file.

- Nothing in the app currently fetches this endpoint (confirmed via repo-wide grep + LSP), so serving it dynamically is safe.
- The `/resources` page builds its own rows server-side and is unaffected.
- A comment documents why, with a note to revert to `force-static` once the payload is shrunk/paginated.

## Verification

- Local `pnpm build` passes (exit 0); the route now shows as `ƒ` (dynamic) instead of a static fallback — no oversized warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
