### PR TITLE
fix(lint): ignore dev/ utility scripts in eslint project

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,8 @@ export default tseslint.config(
       '.claude/**',
       'docker/**',
       'public/**',
+      // dev/ holds standalone utility scripts that aren't part of the typed lint project.
+      'dev/**',
       // Drizzle migration metadata is generated.
       'apps/wiki-server/drizzle/meta/**',
       // Test fixtures and snapshot data have intentionally weird shapes.


### PR DESCRIPTION
## Summary
`dev/` holds standalone utility scripts (e.g. `missing-sources-count.ts`, added in the dev-observability backfill) that aren't included in `tsconfig.eslint.json`'s project. ESLint's typed parser therefore errored on them:

```
Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser.
The file was not found in any of the provided project(s): dev/missing-sources-count.ts
```

This adds `dev/**` to the eslint `ignores` list, matching how `.claude/`, `docker/`, and `public/` are already handled.

## Validation
- `npx eslint dev/` now reports the dir is fully ignored (no parse error).
- Replaces the two competing fixes from the closed maintenance sweeps (#4935 ignore-approach / #4936 tsconfig-include) with the idiomatic ignore.

## Context
Surfaced while clearing the open-PR backlog 2026-06-03; the closed sweep PRs each bundled this fix with stale audit-log snapshots.