### PR TITLE
ci(security): least-privilege permissions for workflows

### DIFF
--- a/.github/workflows/_paused-notice.yml
+++ b/.github/workflows/_paused-notice.yml
@@ -2,6 +2,8 @@ name: Paused Notice
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   paused-notice:
     if: vars.AUTOMATION_PAUSED == 'true'

--- a/.github/workflows/_preflight-wiki-server.yml
+++ b/.github/workflows/_preflight-wiki-server.yml
@@ -6,6 +6,8 @@ on:
         description: "Whether the wiki-server is reachable and healthy"
         value: ${{ jobs.check.outputs.healthy }}
 
+permissions: {}
+
 # Reusable workflow that checks wiki-server health before running dependent jobs.
 # Replaces the duplicated preflight pattern across 8+ workflows.
 #

--- a/.github/workflows/ci-pr-health.yml
+++ b/.github/workflows/ci-pr-health.yml
@@ -22,6 +22,8 @@ concurrency:
   group: ci-pr-health
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   paused-notice:
     uses: ./.github/workflows/_paused-notice.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ci-${{ github.event.pull_request.number || github.sha }}-${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && 'label' || 'main' }}
   cancel-in-progress: ${{ github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
 
+permissions:
+  contents: read
+
 jobs:
   # ---------------------------------------------------------------------------
   # Phase 1: Build data (shared by validate and test jobs via artifact)
@@ -415,6 +418,9 @@ jobs:
     needs: [ci]
     if: failure() && github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -19,6 +19,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   paused-notice:
     uses: ./.github/workflows/_paused-notice.yml

--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -16,6 +16,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   restore:
     name: Restore database

--- a/.github/workflows/e2e-post-deploy.yml
+++ b/.github/workflows/e2e-post-deploy.yml
@@ -11,6 +11,9 @@ on:
     branches: [production]
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     # Only run if CI succeeded (or on manual trigger)

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -19,6 +19,9 @@ concurrency:
   group: e2e-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-data-health.yml
+++ b/.github/workflows/frontend-data-health.yml
@@ -19,6 +19,8 @@ concurrency:
   group: frontend-data-health
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   preflight:
     # Global circuit breaker — skip when automation is paused.

--- a/.github/workflows/server-api-health.yml
+++ b/.github/workflows/server-api-health.yml
@@ -19,6 +19,8 @@ concurrency:
   group: server-api-health
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   preflight:
     # Global circuit breaker — skip when automation is paused.

--- a/.github/workflows/snapshot-resources.yml
+++ b/.github/workflows/snapshot-resources.yml
@@ -18,6 +18,9 @@ concurrency:
   group: snapshot-resources
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   paused-notice:
     uses: ./.github/workflows/_paused-notice.yml

--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -11,6 +11,9 @@ concurrency:
   group: sync-data-${{ github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   paused-notice:
     uses: ./.github/workflows/_paused-notice.yml

--- a/.github/workflows/sync-entities-facts.yml
+++ b/.github/workflows/sync-entities-facts.yml
@@ -29,6 +29,9 @@ concurrency:
   group: sync-entities-${{ github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   paused-notice:
     uses: ./.github/workflows/_paused-notice.yml
@@ -47,6 +50,8 @@ jobs:
     if: github.ref == 'refs/heads/production'
     needs: [preflight]
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
     steps:
       - name: Wait for wiki-server deploy
         env:

--- a/.github/workflows/wiki-server-docker.yml
+++ b/.github/workflows/wiki-server-docker.yml
@@ -31,6 +31,9 @@ concurrency:
   group: wiki-server-docker-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     name: Build & push to GHCR
@@ -79,6 +82,8 @@ jobs:
       github.ref == 'refs/heads/production'
       && inputs.skip_smoke_test != true
     runs-on: ubuntu-latest
+    permissions:
+      packages: read
 
     services:
       postgres:

--- a/.github/workflows/wiki-server-export.yml
+++ b/.github/workflows/wiki-server-export.yml
@@ -20,6 +20,8 @@ concurrency:
   group: wiki-server-export
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   paused-notice:
     uses: ./.github/workflows/_paused-notice.yml

--- a/.github/workflows/worker-docker.yml
+++ b/.github/workflows/worker-docker.yml
@@ -26,6 +26,8 @@ concurrency:
   # landed in quick succession (incident 2026-03-29, issue #3418).
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   build-and-push:
     name: Build & push to GHCR


### PR DESCRIPTION
Resolves the 34 CodeQL `actions/missing-workflow-permissions` alerts.

Each flagged workflow now declares an explicit top-level `permissions:` block — read-only (or empty) by default — with job-level grants only where a job needs more:
- `file-regression-issue` → `issues: write` (`gh issue create`)
- `wait-for-deploy` → `actions: read` (reads other runs)
- `pre-deploy-smoke-test` → `packages: read` (GHCR pull)

Only permission lines were added; no workflow logic changed. Jobs that already had permissions were left untouched.

Note: this touches `.github/workflows/`, so the protected-paths check needs the `gate:rules-ok` label to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)