### PR TITLE
ci(job-worker): enable LLM payload capture via repo variable

### DIFF
--- a/.github/workflows/job-worker.yml
+++ b/.github/workflows/job-worker.yml
@@ -48,6 +48,10 @@ permissions:
 env:
   LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
   LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
+  # Sampling rate for LLM request/response payload capture (model-swap eval).
+  # Driven by the repo variable so it can be tuned without a workflow change;
+  # empty/unset = off. Set vars.LLM_PAYLOAD_CAPTURE_RATE to 1 to capture all.
+  LLM_PAYLOAD_CAPTURE_RATE: ${{ vars.LLM_PAYLOAD_CAPTURE_RATE }}
 
 jobs:
   paused-notice:


### PR DESCRIPTION
Wires `LLM_PAYLOAD_CAPTURE_RATE` into the GitHub Actions **job worker** (where the page-improve / research-agent pipelines run), driven by the `LLM_PAYLOAD_CAPTURE_RATE` repo variable (already set to `1`).

- Follow-up to #4942 (the capture mechanism).
- Variable-driven so the rate is tunable without a workflow edit; unset = off.
- Note: the in-cluster k8s worker (claim-sourcing, source-discover) is a separate env and not covered by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to include a new environment variable for controlling LLM payload capture sampling. This enables flexible configuration of request and response data capture levels during job processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->