### PR TITLE
fix(security): bump wiki-server base image to node 24

### DIFF
--- a/apps/wiki-server/Dockerfile
+++ b/apps/wiki-server/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+RUN apk upgrade --no-cache && corepack enable && corepack prepare pnpm@9.15.4 --activate
 
 WORKDIR /repo
 


### PR DESCRIPTION
Cuts Trivy CRITICAL/HIGH findings on the wiki-server image **~29 → 13** (verified locally with trivy 0.69.3).

- Base `node:22-alpine` → `node:24-alpine` (newer bundled npm tooling: minimatch 10, glob 13).
- `apk upgrade --no-cache` to patch alpine libssl/libcrypto.
- pnpm left at the repo's pinned 9.15.4 — bumping it adds its own newer CVEs (tested pnpm 10 → worse, 26 findings).

Remaining 13 are all inside pnpm's own bundled dependencies (tar/minimatch/glob/pnpm) — build/runtime tool internals, not the app's deps. Image builds clean; the deploy pipeline's smoke test validates runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment Node.js version from 22 to 24.
  * Upgraded Alpine Linux packages in the Docker base image.
  * Updated package manager dependencies for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->