### PR TITLE
feat: LLM call logging — per-flow cost (1a) + sampled request/response capture (1b)

### DIFF
--- a/apps/wiki-server/drizzle/0225_llm_call_payloads.sql
+++ b/apps/wiki-server/drizzle/0225_llm_call_payloads.sql
@@ -19,7 +19,6 @@ CREATE TABLE IF NOT EXISTS "llm_call_payloads" (
 	"response" text NOT NULL,
 	"tokens_input" integer,
 	"tokens_output" integer,
-	"truncated" boolean DEFAULT false NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint

--- a/apps/wiki-server/drizzle/0225_llm_call_payloads.sql
+++ b/apps/wiki-server/drizzle/0225_llm_call_payloads.sql
@@ -1,0 +1,29 @@
+-- Model-swap eval step 1b: capture LLM request/response bodies.
+--
+-- One row per sampled API call — the prompt we sent and the completion we got
+-- back, plus model + token usage — so we can later replay the same prompts
+-- through candidate models and compare quality against the Anthropic baseline.
+--
+-- Capture is OFF by default and sampled (LLM_PAYLOAD_CAPTURE_RATE in the crux
+-- logger); this table only fills when we deliberately turn it on. run_id is a
+-- soft reference to pipeline_runs (no FK) so a payload is never lost or blocked
+-- on referential integrity. CREATE TABLE completes in ms — normal Drizzle path.
+CREATE TABLE IF NOT EXISTS "llm_call_payloads" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"run_id" text,
+	"flow" text,
+	"label" text,
+	"model" text NOT NULL,
+	"via_openrouter" boolean DEFAULT false NOT NULL,
+	"request" jsonb NOT NULL,
+	"response" text NOT NULL,
+	"tokens_input" integer,
+	"tokens_output" integer,
+	"truncated" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_llm_call_payloads_flow" ON "llm_call_payloads" USING btree ("flow");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_llm_call_payloads_model" ON "llm_call_payloads" USING btree ("model");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_llm_call_payloads_run_id" ON "llm_call_payloads" USING btree ("run_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_llm_call_payloads_created_at" ON "llm_call_payloads" USING btree ("created_at");

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1569,6 +1569,13 @@
       "when": 1788000200000,
       "tag": "0224_qua_1071_sourcing_attempts",
       "breakpoints": true
+    },
+    {
+      "idx": 225,
+      "version": "7",
+      "when": 1788000300000,
+      "tag": "0225_llm_call_payloads",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/api-types-llm-payload-schema.test.ts
+++ b/apps/wiki-server/src/__tests__/api-types-llm-payload-schema.test.ts
@@ -6,11 +6,7 @@
  * are rejected (server-side backstop to the logger's own truncation).
  */
 import { describe, it, expect } from "vitest";
-import {
-  RecordLlmPayloadSchema,
-  MAX_LLM_PAYLOAD_REQUEST_BYTES,
-  MAX_LLM_PAYLOAD_RESPONSE_CHARS,
-} from "../api-types.js";
+import { RecordLlmPayloadSchema } from "../api-types.js";
 
 describe("RecordLlmPayloadSchema", () => {
   const baseValid = {
@@ -41,18 +37,13 @@ describe("RecordLlmPayloadSchema", () => {
     expect(RecordLlmPayloadSchema.safeParse(noModel).success).toBe(false);
   });
 
-  it("rejects a request that serializes over the byte cap", () => {
-    const big = { blob: "x".repeat(MAX_LLM_PAYLOAD_REQUEST_BYTES + 100) };
-    const r = RecordLlmPayloadSchema.safeParse({ ...baseValid, request: big });
-    expect(r.success).toBe(false);
-  });
-
-  it("rejects a response over the char cap", () => {
+  it("accepts a large request/response (no size cap — stored whole)", () => {
     const r = RecordLlmPayloadSchema.safeParse({
       ...baseValid,
-      response: "x".repeat(MAX_LLM_PAYLOAD_RESPONSE_CHARS + 1),
+      request: { blob: "x".repeat(500_000) },
+      response: "x".repeat(500_000),
     });
-    expect(r.success).toBe(false);
+    expect(r.success).toBe(true);
   });
 
   it("rejects a malformed runId", () => {

--- a/apps/wiki-server/src/__tests__/api-types-llm-payload-schema.test.ts
+++ b/apps/wiki-server/src/__tests__/api-types-llm-payload-schema.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Schema validation for RecordLlmPayloadSchema (model-swap eval, step 1b).
+ *
+ * The POST /api/llm-payloads endpoint persists captured LLM request/response
+ * bodies. Validate at the boundary: model is required, oversize request/response
+ * are rejected (server-side backstop to the logger's own truncation).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  RecordLlmPayloadSchema,
+  MAX_LLM_PAYLOAD_REQUEST_BYTES,
+  MAX_LLM_PAYLOAD_RESPONSE_CHARS,
+} from "../api-types.js";
+
+describe("RecordLlmPayloadSchema", () => {
+  const baseValid = {
+    model: "claude-haiku-4-5-20251001",
+    request: { system: "sys", messages: [{ role: "user", content: "hi" }] },
+    response: "hello",
+  };
+
+  it("accepts a minimal valid payload", () => {
+    expect(RecordLlmPayloadSchema.safeParse(baseValid).success).toBe(true);
+  });
+
+  it("accepts optional flow/runId/label/tokens", () => {
+    const r = RecordLlmPayloadSchema.safeParse({
+      ...baseValid,
+      runId: "11111111-1111-4111-8111-111111111111",
+      flow: "research-agent",
+      label: "verify",
+      viaOpenrouter: true,
+      tokensInput: 10,
+      tokensOutput: 5,
+      truncated: false,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a missing model", () => {
+    const { model: _omit, ...noModel } = baseValid;
+    expect(RecordLlmPayloadSchema.safeParse(noModel).success).toBe(false);
+  });
+
+  it("rejects a request that serializes over the byte cap", () => {
+    const big = { blob: "x".repeat(MAX_LLM_PAYLOAD_REQUEST_BYTES + 100) };
+    const r = RecordLlmPayloadSchema.safeParse({ ...baseValid, request: big });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a response over the char cap", () => {
+    const r = RecordLlmPayloadSchema.safeParse({
+      ...baseValid,
+      response: "x".repeat(MAX_LLM_PAYLOAD_RESPONSE_CHARS + 1),
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a malformed runId", () => {
+    const r = RecordLlmPayloadSchema.safeParse({ ...baseValid, runId: "not a uuid!" });
+    expect(r.success).toBe(false);
+  });
+});

--- a/apps/wiki-server/src/__tests__/api-types-llm-payload-schema.test.ts
+++ b/apps/wiki-server/src/__tests__/api-types-llm-payload-schema.test.ts
@@ -32,7 +32,6 @@ describe("RecordLlmPayloadSchema", () => {
       viaOpenrouter: true,
       tokensInput: 10,
       tokensOutput: 5,
-      truncated: false,
     });
     expect(r.success).toBe(true);
   });

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1760,7 +1760,6 @@ export const RecordLlmPayloadSchema = z.object({
   response: z.string().max(MAX_LLM_PAYLOAD_RESPONSE_CHARS),
   tokensInput: TokenCountSchema,
   tokensOutput: TokenCountSchema,
-  truncated: z.boolean().optional(),
 });
 export type RecordLlmPayload = z.infer<typeof RecordLlmPayloadSchema>;
 

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1737,13 +1737,10 @@ export const EndPipelineRunSchema = z.object({
 });
 export type EndPipelineRun = z.infer<typeof EndPipelineRunSchema>;
 
-// Model-swap eval step 1b: captured LLM request/response bodies. The crux
-// logger truncates request + response to a size cap before sending (and sets
-// `truncated`); these server-side bounds are a backstop so a misbehaving caller
-// can't post unbounded rows into the table.
-export const MAX_LLM_PAYLOAD_REQUEST_BYTES = 262_144; // 256 KiB
-export const MAX_LLM_PAYLOAD_RESPONSE_CHARS = 262_144; // 256 Ki chars
-
+// Model-swap eval step 1b: captured LLM request/response bodies. Stored whole
+// — no size cap. Postgres text/jsonb handle multi-MB values fine, and a clipped
+// prompt is useless for replay. Capture is sampled + off by default, so volume
+// is bounded by the sample rate rather than a per-row size limit.
 export const RecordLlmPayloadSchema = z.object({
   // Soft reference to the pipeline_runs row (no FK). Null when the call ran
   // outside any withPipelineRun lifecycle.
@@ -1752,12 +1749,8 @@ export const RecordLlmPayloadSchema = z.object({
   label: z.string().max(200).nullable().optional(),
   model: z.string().min(1).max(200),
   viaOpenrouter: z.boolean().optional(),
-  request: z
-    .record(z.unknown())
-    .refine((v) => jsonByteSize(v) <= MAX_LLM_PAYLOAD_REQUEST_BYTES, {
-      message: `request must serialize to <= ${MAX_LLM_PAYLOAD_REQUEST_BYTES} bytes`,
-    }),
-  response: z.string().max(MAX_LLM_PAYLOAD_RESPONSE_CHARS),
+  request: z.record(z.unknown()),
+  response: z.string(),
   tokensInput: TokenCountSchema,
   tokensOutput: TokenCountSchema,
 });

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1737,6 +1737,33 @@ export const EndPipelineRunSchema = z.object({
 });
 export type EndPipelineRun = z.infer<typeof EndPipelineRunSchema>;
 
+// Model-swap eval step 1b: captured LLM request/response bodies. The crux
+// logger truncates request + response to a size cap before sending (and sets
+// `truncated`); these server-side bounds are a backstop so a misbehaving caller
+// can't post unbounded rows into the table.
+export const MAX_LLM_PAYLOAD_REQUEST_BYTES = 262_144; // 256 KiB
+export const MAX_LLM_PAYLOAD_RESPONSE_CHARS = 262_144; // 256 Ki chars
+
+export const RecordLlmPayloadSchema = z.object({
+  // Soft reference to the pipeline_runs row (no FK). Null when the call ran
+  // outside any withPipelineRun lifecycle.
+  runId: z.string().min(1).max(128).regex(PIPELINE_RUN_ID_RE).nullable().optional(),
+  flow: z.string().max(200).nullable().optional(),
+  label: z.string().max(200).nullable().optional(),
+  model: z.string().min(1).max(200),
+  viaOpenrouter: z.boolean().optional(),
+  request: z
+    .record(z.unknown())
+    .refine((v) => jsonByteSize(v) <= MAX_LLM_PAYLOAD_REQUEST_BYTES, {
+      message: `request must serialize to <= ${MAX_LLM_PAYLOAD_REQUEST_BYTES} bytes`,
+    }),
+  response: z.string().max(MAX_LLM_PAYLOAD_RESPONSE_CHARS),
+  tokensInput: TokenCountSchema,
+  tokensOutput: TokenCountSchema,
+  truncated: z.boolean().optional(),
+});
+export type RecordLlmPayload = z.infer<typeof RecordLlmPayloadSchema>;
+
 // ---------------------------------------------------------------------------
 // Monitoring / Incident Tracking
 // ---------------------------------------------------------------------------

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -59,6 +59,7 @@ import { autoUpdateRunsRoute } from "./routes/operational/auto-update-runs.js";
 import { autoUpdateNewsRoute } from "./routes/operational/auto-update-news.js";
 import { groundskeeperRunsRoute } from "./routes/operational/groundskeeper-runs.js";
 import { pipelineRunsRoute } from "./routes/operational/pipeline-runs.js";
+import { llmPayloadsRoute } from "./routes/operational/llm-payloads.js";
 import { githubIssuesRoute } from "./routes/operational/github-issues.js";
 import { githubPullsRoute } from "./routes/operational/github-pulls.js";
 import { monitoringRoute } from "./routes/operational/monitoring.js";
@@ -249,6 +250,7 @@ export function createApp() {
   app.route("/api/github/pulls", githubPullsRoute);
   app.route("/api/groundskeeper-runs", groundskeeperRunsRoute);
   app.route("/api/pipeline-runs", pipelineRunsRoute);
+  app.route("/api/llm-payloads", llmPayloadsRoute);
   app.route("/api/monitoring", monitoringRoute);
   app.route("/api/build-metrics", buildMetricsRoute);
   app.route("/api/qa-checks", qaChecksRoute);

--- a/apps/wiki-server/src/routes/operational/llm-payloads.ts
+++ b/apps/wiki-server/src/routes/operational/llm-payloads.ts
@@ -1,0 +1,97 @@
+/**
+ * LLM Call Payloads API (model-swap eval, step 1b).
+ *
+ * Captures sampled LLM request/response bodies so we can later replay the same
+ * prompts through candidate models and compare quality against the Anthropic
+ * baseline.
+ *
+ *   - POST /   — record one captured call
+ *   - GET  /   — list captured calls (filter by flow / model) for replay
+ *
+ * Hand-rolled (not factory-mounted): the surface is small and write-only from
+ * the pipeline side, so it doesn't fit the `/sync` batch-upsert contract.
+ */
+
+import { Hono } from "hono";
+import { eq, desc, and } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { z } from "zod";
+import { getDrizzleDb } from "../../db.js";
+import { llmCallPayloads } from "../../schema.js";
+import {
+  parseJsonBody,
+  validationError,
+  invalidJsonError,
+  firstOrThrow,
+  clampedLimit,
+  zv,
+} from "../shared/utils.js";
+import { RecordLlmPayloadSchema } from "../../api-types.js";
+
+const ListPayloadsQuery = z.object({
+  flow: z.string().min(1).max(200).optional(),
+  model: z.string().min(1).max(200).optional(),
+  limit: clampedLimit(500, 100),
+});
+
+const llmPayloadsApp = new Hono()
+  // ---- POST / (record a captured call) ----
+  .post("/", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = RecordLlmPayloadSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const d = parsed.data;
+    const db = getDrizzleDb();
+
+    const inserted = await db.transaction(async (tx) => {
+      // High-volume capture rows — skip the universal audit trigger so we
+      // don't write one audit_log row per sampled LLM call (same rationale as
+      // pipeline-run heartbeats).
+      await tx.execute(sql`SET LOCAL app.audit_skip = 'true'`);
+      return tx
+        .insert(llmCallPayloads)
+        .values({
+          runId: d.runId ?? null,
+          flow: d.flow ?? null,
+          label: d.label ?? null,
+          model: d.model,
+          viaOpenrouter: d.viaOpenrouter ?? false,
+          request: d.request,
+          response: d.response,
+          tokensInput: d.tokensInput ?? null,
+          tokensOutput: d.tokensOutput ?? null,
+          truncated: d.truncated ?? false,
+        })
+        .returning({ id: llmCallPayloads.id });
+    });
+
+    return c.json(firstOrThrow(inserted, "llm payload insert"), 201);
+  })
+
+  // ---- GET / (list captured calls for replay) ----
+  .get("/", zv("query", ListPayloadsQuery), async (c) => {
+    const { flow, model, limit } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    const conditions = [
+      flow ? eq(llmCallPayloads.flow, flow) : undefined,
+      model ? eq(llmCallPayloads.model, model) : undefined,
+    ].filter((x): x is NonNullable<typeof x> => x !== undefined);
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const rows = await db
+      .select()
+      .from(llmCallPayloads)
+      .where(where)
+      .orderBy(desc(llmCallPayloads.createdAt))
+      .limit(limit);
+
+    return c.json({ payloads: rows, count: rows.length });
+  });
+
+export const llmPayloadsRoute = llmPayloadsApp;
+export type LlmPayloadsRoute = typeof llmPayloadsApp;

--- a/apps/wiki-server/src/routes/operational/llm-payloads.ts
+++ b/apps/wiki-server/src/routes/operational/llm-payloads.ts
@@ -63,7 +63,6 @@ const llmPayloadsApp = new Hono()
           response: d.response,
           tokensInput: d.tokensInput ?? null,
           tokensOutput: d.tokensOutput ?? null,
-          truncated: d.truncated ?? false,
         })
         .returning({ id: llmCallPayloads.id });
     });

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1516,15 +1516,14 @@ export const llmCallPayloads = pgTable(
     model: text("model").notNull(),
     // Whether this call went through OpenRouter instead of the Anthropic SDK.
     viaOpenrouter: boolean("via_openrouter").notNull().default(false),
-    // The request we sent: system + messages (and key params). Truncated to a
-    // size cap by the logger before it ever reaches here.
+    // The request we sent: system + messages (and key params). Stored whole —
+    // the logger skips (does not clip) calls over its size cap so every row is
+    // a complete, replayable prompt.
     request: jsonb("request").$type<Record<string, unknown>>().notNull(),
-    // The model's response text (truncated to the same size cap).
+    // The model's response text, stored whole (same whole-or-nothing rule).
     response: text("response").notNull(),
     tokensInput: integer("tokens_input"),
     tokensOutput: integer("tokens_output"),
-    // True when the logger truncated request and/or response to the size cap.
-    truncated: boolean("truncated").notNull().default(false),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1491,6 +1491,52 @@ export const pipelineRuns = pgTable(
   ]
 );
 
+// Captured LLM request/response bodies for the model-swap evaluation
+// (step 1b). One row per sampled API call: the prompt we sent and the
+// completion we got back, plus model + token usage, so we can later replay
+// the same prompts through candidate models and compare quality.
+//
+// Capture is OFF by default and sampled (see LLM_PAYLOAD_CAPTURE_RATE in the
+// crux logger) — this table only fills when we deliberately turn it on to
+// gather a corpus. `run_id` ties a payload back to its pipeline_runs row, but
+// there's no hard FK: a payload must never be lost just because the run row
+// is gone, and capture must never block on referential integrity.
+export const llmCallPayloads = pgTable(
+  "llm_call_payloads",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    // Pipeline run this call belongs to (soft reference, no FK). Null when the
+    // call happened outside any withPipelineRun lifecycle.
+    runId: text("run_id"),
+    // Flow / pipeline name the call was attributed to (ambient context).
+    flow: text("flow"),
+    // Per-call grouping label (e.g. "verify", "rewrite_section").
+    label: text("label"),
+    // Canonical model id the request used (e.g. "claude-haiku-4-5-20251001").
+    model: text("model").notNull(),
+    // Whether this call went through OpenRouter instead of the Anthropic SDK.
+    viaOpenrouter: boolean("via_openrouter").notNull().default(false),
+    // The request we sent: system + messages (and key params). Truncated to a
+    // size cap by the logger before it ever reaches here.
+    request: jsonb("request").$type<Record<string, unknown>>().notNull(),
+    // The model's response text (truncated to the same size cap).
+    response: text("response").notNull(),
+    tokensInput: integer("tokens_input"),
+    tokensOutput: integer("tokens_output"),
+    // True when the logger truncated request and/or response to the size cap.
+    truncated: boolean("truncated").notNull().default(false),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_llm_call_payloads_flow").on(table.flow),
+    index("idx_llm_call_payloads_model").on(table.model),
+    index("idx_llm_call_payloads_run_id").on(table.runId),
+    index("idx_llm_call_payloads_created_at").on(table.createdAt),
+  ]
+);
+
 // QUA-1071 — sourcing attempt ledger.
 //
 // The backfill-sources job re-queries the missing-sources endpoint every

--- a/crux/authoring/creator/grading.ts
+++ b/crux/authoring/creator/grading.ts
@@ -11,6 +11,7 @@ import { appendEditLog } from '../../lib/session/edit-log.ts';
 import { reorderFrontmatterObject } from '../../lib/frontmatter-order.ts';
 import { ensureMdxSafeYaml } from '../../lib/yaml-mdx-safe.ts';
 import { extractText } from '../../lib/llm.ts';
+import { recordDirectCall } from '../../lib/llm-usage/capture-payload.ts';
 import { READER_IMPORTANCE_GUIDELINES, TACTICAL_VALUE_GUIDELINES } from '../../lib/grading-shared.ts';
 import type { TopicPhaseContext } from './types.ts';
 
@@ -156,6 +157,14 @@ Respond with JSON:
     });
 
     const text = extractText(response);
+    // Direct SDK call — record cost + capture so grading is logged too.
+    recordDirectCall({
+      model: MODELS.sonnet,
+      request: { system: GRADING_SYSTEM_PROMPT, max_tokens: 800, messages: [{ role: 'user', content: userPrompt }] },
+      responseText: text,
+      usage: response.usage,
+      label: 'grading',
+    });
     if (!text) {
       return { success: false, error: 'Expected text response from API' };
     }

--- a/crux/authoring/reassign-update-frequency.ts
+++ b/crux/authoring/reassign-update-frequency.ts
@@ -28,6 +28,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 import { CONTENT_DIR_ABS as CONTENT_DIR } from '../lib/content-types.ts';
 import { findMdxFiles } from '../lib/file-utils.ts';
 import { createLlmClient, extractText, MODELS } from '../lib/llm.ts';
+import { recordDirectCall } from '../lib/llm-usage/capture-payload.ts';
 import { parseFrontmatter } from '../lib/mdx-utils.ts';
 import { stripFrontmatter } from '../lib/patterns.ts';
 import { parseJsonFromLlm } from '../lib/json-parsing.ts';
@@ -325,6 +326,14 @@ Return ONLY: {"frequency": N, "reason": "5 words max"}`;
     });
 
     const text = extractText(response).trim();
+    // Direct SDK call — record cost + capture so this flow is logged too.
+    recordDirectCall({
+      model: MODELS.haiku,
+      request: { max_tokens: 60, messages: [{ role: 'user', content: prompt }] },
+      responseText: text,
+      usage: response.usage,
+      label: 'reassign-update-frequency',
+    });
     if (!text) throw new Error('No text block in response');
     const parsed = parseJsonFromLlm<{ frequency: number; reason: string }>(
       text,

--- a/crux/generate/generate-summaries.ts
+++ b/crux/generate/generate-summaries.ts
@@ -31,6 +31,7 @@ import { upsertSummary } from '../lib/wiki-server/summaries.ts';
 import { getColors } from '../lib/output.ts';
 import { createClient, resolveModel, sleep } from '../lib/anthropic.ts';
 import { extractText } from '../lib/llm.ts';
+import { recordDirectCall } from '../lib/llm-usage/capture-payload.ts';
 import { findPageFile, findMdxFiles } from '../lib/file-utils.ts';
 import { parseFrontmatter, getContentBody } from '../lib/mdx-utils.ts';
 import { CONTENT_DIR_ABS as CONTENT_DIR } from '../lib/content-types.ts';
@@ -217,6 +218,14 @@ async function generateSummary(prompt: string): Promise<SummaryResult> {
   });
 
   const text = extractText(response);
+  // Direct SDK call — record cost + capture so summary generation is logged.
+  recordDirectCall({
+    model: MODEL_ID,
+    request: { max_tokens: 1500, messages: [{ role: 'user', content: prompt }] },
+    responseText: text,
+    usage: response.usage,
+    label: 'generate-summaries',
+  });
   if (!text) {
     throw new Error('Expected text content block from API response');
   }

--- a/crux/lib/anthropic.ts
+++ b/crux/lib/anthropic.ts
@@ -18,6 +18,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { config } from 'dotenv';
 import { getApiKey } from './api-keys.ts';
+import { recordDirectCall } from './llm-usage/capture-payload.ts';
 
 // Load environment variables from multiple possible locations
 config({ path: '.env' });
@@ -143,6 +144,16 @@ export async function callClaude(client: Anthropic, {
         return '';
       })
       .join('\n');
+
+    // Direct SDK call (bypasses streamingCreate) — record cost + capture
+    // request/response so this flow is logged like the streaming ones.
+    recordDirectCall({
+      model: modelId,
+      request: { system: systemPrompt, messages: [{ role: 'user', content: userPrompt }], max_tokens: maxTokens, temperature },
+      responseText: text,
+      usage: response.usage,
+      label: 'callClaude',
+    });
 
     return {
       text,

--- a/crux/lib/llm-usage/ambient-tracker.test.ts
+++ b/crux/lib/llm-usage/ambient-tracker.test.ts
@@ -6,6 +6,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { CostTracker } from '../cost-tracker.ts';
 import {
   runWithAmbientTracker,
+  runWithAmbientContext,
+  getAmbientContext,
   getAmbientTracker,
   recordAmbient,
   recordAmbientExternalCost,
@@ -20,6 +22,17 @@ describe('ambient-tracker', () => {
     });
     // Restored after the context exits.
     expect(getAmbientTracker()).toBeUndefined();
+  });
+
+  it('runWithAmbientContext exposes flow + runId', () => {
+    const tracker = new CostTracker();
+    runWithAmbientContext({ tracker, flow: 'source-discover', runId: 'r-9' }, () => {
+      const ctx = getAmbientContext();
+      expect(ctx?.flow).toBe('source-discover');
+      expect(ctx?.runId).toBe('r-9');
+      expect(getAmbientTracker()).toBe(tracker);
+    });
+    expect(getAmbientContext()).toBeUndefined();
   });
 
   it('recordAmbient records into the ambient tracker', () => {

--- a/crux/lib/llm-usage/ambient-tracker.test.ts
+++ b/crux/lib/llm-usage/ambient-tracker.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the ambient cost tracker.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { CostTracker } from '../cost-tracker.ts';
+import {
+  runWithAmbientTracker,
+  getAmbientTracker,
+  recordAmbient,
+  recordAmbientExternalCost,
+} from './ambient-tracker.ts';
+
+describe('ambient-tracker', () => {
+  it('exposes the tracker set for the async context', async () => {
+    const tracker = new CostTracker();
+    expect(getAmbientTracker()).toBeUndefined();
+    await runWithAmbientTracker(tracker, async () => {
+      expect(getAmbientTracker()).toBe(tracker);
+    });
+    // Restored after the context exits.
+    expect(getAmbientTracker()).toBeUndefined();
+  });
+
+  it('recordAmbient records into the ambient tracker', () => {
+    const tracker = new CostTracker();
+    runWithAmbientTracker(tracker, () => {
+      recordAmbient(
+        'claude-haiku-4-5-20251001',
+        { input_tokens: 1000, output_tokens: 500 },
+        'verify',
+      );
+    });
+    expect(tracker.entries).toHaveLength(1);
+    expect(tracker.entries[0].label).toBe('verify');
+    expect(tracker.totalCost).toBeGreaterThan(0);
+  });
+
+  it('recordAmbientExternalCost records a direct cost', () => {
+    const tracker = new CostTracker();
+    runWithAmbientTracker(tracker, () => {
+      recordAmbientExternalCost('deepseek/deepseek-v4-flash', 0.0123, 'entail');
+    });
+    expect(tracker.entries).toHaveLength(1);
+    expect(tracker.totalCost).toBeCloseTo(0.0123);
+  });
+
+  it('is a no-op outside any context', () => {
+    // Must not throw when there's no ambient tracker.
+    expect(() =>
+      recordAmbient('claude-haiku-4-5-20251001', { input_tokens: 1, output_tokens: 1 }),
+    ).not.toThrow();
+  });
+
+  it('swallows recording failures so instrumentation never breaks the call', () => {
+    const tracker = new CostTracker();
+    // Force record() to throw — recordAmbient must catch and log, not rethrow.
+    vi.spyOn(tracker, 'record').mockImplementation(() => {
+      throw new Error('boom');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    runWithAmbientTracker(tracker, () => {
+      expect(() =>
+        recordAmbient('claude-haiku-4-5-20251001', { input_tokens: 1, output_tokens: 1 }),
+      ).not.toThrow();
+    });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/crux/lib/llm-usage/ambient-tracker.ts
+++ b/crux/lib/llm-usage/ambient-tracker.ts
@@ -20,16 +20,42 @@
 import { AsyncLocalStorage } from 'async_hooks';
 import type { CostTracker } from '../cost-tracker.ts';
 
-const storage = new AsyncLocalStorage<CostTracker>();
+/**
+ * The ambient context threaded through a pipeline body: the cost tracker plus
+ * the flow name and run id, so both cost recording (1a) and payload capture
+ * (1b) can attribute a call without the call site passing anything.
+ */
+export interface AmbientContext {
+  tracker: CostTracker;
+  /** Pipeline/flow name (pipeline_runs.pipeline_name). */
+  flow?: string;
+  /** The pipeline run id, for joining captured payloads back to the run. */
+  runId?: string;
+}
 
-/** Run `fn` with `tracker` set as the ambient tracker for the async context. */
+const storage = new AsyncLocalStorage<AmbientContext>();
+
+/** Run `fn` with `ctx` set as the ambient context for the async context. */
+export function runWithAmbientContext<T>(ctx: AmbientContext, fn: () => T): T {
+  return storage.run(ctx, fn);
+}
+
+/**
+ * Run `fn` with just a tracker set (no flow/runId). Kept for callers/tests that
+ * only care about cost recording.
+ */
 export function runWithAmbientTracker<T>(tracker: CostTracker, fn: () => T): T {
-  return storage.run(tracker, fn);
+  return storage.run({ tracker }, fn);
+}
+
+/** The full ambient context for the current async context, or undefined. */
+export function getAmbientContext(): AmbientContext | undefined {
+  return storage.getStore();
 }
 
 /** The ambient tracker for the current async context, or undefined. */
 export function getAmbientTracker(): CostTracker | undefined {
-  return storage.getStore();
+  return storage.getStore()?.tracker;
 }
 
 /**
@@ -51,7 +77,7 @@ export function recordAmbient(
   label?: string,
 ): void {
   try {
-    const tracker = storage.getStore();
+    const tracker = storage.getStore()?.tracker;
     if (!tracker) return;
     tracker.record(model, usage, label);
   } catch (err) {
@@ -68,7 +94,7 @@ export function recordAmbient(
  */
 export function recordAmbientExternalCost(model: string, cost: number, label: string): void {
   try {
-    const tracker = storage.getStore();
+    const tracker = storage.getStore()?.tracker;
     if (!tracker) return;
     tracker.recordExternalCost(model, cost, label);
   } catch (err) {

--- a/crux/lib/llm-usage/ambient-tracker.ts
+++ b/crux/lib/llm-usage/ambient-tracker.ts
@@ -1,0 +1,79 @@
+/**
+ * Ambient cost tracker (QUA — model-swap eval, step 1).
+ *
+ * Threads a per-run CostTracker through the call stack via AsyncLocalStorage
+ * so that LLM helpers (streamingCreate, the OpenRouter path, and direct
+ * `client.messages.create` calls) can record every API call's real spend
+ * WITHOUT each call site passing a tracker explicitly.
+ *
+ * `withPipelineRun` sets the ambient tracker for the duration of a pipeline
+ * body; its existing `/end` path then persists the totals into the
+ * `pipeline_runs` cost columns. The result: every pipeline-wrapped flow gets
+ * its real per-flow spend recorded automatically, which is what the
+ * model-swap ranking step needs.
+ *
+ * FAIL-SAFE CONTRACT: instrumentation must NEVER break a real LLM call.
+ * `recordAmbient` swallows and logs its own errors; callers wrap it in the
+ * same spirit. A logging failure logs and lets the call proceed.
+ */
+
+import { AsyncLocalStorage } from 'async_hooks';
+import type { CostTracker } from '../cost-tracker.ts';
+
+const storage = new AsyncLocalStorage<CostTracker>();
+
+/** Run `fn` with `tracker` set as the ambient tracker for the async context. */
+export function runWithAmbientTracker<T>(tracker: CostTracker, fn: () => T): T {
+  return storage.run(tracker, fn);
+}
+
+/** The ambient tracker for the current async context, or undefined. */
+export function getAmbientTracker(): CostTracker | undefined {
+  return storage.getStore();
+}
+
+/**
+ * Record a completed LLM call into the ambient tracker, if one is set.
+ *
+ * Best-effort: any failure (pricing lookup, unexpected usage shape) is logged
+ * and swallowed so instrumentation can never break the underlying call.
+ * No-op when there's no ambient tracker (e.g. a one-off CLI call outside any
+ * pipeline) — such calls simply aren't attributed.
+ */
+export function recordAmbient(
+  model: string,
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number | null;
+    cache_read_input_tokens?: number | null;
+  },
+  label?: string,
+): void {
+  try {
+    const tracker = storage.getStore();
+    if (!tracker) return;
+    tracker.record(model, usage, label);
+  } catch (err) {
+    console.warn(
+      `[llm-usage] recordAmbient failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Record an externally-priced call (e.g. OpenRouter reports cost directly)
+ * into the ambient tracker, if one is set. Best-effort, same contract as
+ * {@link recordAmbient}.
+ */
+export function recordAmbientExternalCost(model: string, cost: number, label: string): void {
+  try {
+    const tracker = storage.getStore();
+    if (!tracker) return;
+    tracker.recordExternalCost(model, cost, label);
+  } catch (err) {
+    console.warn(
+      `[llm-usage] recordAmbientExternalCost failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/crux/lib/llm-usage/capture-payload.test.ts
+++ b/crux/lib/llm-usage/capture-payload.test.ts
@@ -71,10 +71,12 @@ describe('capturePayload', () => {
     expect(mockRecord).toHaveBeenCalledTimes(1);
   });
 
-  it('skips (does not clip) oversize calls so the corpus stays replayable', () => {
+  it('captures large payloads whole (no size cap)', () => {
     process.env.LLM_PAYLOAD_CAPTURE_RATE = '1';
-    capturePayload({ ...baseInput, response: 'x'.repeat(300_000) });
-    expect(mockRecord).not.toHaveBeenCalled();
+    const big = 'x'.repeat(300_000);
+    capturePayload({ ...baseInput, response: big });
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+    expect(mockRecord.mock.calls[0][0].response).toBe(big);
   });
 
   it('never throws when the POST rejects', () => {

--- a/crux/lib/llm-usage/capture-payload.test.ts
+++ b/crux/lib/llm-usage/capture-payload.test.ts
@@ -57,7 +57,6 @@ describe('capturePayload', () => {
       response: 'hello',
       tokensInput: 10,
       tokensOutput: 5,
-      truncated: false,
     });
   });
 
@@ -72,13 +71,10 @@ describe('capturePayload', () => {
     expect(mockRecord).toHaveBeenCalledTimes(1);
   });
 
-  it('truncates oversize responses and flags truncated', () => {
+  it('skips (does not clip) oversize calls so the corpus stays replayable', () => {
     process.env.LLM_PAYLOAD_CAPTURE_RATE = '1';
     capturePayload({ ...baseInput, response: 'x'.repeat(300_000) });
-    expect(mockRecord).toHaveBeenCalledTimes(1);
-    const arg = mockRecord.mock.calls[0][0];
-    expect(arg.truncated).toBe(true);
-    expect(arg.response.length).toBeLessThanOrEqual(200_000);
+    expect(mockRecord).not.toHaveBeenCalled();
   });
 
   it('never throws when the POST rejects', () => {

--- a/crux/lib/llm-usage/capture-payload.test.ts
+++ b/crux/lib/llm-usage/capture-payload.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for LLM payload capture (step 1b).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockRecord = vi.fn();
+vi.mock('../wiki-server/llm-payloads.ts', () => ({
+  recordLlmPayload: (...args: unknown[]) => mockRecord(...args),
+}));
+
+import { capturePayload } from './capture-payload.ts';
+import { runWithAmbientContext } from './ambient-tracker.ts';
+import { CostTracker } from '../cost-tracker.ts';
+
+const baseInput = {
+  model: 'claude-haiku-4-5-20251001',
+  request: { system: 'sys', messages: [{ role: 'user', content: 'hi' }] },
+  response: 'hello',
+  usage: { input_tokens: 10, output_tokens: 5 },
+};
+
+describe('capturePayload', () => {
+  beforeEach(() => {
+    mockRecord.mockReset().mockResolvedValue({ ok: true, data: { id: 1 } });
+    delete process.env.LLM_PAYLOAD_CAPTURE_RATE;
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is off by default — no POST when rate is unset', () => {
+    capturePayload(baseInput);
+    expect(mockRecord).not.toHaveBeenCalled();
+  });
+
+  it('does not capture when rate is 0', () => {
+    process.env.LLM_PAYLOAD_CAPTURE_RATE = '0';
+    capturePayload(baseInput);
+    expect(mockRecord).not.toHaveBeenCalled();
+  });
+
+  it('captures at rate 1 and tags flow + runId from ambient context', () => {
+    process.env.LLM_PAYLOAD_CAPTURE_RATE = '1';
+    runWithAmbientContext(
+      { tracker: new CostTracker(), flow: 'research-agent', runId: 'run-123' },
+      () => capturePayload({ ...baseInput, label: 'verify' }),
+    );
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+    const arg = mockRecord.mock.calls[0][0];
+    expect(arg).toMatchObject({
+      flow: 'research-agent',
+      runId: 'run-123',
+      label: 'verify',
+      model: 'claude-haiku-4-5-20251001',
+      response: 'hello',
+      tokensInput: 10,
+      tokensOutput: 5,
+      truncated: false,
+    });
+  });
+
+  it('respects the sample rate via Math.random', () => {
+    process.env.LLM_PAYLOAD_CAPTURE_RATE = '0.5';
+    vi.spyOn(Math, 'random').mockReturnValue(0.9); // above 0.5 → skip
+    capturePayload(baseInput);
+    expect(mockRecord).not.toHaveBeenCalled();
+
+    (Math.random as ReturnType<typeof vi.fn>).mockReturnValue(0.1); // below 0.5 → capture
+    capturePayload(baseInput);
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it('truncates oversize responses and flags truncated', () => {
+    process.env.LLM_PAYLOAD_CAPTURE_RATE = '1';
+    capturePayload({ ...baseInput, response: 'x'.repeat(300_000) });
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+    const arg = mockRecord.mock.calls[0][0];
+    expect(arg.truncated).toBe(true);
+    expect(arg.response.length).toBeLessThanOrEqual(200_000);
+  });
+
+  it('never throws when the POST rejects', () => {
+    process.env.LLM_PAYLOAD_CAPTURE_RATE = '1';
+    mockRecord.mockRejectedValue(new Error('network down'));
+    expect(() => capturePayload(baseInput)).not.toThrow();
+  });
+});

--- a/crux/lib/llm-usage/capture-payload.ts
+++ b/crux/lib/llm-usage/capture-payload.ts
@@ -18,7 +18,7 @@
  */
 
 import { recordLlmPayload } from '../wiki-server/llm-payloads.ts';
-import { getAmbientContext } from './ambient-tracker.ts';
+import { getAmbientContext, recordAmbient } from './ambient-tracker.ts';
 
 // No size cap: payloads are stored whole. Postgres text/jsonb handle multi-MB
 // values fine, and a clipped prompt is useless for replay — so we'd rather
@@ -86,4 +86,36 @@ export function capturePayload(input: CapturePayloadInput): void {
       `[llm-usage] capturePayload failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+}
+
+/**
+ * Instrument a direct `client.messages.create` call — the ones that bypass
+ * streamingCreate. Records cost into the ambient tracker (1a) and captures the
+ * request/response (1b), mirroring what streamingCreate does automatically.
+ * Call this right after the SDK call at each direct site. Best-effort; never
+ * throws (both callees swallow their own errors).
+ *
+ * `model` must be the resolved model id. `responseText` is the already-extracted
+ * completion text. `usage` is the SDK response's `.usage`.
+ */
+export function recordDirectCall(args: {
+  model: string;
+  request: Record<string, unknown>;
+  responseText: string;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number | null;
+    cache_read_input_tokens?: number | null;
+  };
+  label?: string;
+}): void {
+  recordAmbient(args.model, args.usage, args.label);
+  capturePayload({
+    model: args.model,
+    request: args.request,
+    response: args.responseText,
+    usage: args.usage,
+    label: args.label,
+  });
 }

--- a/crux/lib/llm-usage/capture-payload.ts
+++ b/crux/lib/llm-usage/capture-payload.ts
@@ -20,16 +20,10 @@
 import { recordLlmPayload } from '../wiki-server/llm-payloads.ts';
 import { getAmbientContext } from './ambient-tracker.ts';
 
-// Keep in lockstep with the server-side backstop in api-types.ts
-// (MAX_LLM_PAYLOAD_REQUEST_BYTES / MAX_LLM_PAYLOAD_RESPONSE_CHARS).
-//
-// We do NOT truncate: a clipped prompt is useless for replay (you can't
-// faithfully re-run a half prompt through a candidate model). Instead, if a
-// call exceeds the cap we SKIP capturing it entirely and log — the corpus only
-// ever holds complete, replayable rows. The cap is set high so this is rare;
-// it's a safety valve against a pathological multi-MB row, not normal clipping.
-const MAX_REQUEST_BYTES = 200_000;
-const MAX_RESPONSE_CHARS = 200_000;
+// No size cap: payloads are stored whole. Postgres text/jsonb handle multi-MB
+// values fine, and a clipped prompt is useless for replay — so we'd rather
+// store the full thing. Capture is sampled and off by default, so the corpus
+// stays bounded by the sample rate, not a per-row clip.
 
 /** Sample rate from env, clamped to [0, 1]. 0 (or unset/invalid) = capture off. */
 function captureRate(): number {
@@ -38,14 +32,6 @@ function captureRate(): number {
   const n = Number.parseFloat(raw);
   if (!Number.isFinite(n) || n <= 0) return 0;
   return n >= 1 ? 1 : n;
-}
-
-function byteSize(value: unknown): number {
-  try {
-    return Buffer.byteLength(JSON.stringify(value), 'utf8');
-  } catch {
-    return Number.POSITIVE_INFINITY;
-  }
 }
 
 export interface CapturePayloadInput {
@@ -69,15 +55,6 @@ export function capturePayload(input: CapturePayloadInput): void {
     const rate = captureRate();
     if (rate <= 0) return;
     if (rate < 1 && Math.random() >= rate) return;
-
-    // Skip (don't clip) anything over the cap — a partial prompt can't be
-    // replayed faithfully, so we'd rather have no row than a corrupt one.
-    if (byteSize(input.request) > MAX_REQUEST_BYTES || input.response.length > MAX_RESPONSE_CHARS) {
-      console.warn(
-        `[llm-usage] payload skipped (over size cap, kept whole-or-nothing for replay): model=${input.model} flow=${getAmbientContext()?.flow ?? 'none'}`,
-      );
-      return;
-    }
 
     const ctx = getAmbientContext();
 

--- a/crux/lib/llm-usage/capture-payload.ts
+++ b/crux/lib/llm-usage/capture-payload.ts
@@ -13,8 +13,9 @@
  *   - Best-effort & fire-and-forget. The POST is never awaited in the hot
  *     path and any failure is logged and swallowed — capture must never add
  *     latency to, or break, a real LLM call.
- *   - Bounded. request + response are truncated to a size cap before sending;
- *     `truncated` records whether that happened.
+ *   - Bounded by sampling, not clipping. Payloads are stored whole (no size
+ *     cap, no truncation) because a clipped prompt can't be replayed; volume
+ *     is kept in check by the sample rate, which is off by default.
  */
 
 import { recordLlmPayload } from '../wiki-server/llm-payloads.ts';

--- a/crux/lib/llm-usage/capture-payload.ts
+++ b/crux/lib/llm-usage/capture-payload.ts
@@ -1,0 +1,118 @@
+/**
+ * LLM payload capture (model-swap eval, step 1b).
+ *
+ * Captures sampled request/response bodies and ships them to the wiki-server
+ * `llm_call_payloads` table so we can later replay the same prompts through
+ * candidate models. Tagged with the ambient flow + run id (see
+ * ambient-tracker.ts) so each payload joins back to its pipeline run.
+ *
+ * Design constraints:
+ *   - OFF by default. Controlled by LLM_PAYLOAD_CAPTURE_RATE (0..1); 0 = off.
+ *     This keeps prod untouched until we deliberately turn capture on to
+ *     gather a corpus.
+ *   - Best-effort & fire-and-forget. The POST is never awaited in the hot
+ *     path and any failure is logged and swallowed — capture must never add
+ *     latency to, or break, a real LLM call.
+ *   - Bounded. request + response are truncated to a size cap before sending;
+ *     `truncated` records whether that happened.
+ */
+
+import { recordLlmPayload } from '../wiki-server/llm-payloads.ts';
+import { getAmbientContext } from './ambient-tracker.ts';
+
+// Keep in lockstep with the server-side backstop in api-types.ts
+// (MAX_LLM_PAYLOAD_REQUEST_BYTES / MAX_LLM_PAYLOAD_RESPONSE_CHARS). We truncate
+// below the server cap so a captured row is never rejected for size.
+const MAX_REQUEST_BYTES = 200_000;
+const MAX_RESPONSE_CHARS = 200_000;
+
+/** Sample rate from env, clamped to [0, 1]. 0 (or unset/invalid) = capture off. */
+function captureRate(): number {
+  const raw = process.env.LLM_PAYLOAD_CAPTURE_RATE;
+  if (!raw) return 0;
+  const n = Number.parseFloat(raw);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return n >= 1 ? 1 : n;
+}
+
+function byteSize(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), 'utf8');
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+export interface CapturePayloadInput {
+  model: string;
+  /** The request we sent: system + messages (+ key params). */
+  request: Record<string, unknown>;
+  /** The model's response text. */
+  response: string;
+  viaOpenrouter?: boolean;
+  label?: string;
+  usage?: { input_tokens?: number | null; output_tokens?: number | null } | null;
+}
+
+/**
+ * Capture one LLM call if sampling is enabled. Returns immediately; the actual
+ * POST runs in the background. Safe to call on every LLM call — it self-gates
+ * on the sample rate and never throws.
+ */
+export function capturePayload(input: CapturePayloadInput): void {
+  try {
+    const rate = captureRate();
+    if (rate <= 0) return;
+    if (rate < 1 && Math.random() >= rate) return;
+
+    let truncated = false;
+
+    // Bound the request: if it serializes over the cap, store a truncated
+    // string preview instead of the full object.
+    let request: Record<string, unknown> = input.request;
+    if (byteSize(request) > MAX_REQUEST_BYTES) {
+      truncated = true;
+      request = {
+        truncated: true,
+        preview: JSON.stringify(input.request).slice(0, MAX_REQUEST_BYTES),
+      };
+    }
+
+    let response = input.response;
+    if (response.length > MAX_RESPONSE_CHARS) {
+      truncated = true;
+      response = response.slice(0, MAX_RESPONSE_CHARS);
+    }
+
+    const ctx = getAmbientContext();
+
+    // Fire-and-forget. Never await; swallow all errors.
+    void recordLlmPayload({
+      runId: ctx?.runId ?? null,
+      flow: ctx?.flow ?? null,
+      label: input.label ?? null,
+      model: input.model,
+      viaOpenrouter: input.viaOpenrouter ?? false,
+      request,
+      response,
+      tokensInput: input.usage?.input_tokens ?? null,
+      tokensOutput: input.usage?.output_tokens ?? null,
+      truncated,
+    }).then(
+      (res) => {
+        if (!res.ok) {
+          console.warn(`[llm-usage] payload capture POST failed (non-fatal): ${res.message}`);
+        }
+      },
+      (err: unknown) => {
+        console.warn(
+          `[llm-usage] payload capture threw (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      },
+    );
+  } catch (err) {
+    console.warn(
+      `[llm-usage] capturePayload failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/crux/lib/llm-usage/capture-payload.ts
+++ b/crux/lib/llm-usage/capture-payload.ts
@@ -21,8 +21,13 @@ import { recordLlmPayload } from '../wiki-server/llm-payloads.ts';
 import { getAmbientContext } from './ambient-tracker.ts';
 
 // Keep in lockstep with the server-side backstop in api-types.ts
-// (MAX_LLM_PAYLOAD_REQUEST_BYTES / MAX_LLM_PAYLOAD_RESPONSE_CHARS). We truncate
-// below the server cap so a captured row is never rejected for size.
+// (MAX_LLM_PAYLOAD_REQUEST_BYTES / MAX_LLM_PAYLOAD_RESPONSE_CHARS).
+//
+// We do NOT truncate: a clipped prompt is useless for replay (you can't
+// faithfully re-run a half prompt through a candidate model). Instead, if a
+// call exceeds the cap we SKIP capturing it entirely and log — the corpus only
+// ever holds complete, replayable rows. The cap is set high so this is rare;
+// it's a safety valve against a pathological multi-MB row, not normal clipping.
 const MAX_REQUEST_BYTES = 200_000;
 const MAX_RESPONSE_CHARS = 200_000;
 
@@ -65,23 +70,13 @@ export function capturePayload(input: CapturePayloadInput): void {
     if (rate <= 0) return;
     if (rate < 1 && Math.random() >= rate) return;
 
-    let truncated = false;
-
-    // Bound the request: if it serializes over the cap, store a truncated
-    // string preview instead of the full object.
-    let request: Record<string, unknown> = input.request;
-    if (byteSize(request) > MAX_REQUEST_BYTES) {
-      truncated = true;
-      request = {
-        truncated: true,
-        preview: JSON.stringify(input.request).slice(0, MAX_REQUEST_BYTES),
-      };
-    }
-
-    let response = input.response;
-    if (response.length > MAX_RESPONSE_CHARS) {
-      truncated = true;
-      response = response.slice(0, MAX_RESPONSE_CHARS);
+    // Skip (don't clip) anything over the cap — a partial prompt can't be
+    // replayed faithfully, so we'd rather have no row than a corrupt one.
+    if (byteSize(input.request) > MAX_REQUEST_BYTES || input.response.length > MAX_RESPONSE_CHARS) {
+      console.warn(
+        `[llm-usage] payload skipped (over size cap, kept whole-or-nothing for replay): model=${input.model} flow=${getAmbientContext()?.flow ?? 'none'}`,
+      );
+      return;
     }
 
     const ctx = getAmbientContext();
@@ -93,11 +88,10 @@ export function capturePayload(input: CapturePayloadInput): void {
       label: input.label ?? null,
       model: input.model,
       viaOpenrouter: input.viaOpenrouter ?? false,
-      request,
-      response,
+      request: input.request,
+      response: input.response,
       tokensInput: input.usage?.input_tokens ?? null,
       tokensOutput: input.usage?.output_tokens ?? null,
-      truncated,
     }).then(
       (res) => {
         if (!res.ok) {

--- a/crux/lib/llm.ts
+++ b/crux/lib/llm.ts
@@ -23,6 +23,7 @@ import type { MessageParam, ToolUseBlock, ToolResultBlockParam } from '@anthropi
 import { createClient, MODELS, resolveModel } from './anthropic.ts';
 import { withRetry, startHeartbeat } from './resilience.ts';
 import type { CostTracker } from './cost-tracker.ts';
+import { recordAmbient, recordAmbientExternalCost } from './llm-usage/ambient-tracker.ts';
 import { getApiKey } from './api-keys.ts';
 import { OpenRouterChatResponseSchema } from './openrouter-schemas.ts';
 
@@ -121,13 +122,21 @@ export async function streamingCreate(
   const stream = client.messages.stream(params as any);
   const message = await stream.finalMessage();
 
-  // Auto-record if tracker provided
-  if (options?.tracker && message.usage) {
-    options.tracker.record(
-      params.model,
-      message.usage,
-      options.label,
-    );
+  // Record spend. Prefer the caller-supplied tracker; otherwise fall back to
+  // the ambient tracker set by withPipelineRun so the call is still attributed
+  // to its flow. Best-effort — instrumentation must never break the call.
+  if (message.usage) {
+    if (options?.tracker) {
+      try {
+        options.tracker.record(params.model, message.usage, options.label);
+      } catch (err) {
+        console.warn(
+          `[llm-usage] tracker.record failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    } else {
+      recordAmbient(params.model, message.usage, options?.label);
+    }
   }
 
   return message;
@@ -216,13 +225,25 @@ async function callOpenRouterAsAnthropic(
     output_tokens: data.usage?.completion_tokens || 0,
   };
 
-  // Record cost
-  if (options?.tracker) {
+  // Record cost. Prefer the caller-supplied tracker; otherwise fall back to
+  // the ambient tracker so OpenRouter calls are attributed to their flow too.
+  // Best-effort — instrumentation must never break the call.
+  try {
     if (data.usage?.cost) {
-      options.tracker.recordExternalCost(model, data.usage.cost, options.label || 'openrouter');
-    } else {
+      if (options?.tracker) {
+        options.tracker.recordExternalCost(model, data.usage.cost, options.label || 'openrouter');
+      } else {
+        recordAmbientExternalCost(model, data.usage.cost, options?.label || 'openrouter');
+      }
+    } else if (options?.tracker) {
       options.tracker.record(model, usage, options.label);
+    } else {
+      recordAmbient(model, usage, options?.label);
     }
+  } catch (err) {
+    console.warn(
+      `[llm-usage] OpenRouter cost record failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
   // Return Anthropic-compatible message shape

--- a/crux/lib/llm.ts
+++ b/crux/lib/llm.ts
@@ -24,6 +24,7 @@ import { createClient, MODELS, resolveModel } from './anthropic.ts';
 import { withRetry, startHeartbeat } from './resilience.ts';
 import type { CostTracker } from './cost-tracker.ts';
 import { recordAmbient, recordAmbientExternalCost } from './llm-usage/ambient-tracker.ts';
+import { capturePayload } from './llm-usage/capture-payload.ts';
 import { getApiKey } from './api-keys.ts';
 import { OpenRouterChatResponseSchema } from './openrouter-schemas.ts';
 
@@ -139,6 +140,20 @@ export async function streamingCreate(
     }
   }
 
+  // Capture request/response for replay (sampled, off by default, best-effort).
+  capturePayload({
+    model: params.model,
+    request: {
+      system: params.system,
+      messages: params.messages,
+      max_tokens: params.max_tokens,
+      temperature: params.temperature,
+    },
+    response: extractText(message),
+    usage: message.usage,
+    label: options?.label,
+  });
+
   return message;
 }
 
@@ -245,6 +260,21 @@ async function callOpenRouterAsAnthropic(
       `[llm-usage] OpenRouter cost record failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+
+  // Capture request/response for replay (sampled, off by default, best-effort).
+  capturePayload({
+    model,
+    request: {
+      system: params.system,
+      messages: params.messages,
+      max_tokens: params.max_tokens,
+      temperature: params.temperature,
+    },
+    response: text,
+    usage,
+    viaOpenrouter: true,
+    label: options?.label,
+  });
 
   // Return Anthropic-compatible message shape
   return {

--- a/crux/lib/pipeline-runs/lifecycle.test.ts
+++ b/crux/lib/pipeline-runs/lifecycle.test.ts
@@ -550,6 +550,35 @@ describe('withPipelineRun', () => {
       expect(endPayload).not.toHaveProperty('tokensCacheWrite');
     });
 
+    it('auto-attributes ambient LLM calls when no tracker is configured', async () => {
+      // The win: a pipeline that makes LLM calls without manually wiring a
+      // CostTracker still records real spend, because withPipelineRun sets an
+      // ambient tracker that the LLM helpers record into. Here we simulate an
+      // LLM call by recording into the ambient tracker directly.
+      mockStart.mockResolvedValue({ ok: true, data: {} });
+      mockEnd.mockResolvedValue({ ok: true, data: {} });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+      const { recordAmbient } = await import('../llm-usage/ambient-tracker.ts');
+
+      await withPipelineRun(
+        { pipelineName: 'research-agent', heartbeatIntervalMs: 1_000_000_000 },
+        async () => {
+          recordAmbient(
+            'claude-haiku-4-5-20251001',
+            { input_tokens: 1000, output_tokens: 500 },
+            'verify',
+          );
+          return 'done';
+        },
+      );
+
+      const [, endPayload] = mockEnd.mock.calls[0];
+      expect(endPayload.costUsd).toBeGreaterThan(0);
+      expect(endPayload.tokensInput).toBe(1000);
+      expect(endPayload.tokensOutput).toBe(500);
+    });
+
     it('warns and skips tracker persistence when allowOffline=true and /start fails', async () => {
       mockStart.mockResolvedValue({
         ok: false,

--- a/crux/lib/pipeline-runs/lifecycle.ts
+++ b/crux/lib/pipeline-runs/lifecycle.ts
@@ -46,7 +46,8 @@ import {
   endPipelineRun,
   type PipelineRunEndStatus,
 } from '../wiki-server/pipeline-runs.ts';
-import type { CostTracker } from '../cost-tracker.ts';
+import { CostTracker } from '../cost-tracker.ts';
+import { runWithAmbientTracker } from '../llm-usage/ambient-tracker.ts';
 import { getCachedAuditSessionId } from '../wiki-server/audit-context.ts';
 import { parseAgentSessionId } from './agent-session-id.ts';
 
@@ -109,12 +110,20 @@ export async function withPipelineRun<T>(
 ): Promise<T> {
   const runId = randomUUID();
   const heartbeatIntervalMs = options.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS;
+  // Resolve the cost tracker. When the caller doesn't supply one we create a
+  // tracker so that LLM calls made inside the body still get attributed to
+  // this flow automatically (recorded via the ambient tracker below and
+  // persisted to pipeline_runs on /end). Callers that pass their own tracker
+  // keep the existing behavior — and that same instance becomes the ambient
+  // one, so un-wired calls accumulate into it rather than being lost.
+  const callerProvidedTracker = options.tracker !== undefined;
+  const tracker = options.tracker ?? new CostTracker();
   // Snapshot the tracker's entry count BEFORE the body runs so each
   // pipeline_runs row only records what its body added — not entries the
   // caller already accumulated. Required for nested wraps (e.g.
   // improve-entity → research-agent, sharing one tracker) so the inner
   // row doesn't double-count parent spend.
-  const trackerStartIndex = options.tracker?.entries.length ?? 0;
+  const trackerStartIndex = tracker.entries.length;
 
   // Start the run. Fail-closed by default.
   // Defaults `agentSessionId` to the cached audit session id when callers
@@ -145,7 +154,7 @@ export async function withPipelineRun<T>(
           { runId, pipelineName: options.pipelineName },
         );
       }
-      return body(makeOfflineCtx(runId));
+      return runWithAmbientTracker(tracker, () => body(makeOfflineCtx(runId)));
     }
 
     throw new Error(
@@ -214,7 +223,7 @@ export async function withPipelineRun<T>(
   if (typeof heartbeatTimer.unref === 'function') heartbeatTimer.unref();
 
   try {
-    const result = await body(ctx);
+    const result = await runWithAmbientTracker(tracker, () => body(ctx));
     clearInterval(heartbeatTimer);
     await finalize({
       runId,
@@ -224,7 +233,9 @@ export async function withPipelineRun<T>(
       errorCode: overrideErrorCode,
       errorPayload: null,
       followups,
-      costTotals: trackerTotals(options.tracker, trackerStartIndex),
+      costTotals: trackerTotals(tracker, trackerStartIndex, {
+        omitWhenEmpty: !callerProvidedTracker,
+      }),
     });
     return result;
   } catch (err: unknown) {
@@ -244,7 +255,9 @@ export async function withPipelineRun<T>(
         errorCode: overrideErrorCode ?? errorCodeFor(err),
         errorPayload: errorPayload(err),
         followups,
-        costTotals: trackerTotals(options.tracker, trackerStartIndex),
+        costTotals: trackerTotals(tracker, trackerStartIndex, {
+          omitWhenEmpty: !callerProvidedTracker,
+        }),
       });
     } catch (finalizeErr: unknown) {
       error(
@@ -304,8 +317,17 @@ interface CostTotals {
  * silently truncate, so rounding client-side keeps caller-side and
  * persisted values equal.
  */
-function trackerTotals(tracker: CostTracker | undefined, startIndex: number): CostTotals | null {
+function trackerTotals(
+  tracker: CostTracker | undefined,
+  startIndex: number,
+  opts?: { omitWhenEmpty?: boolean },
+): CostTotals | null {
   if (!tracker) return null;
+  // When the tracker was auto-created (caller passed none) and the body
+  // recorded no LLM calls, omit cost fields so the /end client preserves any
+  // existing values rather than overwriting with 0. A caller-supplied tracker
+  // keeps the old contract: explicit zeros are sent even when empty.
+  if (opts?.omitWhenEmpty && tracker.entries.length <= startIndex) return null;
   let costUsd = 0;
   let tokensInput = 0;
   let tokensOutput = 0;

--- a/crux/lib/pipeline-runs/lifecycle.ts
+++ b/crux/lib/pipeline-runs/lifecycle.ts
@@ -47,7 +47,7 @@ import {
   type PipelineRunEndStatus,
 } from '../wiki-server/pipeline-runs.ts';
 import { CostTracker } from '../cost-tracker.ts';
-import { runWithAmbientTracker } from '../llm-usage/ambient-tracker.ts';
+import { runWithAmbientContext } from '../llm-usage/ambient-tracker.ts';
 import { getCachedAuditSessionId } from '../wiki-server/audit-context.ts';
 import { parseAgentSessionId } from './agent-session-id.ts';
 
@@ -154,7 +154,10 @@ export async function withPipelineRun<T>(
           { runId, pipelineName: options.pipelineName },
         );
       }
-      return runWithAmbientTracker(tracker, () => body(makeOfflineCtx(runId)));
+      return runWithAmbientContext(
+        { tracker, flow: options.pipelineName, runId },
+        () => body(makeOfflineCtx(runId)),
+      );
     }
 
     throw new Error(
@@ -223,7 +226,10 @@ export async function withPipelineRun<T>(
   if (typeof heartbeatTimer.unref === 'function') heartbeatTimer.unref();
 
   try {
-    const result = await runWithAmbientTracker(tracker, () => body(ctx));
+    const result = await runWithAmbientContext(
+      { tracker, flow: options.pipelineName, runId },
+      () => body(ctx),
+    );
     clearInterval(heartbeatTimer);
     await finalize({
       runId,

--- a/crux/lib/scorecard-import/extract/fli.ts
+++ b/crux/lib/scorecard-import/extract/fli.ts
@@ -15,6 +15,7 @@ import { readFileSync, existsSync, writeFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 import type { CallClaudeResult } from "../../anthropic.ts";
 import { createClient, MODELS, callClaude, parseJsonResponse } from "../../anthropic.ts";
+import { recordDirectCall } from "../../llm-usage/capture-payload.ts";
 import { escapeXml } from "../../prompt-utils.ts";
 import { stripHtmlForLlm, fetchToCache } from "./html-utils.ts";
 import type { FLIWaveFile } from "../sources/fli.ts";
@@ -303,6 +304,20 @@ async function defaultPdfCall(wave: FliWaveConfig, pdfBuf: Buffer): Promise<Call
     .map((b) => (b.type === "text" ? b.text : ""))
     .filter((s) => s.length > 0)
     .join("\n");
+  // Direct SDK call — record cost + capture. The request carries a PDF
+  // document; we note it rather than storing the megabytes of base64.
+  recordDirectCall({
+    model: MODELS.sonnet,
+    request: {
+      system: EXTRACTOR_SYSTEM,
+      max_tokens: 4000,
+      temperature: 0,
+      messages: [{ role: "user", content: `[PDF document attached]\n${buildPdfPrompt(wave)}` }],
+    },
+    responseText: text,
+    usage: response.usage,
+    label: "fli-pdf-extract",
+  });
   return { text, usage: response.usage, model: MODELS.sonnet };
 }
 

--- a/crux/lib/wiki-server/llm-payloads.ts
+++ b/crux/lib/wiki-server/llm-payloads.ts
@@ -26,7 +26,6 @@ export interface RecordLlmPayloadInput {
   response: string;
   tokensInput?: number | null;
   tokensOutput?: number | null;
-  truncated?: boolean;
 }
 
 /** Record one captured LLM call. */

--- a/crux/lib/wiki-server/llm-payloads.ts
+++ b/crux/lib/wiki-server/llm-payloads.ts
@@ -1,0 +1,51 @@
+/**
+ * LLM Call Payloads API — wiki-server client (model-swap eval, step 1b).
+ *
+ * Mirrors pipeline-runs.ts: response types are inferred from the Hono RPC
+ * route via InferResponseType<>, no raw `apiRequest<T>` with hand-written
+ * generics. Used by the capture path in `crux/lib/llm-usage/capture-payload.ts`.
+ */
+
+import { apiRequest, type ApiResult } from './client.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { LlmPayloadsRoute } from '../../../apps/wiki-server/src/routes/operational/llm-payloads.ts';
+
+type RpcClient = ReturnType<typeof hc<LlmPayloadsRoute>>;
+
+export type LlmPayloadRecorded = InferResponseType<RpcClient['index']['$post'], 201>;
+export type LlmPayloadsListResult = InferResponseType<RpcClient['index']['$get'], 200>;
+export type LlmPayloadRow = LlmPayloadsListResult['payloads'][number];
+
+export interface RecordLlmPayloadInput {
+  runId?: string | null;
+  flow?: string | null;
+  label?: string | null;
+  model: string;
+  viaOpenrouter?: boolean;
+  request: Record<string, unknown>;
+  response: string;
+  tokensInput?: number | null;
+  tokensOutput?: number | null;
+  truncated?: boolean;
+}
+
+/** Record one captured LLM call. */
+export async function recordLlmPayload(
+  input: RecordLlmPayloadInput,
+): Promise<ApiResult<LlmPayloadRecorded>> {
+  return apiRequest<LlmPayloadRecorded>('POST', '/api/llm-payloads', input);
+}
+
+/** List captured calls (filter by flow / model) for replay. */
+export async function listLlmPayloads(options?: {
+  flow?: string;
+  model?: string;
+  limit?: number;
+}): Promise<ApiResult<LlmPayloadsListResult>> {
+  const params = new URLSearchParams();
+  if (options?.flow) params.set('flow', options.flow);
+  if (options?.model) params.set('model', options.model);
+  if (options?.limit != null) params.set('limit', String(options.limit));
+  const qs = params.toString();
+  return apiRequest<LlmPayloadsListResult>('GET', `/api/llm-payloads${qs ? `?${qs}` : ''}`);
+}


### PR DESCRIPTION
## What

Step 1 of the model-swap evaluation — capture what every LLM call costs **and** what it sent/received, so we can rank flows by spend and later replay real prompts through cheaper candidate models.

Two parts:
- **1a — cost/tokens** per flow into `pipeline_runs`.
- **1b — request/response bodies** (sampled) into a new `llm_call_payloads` table.

## How

**Ambient context (AsyncLocalStorage).** `withPipelineRun` sets a per-run context (cost tracker + flow name + run id) for the body, auto-created when the caller passes none. `streamingCreate` and the **OpenRouter** path read it, so calls get attributed **without each call site wiring anything**.

**1a — cost.** Calls record into the ambient tracker; the existing `/end` path persists totals to the `pipeline_runs` cost columns.

**1b — payloads.** New `llm_call_payloads` table (migration `0225`) + `POST/GET /api/llm-payloads` route + typed crux client. Captured rows carry `flow` + `run_id` so they join back to the run.

## Safety

- **Off by default.** 1b is gated on `LLM_PAYLOAD_CAPTURE_RATE` (0..1; 0 = off) — prod is untouched until we deliberately turn it on.
- **Best-effort & fire-and-forget.** Recording/capture is never awaited in the hot path and all errors are logged and swallowed — instrumentation can never add latency to or break a real LLM call.
- **Stored whole.** No size cap — Postgres handles multi-MB rows fine and a clipped prompt cannot be replayed; volume is bounded by the sample rate, not a per-row limit.
- `trackerTotals` omits cost fields (preserve-on-`/end`) for an auto-created tracker that recorded nothing; a caller-supplied empty tracker keeps the old explicit-zeros contract.

## Coverage

All LLM call paths are logged: `streamingCreate`, the OpenRouter path, and the 5 direct `client.messages.create` sites (`callClaude`, fli PDF extract, `grading`, `generate-summaries`, `reassign-update-frequency`) via a shared `recordDirectCall()` helper.

## Tests / verification

- Unit: `ambient-tracker`, `capture-payload` (sampling/whole-payload/fail-safe), `RecordLlmPayloadSchema`, lifecycle auto-attribution; touched-area suite green.
- Live: ran the real `research-agent` flow against a local stack — `pipeline_runs` got `cost_usd=0.0248` + 20894/2010 tokens, `llm_call_payloads` got 13 prompt/response rows with `run_id` linked; migration `0225` applied clean on Postgres 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New LLM payload capture system records request/response data during API calls
  * New API endpoints enable recording and querying captured payloads with filtering by flow and model
  * Automatic payload capture integrated throughout existing workflows for transparent tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->