### PR TITLE
Update Lionheart Ventures entry: stage, check size, portfolio, team (July 2026)

### DIFF
--- a/content/docs/knowledge-base/organizations/lionheart-ventures.mdx
+++ b/content/docs/knowledge-base/organizations/lionheart-ventures.mdx
@@ -96,7 +96,7 @@ This advisory network positions Lionheart Ventures within the broader AI safety 
 
 ### Effective Altruism Connections
 
-Milan Griffes, an active EA Forum contributor, was previously associated with Lionheart Ventures, indicating engagement with the effective altruism community.[^rc-3b94] In 2021, a business analysis the firm conducted of Mind Ease (a mental health startup) was featured as a case study in EA-aligned impact investing, demonstrating the firm's integration with EA funding evaluation frameworks.[^rc-b26d]
+Milan Griffes, an active EA Forum contributor, was previously a principal at Lionheart Ventures, indicating engagement with the effective altruism community.[^rc-3b94] In 2021, a business analysis the firm conducted of Mind Ease (a mental health startup) was featured as a case study in EA-aligned impact investing, demonstrating the firm's integration with EA funding evaluation frameworks.[^rc-b26d]
 
 The analysis assessed Mind Ease as comparable to other venture-financed startups, projecting user growth up to 1.5 million users in optimistic scenarios over 8 years and evaluating the company's validated revenue model, product development, unit economics, and large user base.[^rc-d9ba] This approach reflects a hybrid model combining venture capital financial analysis with impact assessment common in the EA community.
 

--- a/content/docs/knowledge-base/organizations/lionheart-ventures.mdx
+++ b/content/docs/knowledge-base/organizations/lionheart-ventures.mdx
@@ -49,7 +49,7 @@ Lionheart Ventures was founded in 2019 by David Langer, a two-time technology en
 
 ### Team Development
 
-The firm expanded its partnership team to include Shelby Clark, a repeat entrepreneur best known for founding Turo, the car-sharing marketplace that filed for IPO in January 2022.[^rc-bdcb] After leaving Turo, Clark trained as a yoga and meditation teacher and committed to dedicating his career to mental health, aligning with Lionheart's focus areas.[^rc-dcb8] As of July 2026, the partnership comprises Langer (Founder & Managing Partner) and partners Shelby Clark, Brandon Goldman, Jurgen Herre, and Tim Mullen, supported by an investment team including a principal and an associate, five venture partners, and an operations team led by Chief Financial Officer Carlos López Enríquez.[^rc-daf1]
+The firm expanded its partnership team to include Shelby Clark, a repeat entrepreneur best known for founding Turo, the car-sharing marketplace that filed for IPO in January 2022.[^rc-bdcb] After leaving Turo, Clark trained as a yoga and meditation teacher and committed to dedicating his career to mental health, aligning with Lionheart's focus areas.[^rc-dcb8] As of July 2026, the partnership comprises Langer (Founder & Managing Partner) and partners Shelby Clark, Brandon Goldman, Jurgen Herre, and Tim Mullen, supported by an investment team of principal Armin Khayatian and associate Yury Orlovskiy, five venture partners, and an operations team led by Chief Financial Officer Carlos López Enríquez.[^rc-daf1]
 
 ### Portfolio Growth
 

--- a/content/docs/knowledge-base/organizations/lionheart-ventures.mdx
+++ b/content/docs/knowledge-base/organizations/lionheart-ventures.mdx
@@ -1,13 +1,13 @@
 ---
 wikiId: E541
 title: Lionheart Ventures
-description: Venture capital firm investing in early-stage AI safety and frontier mental health technologies
+description: Venture capital firm investing pre-seed to Series A in AI safety and frontier mental health technologies
 sidebar:
   order: 50
 subcategory: venture-capital
-lastEdited: 2026-02-03
+lastEdited: 2026-07-10
 update_frequency: 21
-summary: "Lionheart Ventures is a small venture capital firm (\\$25M inaugural fund) focused on AI safety and mental health investments, notable for its investment in Anthropic and integration with the EA community through advisors and personnel. The firm represents an interesting model of for-profit AI safety funding, though its actual impact and financial performance remain unclear due to limited disclosure."
+summary: "Lionheart Ventures is a venture capital firm investing pre-seed to Series A in AI safety and frontier mental health, notable for investments including Anthropic, Goodfire, Gray Swan, and Lucid Computing, and for its integration with the AI safety ecosystem through advisors and personnel. The firm represents an interesting model of for-profit AI safety funding, though its actual impact and financial performance remain unclear due to limited disclosure."
 clusters:
   - ai-safety
   - community
@@ -21,9 +21,10 @@ import { EntityLink } from '@components/wiki';
 | **Type** | Venture capital firm |
 | **Founded** | 2019 |
 | **Focus Areas** | AI safety, frontier mental health technologies |
-| **Stage** | Seed, Series A, some Series B |
-| **Check Size** | Target range \$2.5M–\$20M per deal (stated strategy); observed historical checks range up to a maximum of \$11.5M across 33 investments as of 2024 |
-| **Notable Investments** | <EntityLink id="E22" name="anthropic">Anthropic</EntityLink>, Calm, Reprompt AI |
+| **Stage** | Pre-seed to Series A |
+| **Check Size** | Target range \$500K–\$2M+ per deal |
+| **Portfolio** | 53 publicly listed portfolio companies as of July 2026 |
+| **Notable Investments** | <EntityLink id="E22" name="anthropic">Anthropic</EntityLink>, Goodfire, Gray Swan, Lucid Computing, Calm |
 | **AI Safety Role** | Explicit focus on reducing existential risks from advanced AI |
 
 ## Key Links
@@ -34,9 +35,9 @@ import { EntityLink } from '@components/wiki';
 
 ## Overview
 
-Lionheart Ventures is a venture capital firm founded in 2019 that focuses on early-stage investments in transformative technologies, with a particular emphasis on artificial intelligence safety and frontier mental health.[^rc-587a] Based in the San Francisco Bay Area (with offices in Bolinas, California), the firm explicitly positions its investments as addressing civilizational risks while aiming to enhance human flourishing, agency, and resilience.[^rc-4806]
+Lionheart Ventures is a venture capital firm founded in 2019 that focuses on early-stage investments in transformative technologies, with a particular emphasis on artificial intelligence safety and frontier mental health.[^rc-587a] Headquartered in California and operating as a distributed team without physical offices, the firm explicitly positions its investments as addressing civilizational risks while aiming to enhance human flourishing, agency, and resilience.[^rc-4806]
 
-The firm's investment thesis draws from Carl Sagan's philosophy that wisdom must accompany technological power to prevent self-destruction.[^rc-8b88] This philosophy manifests in a concentrated focus on two primary sectors: advanced AI systems (with particular attention to safety and alignment) and frontier mental health technologies including psychedelics research and digital mental health products.[^rc-007a] As of 2024, Lionheart Ventures has made 33 investments with a maximum check size of \$11.5 million.[^rc-a4e6]
+The firm's investment thesis draws from Carl Sagan's philosophy that wisdom must accompany technological power to prevent self-destruction.[^rc-8b88] This philosophy manifests in a concentrated focus on two primary sectors: advanced AI systems (with particular attention to safety and alignment) and frontier mental health technologies including psychedelics research and digital mental health products.[^rc-007a] As of 2026, the firm frames its investment philosophy in defensive acceleration (def/acc) terms, backing AI technologies which "defend and enhance human flourishing, agency, and resilience."[^rc-8b88] The firm has made more than fifty investments to date,[^rc-e64a] with 53 portfolio companies publicly listed on its website as of July 2026.[^rc-3b21]
 
 Lionheart Ventures distinguishes itself through its advisory team, which includes prominent figures in AI safety and existential risk reduction, connecting the firm directly to the broader AI safety ecosystem and effective altruism community.[^rc-daf1]
 
@@ -48,11 +49,11 @@ Lionheart Ventures was founded in 2019 by David Langer, a two-time technology en
 
 ### Team Development
 
-The firm expanded its partnership team to include Shelby Clark, a repeat entrepreneur best known for founding Turo, the car-sharing marketplace that filed for IPO in January 2022.[^rc-bdcb] After leaving Turo, Clark trained as a yoga and meditation teacher and committed to dedicating his career to mental health, aligning with Lionheart's focus areas.[^rc-dcb8] Additional partners include Brandon Goldman and investor Ben Lee, along with Vice President of Finance Carlos López Enríquez and partner Sierra Peterson (focusing on AgTech and ClimateTech).[^rc-b9b3]
+The firm expanded its partnership team to include Shelby Clark, a repeat entrepreneur best known for founding Turo, the car-sharing marketplace that filed for IPO in January 2022.[^rc-bdcb] After leaving Turo, Clark trained as a yoga and meditation teacher and committed to dedicating his career to mental health, aligning with Lionheart's focus areas.[^rc-dcb8] As of July 2026, the partnership comprises Langer (Founder & Managing Partner) and partners Shelby Clark, Brandon Goldman, Jurgen Herre, and Tim Mullen, supported by an investment team including a principal and an associate, five venture partners, and an operations team led by Chief Financial Officer Carlos López Enríquez.[^rc-daf1]
 
 ### Portfolio Growth
 
-By August 2024, Lionheart Ventures had deployed capital across 33 investments, with the most recent investment occurring in August 2024.[^rc-8efb] The inaugural \$25 million fund was nearly fully deployed as of late 2024, with investments spanning companies like Calm, Reconnect Labs, Psylo, Journey Clinical, TRIPP, Sanmai, and <EntityLink id="E22" name="anthropic">Anthropic</EntityLink>.[^rc-e64a]
+The inaugural \$25 million fund was nearly fully deployed as of late 2024, by which point the firm had made more than fifty investments into companies such as Calm, Reconnect Labs, Psylo, Journey Clinical, TRIPP, and Sanmai.[^rc-e64a] As of July 2026, the firm publicly lists 53 portfolio companies, including <EntityLink id="E22" name="anthropic">Anthropic</EntityLink>.[^rc-3b21]
 
 ### Recent Fund Activity
 
@@ -66,35 +67,36 @@ Lionheart Ventures has positioned AI as a central investment thesis, viewing the
 
 The most prominent example of this focus is the firm's investment in <EntityLink id="E22" name="anthropic">Anthropic</EntityLink>, an AI company founded by former <EntityLink id="E218" name="openai">OpenAI</EntityLink> members that specializes in developing general AI systems with a focus on responsible AI usage and alignment.[^rc-f2c2] Anthropic's work includes research on adversarial robustness, <EntityLink id="E271" name="scalable-oversight">scalable oversight</EntityLink>, and <EntityLink id="E174" name="interpretability">mechanistic interpretability</EntityLink>—core AI safety research areas.[^rc-0c01]
 
-Other AI safety-relevant investments include Reprompt AI, which develops "last mile guardrails" for AI chatbots to prevent violations of business and security policies, representing a practical approach to <EntityLink id="E439" name="alignment">AI alignment</EntityLink> in deployed systems.[^rc-3b21]
+Other AI safety-relevant investments include Goodfire, which examines the inner workings of advanced AI models to advance understanding of AI; Gray Swan, an AI safety and security company building tools that automatically assess the risks of AI models; Lucid Computing, which provides hardware-rooted cryptographic proof that AI workloads operate within specific jurisdictions; Softmax, which pursues a mathematical theory of "organic alignment"; Nuanced, which detects AI-generated images; and Reprompt AI, which develops "last mile guardrails" for AI chatbots to prevent violations of business and security policies, representing practical approaches to <EntityLink id="E439" name="alignment">AI alignment</EntityLink> in deployed systems.[^rc-3b21]
 
 ### Frontier Mental Health Technologies
 
 The firm's second major focus area encompasses psychedelics research and related mental health innovations.[^rc-9c14] This sector is viewed not only as addressing a mental health crisis but also as supporting human flourishing—a consideration relevant to navigating transformative technological change.[^rc-2274]
 
-Portfolio companies in this category include Calm (a mental health and wellness app for meditation, relaxation, anxiety, depression, insomnia, and stress relief), Mind Ease (a mental health startup providing free or discounted access in low and middle-income countries), and various companies working on psychedelic medicine and neurotech applications.[^rc-cf6a]
+Portfolio companies in this category include Calm (a mental health and wellness app for meditation, relaxation, anxiety, depression, insomnia, and stress relief), Pelago (a digital clinic for substance use management), Journey Clinical (expanding access to psychedelic-assisted therapies), and numerous companies working on psychedelic medicine and neurotech applications.[^rc-3b21]
 
 ### Investment Strategy and Criteria
 
-Lionheart Ventures typically invests \$2.5 million to \$20 million per deal.[^rc-013c] The firm seeks mission-driven founders building companies that address civilizational risks while maintaining potential for strong financial returns.[^rc-013c] Investment decisions emphasize scalability, market size, scientific validation, and alignment with the firm's thesis of enhancing human resilience.[^rc-58b3]
+Lionheart Ventures invests from pre-seed to Series A, with a target check size of \$500,000 to \$2 million and above. The firm seeks mission-driven founders building companies that address civilizational risks while maintaining potential for strong financial returns.[^rc-013c] Investment decisions emphasize scalability, market size, scientific validation, and alignment with the firm's thesis of enhancing human resilience.[^rc-58b3]
 
 ## AI Safety Ecosystem Connections
 
 ### Advisory Team
 
-Lionheart Ventures has assembled a specialized advisory team with deep connections to AI safety research and existential risk reduction:[^rc-9148]
+Lionheart Ventures has assembled a specialized advisory team with deep connections to AI safety research and existential risk reduction:[^rc-daf1]
 
 - **<EntityLink id="richard-mallah" name="richard-mallah">Richard Mallah</EntityLink>**: Head of the Center for AI Risk Management & Alignment and Strategist at the <EntityLink id="E528" name="fli">Future of Life Institute</EntityLink>, focusing on managing extreme risks from general AI systems
 - **Aaron Tucker**: Technical Lead at <EntityLink id="E138" name="far-ai">FAR AI</EntityLink> with a PhD in Machine Learning from Cornell and prior research at Microsoft, Berkeley's <EntityLink id="E57" name="chai">Center for Human-Compatible AI</EntityLink>, and the <EntityLink id="E153" name="govai">Centre for the Governance of AI</EntityLink>
 - **Jeffrey Ladish**: Executive Director of <EntityLink id="E428" name="palisade-research">Palisade Research</EntityLink> who has consulted on <EntityLink id="E22" name="anthropic">Anthropic</EntityLink>'s information security and advised the White House and Department of Defense on emerging technology risks
 - **Cyrus Hodes**: Venture Partner who co-founded Stability AI and The Future Society (an AI governance nonprofit) and manages AI Safety Connect for international gatherings and policy solutions
-- **Allison Duettmann**: Listed as an AI safety advisor to the firm
+- **Zvi Mowshowitz**: AI advisor, author of widely read weekly analyses of AI progress and policy
+- **Allison Duettmann**: President and CEO of the Foresight Institute, listed as an AI advisor to the firm
 
 This advisory network positions Lionheart Ventures within the broader AI safety ecosystem, providing deal flow, technical evaluation capabilities, and strategic guidance on existential risk considerations.
 
 ### Effective Altruism Connections
 
-Milan Griffes is associated with Lionheart Ventures and is an active EA Forum contributor, indicating significant engagement with the effective altruism community.[^rc-3b94] The firm conducted a detailed business analysis of Mind Ease (a mental health startup) that was featured as a case study in EA-aligned impact investing, demonstrating the firm's integration with EA funding evaluation frameworks.[^rc-b26d]
+Milan Griffes, an active EA Forum contributor, was previously associated with Lionheart Ventures, indicating engagement with the effective altruism community.[^rc-3b94] In 2021, a business analysis the firm conducted of Mind Ease (a mental health startup) was featured as a case study in EA-aligned impact investing, demonstrating the firm's integration with EA funding evaluation frameworks.[^rc-b26d]
 
 The analysis assessed Mind Ease as comparable to other venture-financed startups, projecting user growth up to 1.5 million users in optimistic scenarios over 8 years and evaluating the company's validated revenue model, product development, unit economics, and large user base.[^rc-d9ba] This approach reflects a hybrid model combining venture capital financial analysis with impact assessment common in the EA community.
 
@@ -107,14 +109,16 @@ Lionheart Ventures has been recommended in AI alignment forums alongside organiz
 Beyond AI safety and mental health, Lionheart Ventures has invested in climate protection technologies including:
 
 - **Charm Industrial**: Converts biomass into bio-oil for carbon removal and steelmaking, aiming to return atmospheric CO₂ to 280 ppm
+- **Twelve**: A chemical company built for the climate era
+- **Wright**: Developing zero-emissions commercial aircraft
 - **Beam**: Urban mobility solutions
-- Various AgTech, FoodTech, and CleanTech companies[^rc-4d8f]
+- Other investments including Heart Aerospace (regional electric aviation), Carbon Crusher (low-carbon road rehabilitation), and cellular agriculture companies Formo and Shiok Meats[^rc-4d8f]
 
 These investments align with the firm's broader thesis of mitigating civilizational risks, with climate change representing another category of existential or catastrophic risk.
 
 ### Investment Performance and Scale
 
-Historical data shows Lionheart Ventures' average check size of \$791,900 with a maximum investment of \$11.5 million.[^rc-3426] The firm's 33 total investments as of August 2024 suggest a concentrated portfolio approach consistent with early-stage venture capital focused on specific theses rather than broad diversification.[^rc-c4f6]
+Lionheart Ventures has made more than fifty investments to date,[^rc-b0be] with 53 portfolio companies publicly listed on its website as of July 2026.[^rc-3b21] The target check size of \$500K–\$2M+ reflects a portfolio approach consistent with early-stage venture capital focused on specific theses rather than broad diversification.
 
 The firm operates primarily in the United States market, though with a stated global scope and investments spanning multiple continents through companies like GroupSpaces (which Langer previously co-founded and served 100+ countries).[^rc-c5ee]
 
@@ -128,7 +132,7 @@ The firm has been discussed in AI safety entrepreneurship resources as one of th
 
 ### Support for Anthropic
 
-The firm's investment in <EntityLink id="E22" name="anthropic">Anthropic</EntityLink> represents its most significant connection to mainstream AI safety research. Anthropic focuses on developing safe, steerable AI systems and conducting core AI safety research.[^rc-c339] Lionheart's support for the Anthropic Fellows Program, which funds research on adversarial robustness, scalable oversight, and mechanistic interpretability, demonstrates engagement beyond pure capital provision.[^rc-b7b2]
+The firm's investment in <EntityLink id="E22" name="anthropic">Anthropic</EntityLink> represents its most significant connection to mainstream AI safety research. Anthropic focuses on developing safe, steerable AI systems and conducting core AI safety research.[^rc-c339]
 
 ### Practical AI Safety Applications
 
@@ -142,7 +146,7 @@ Lionheart Ventures has not publicly disclosed specific fund sizes, assets under 
 
 ### Concentration Risk
 
-With only 33 investments as of August 2024 and a \$25 million inaugural fund, Lionheart Ventures operates at a relatively small scale compared to major AI safety funders like <EntityLink id="E521" name="coefficient-giving">Coefficient Giving</EntityLink> or mainstream venture capital firms investing in AI.[^rc-b0be] This limited scale constrains the firm's ability to support a broad portfolio of safety-relevant companies or to lead large funding rounds for mature startups.
+With a \$25 million inaugural fund and undisclosed subsequent fund sizes, Lionheart Ventures operates at a relatively small scale compared to major AI safety funders like <EntityLink id="E521" name="coefficient-giving">Coefficient Giving</EntityLink> or mainstream venture capital firms investing in AI.[^rc-b0be] This limited scale constrains the firm's ability to support a broad portfolio of safety-relevant companies or to lead large funding rounds for mature startups.
 
 ### Portfolio Diversification Questions
 
@@ -166,7 +170,7 @@ Several important questions remain unresolved about Lionheart Ventures' role and
 
 3. **Counterfactual Impact**: It is unclear whether Lionheart Ventures' investments enable safety work that would not otherwise occur, or whether the firm primarily funds companies that would have received funding from other sources. The counterfactual impact question is particularly relevant for investments like <EntityLink id="E22" name="anthropic">Anthropic</EntityLink>, which has raised over \$7 billion from multiple sources.
 
-4. **Scale and Influence**: Whether a \$25 million inaugural fund and 33 investments can meaningfully influence AI safety outcomes at the scale of the broader AI industry (which involves hundreds of billions in capital deployment) remains uncertain.
+4. **Scale and Influence**: Whether funds of this size making early-stage investments can meaningfully influence AI safety outcomes at the scale of the broader AI industry (which involves hundreds of billions in capital deployment) remains uncertain.
 
 5. **Mental Health Connection**: The strategic relationship between frontier mental health investments and AI safety is not fully articulated. While improved mental health and decision-making capacity could plausibly contribute to better navigation of AI risks, the causal pathway and magnitude of impact are speculative.
 

--- a/content/docs/knowledge-base/organizations/lionheart-ventures.mdx
+++ b/content/docs/knowledge-base/organizations/lionheart-ventures.mdx
@@ -77,7 +77,7 @@ Portfolio companies in this category include Calm (a mental health and wellness 
 
 ### Investment Strategy and Criteria
 
-Lionheart Ventures invests from pre-seed to Series A, with a target check size of \$500,000 to \$2 million and above. The firm seeks mission-driven founders building companies that address civilizational risks while maintaining potential for strong financial returns.[^rc-013c] Investment decisions emphasize scalability, market size, scientific validation, and alignment with the firm's thesis of enhancing human resilience.[^rc-58b3]
+Lionheart Ventures invests from pre-seed to Series A, with a target check size of \$500K–\$2M+ per deal. The firm seeks mission-driven founders building companies that address civilizational risks while maintaining potential for strong financial returns.[^rc-013c] Investment decisions emphasize scalability, market size, scientific validation, and alignment with the firm's thesis of enhancing human resilience.[^rc-58b3]
 
 ## AI Safety Ecosystem Connections
 

--- a/content/docs/knowledge-base/organizations/lionheart-ventures.mdx
+++ b/content/docs/knowledge-base/organizations/lionheart-ventures.mdx
@@ -35,9 +35,9 @@ import { EntityLink } from '@components/wiki';
 
 ## Overview
 
-Lionheart Ventures is a venture capital firm founded in 2019 that focuses on early-stage investments in transformative technologies, with a particular emphasis on artificial intelligence safety and frontier mental health.[^rc-587a] Headquartered in California and operating as a distributed team without physical offices, the firm explicitly positions its investments as addressing civilizational risks while aiming to enhance human flourishing, agency, and resilience.[^rc-4806]
+Lionheart Ventures is a venture capital firm founded in 2019 that focuses on early-stage investments in transformative technologies, with a particular emphasis on artificial intelligence safety and frontier mental health.[^rc-587a] A distributed team headquartered in California, the firm explicitly positions its investments as addressing civilizational risks while aiming to enhance human flourishing, agency, and resilience.[^rc-4806]
 
-The firm's investment thesis draws from Carl Sagan's philosophy that wisdom must accompany technological power to prevent self-destruction.[^rc-8b88] This philosophy manifests in a concentrated focus on two primary sectors: advanced AI systems (with particular attention to safety and alignment) and frontier mental health technologies including psychedelics research and digital mental health products.[^rc-007a] As of 2026, the firm frames its investment philosophy in defensive acceleration (def/acc) terms, backing AI technologies which "defend and enhance human flourishing, agency, and resilience."[^rc-8b88] The firm has made more than fifty investments to date,[^rc-e64a] with 53 portfolio companies publicly listed on its website as of July 2026.[^rc-3b21]
+The firm's investment thesis draws from Carl Sagan's philosophy that wisdom must accompany technological power to prevent self-destruction.[^rc-8b88] This philosophy manifests in a concentrated focus on two primary sectors: advanced AI systems (with particular attention to safety and alignment) and frontier mental health technologies including psychedelics research and digital mental health products.[^rc-007a] As of 2026, the firm frames its investment philosophy in defensive acceleration (def/acc) terms, backing AI technologies which "defend and enhance human flourishing, agency, and resilience."[^rc-4806] The firm has made more than fifty investments to date,[^rc-e64a] with 53 portfolio companies publicly listed on its website as of July 2026.[^rc-3b21]
 
 Lionheart Ventures distinguishes itself through its advisory team, which includes prominent figures in AI safety and existential risk reduction, connecting the firm directly to the broader AI safety ecosystem and effective altruism community.[^rc-daf1]
 
@@ -53,7 +53,7 @@ The firm expanded its partnership team to include Shelby Clark, a repeat entrepr
 
 ### Portfolio Growth
 
-The inaugural \$25 million fund was nearly fully deployed as of late 2024, by which point the firm had made more than fifty investments into companies such as Calm, Reconnect Labs, Psylo, Journey Clinical, TRIPP, and Sanmai.[^rc-e64a] As of July 2026, the firm publicly lists 53 portfolio companies, including <EntityLink id="E22" name="anthropic">Anthropic</EntityLink>.[^rc-3b21]
+The inaugural \$25 million fund was nearly fully deployed as of late 2024, with investments spanning companies like Calm, Reconnect Labs, Psylo, Journey Clinical, TRIPP, and Sanmai.[^rc-e64a] Across its funds, the firm has made more than fifty investments to date,[^rc-e64a] and publicly lists 53 portfolio companies as of July 2026, including <EntityLink id="E22" name="anthropic">Anthropic</EntityLink>.[^rc-3b21]
 
 ### Recent Fund Activity
 
@@ -118,7 +118,7 @@ These investments align with the firm's broader thesis of mitigating civilizatio
 
 ### Investment Performance and Scale
 
-Lionheart Ventures has made more than fifty investments to date,[^rc-b0be] with 53 portfolio companies publicly listed on its website as of July 2026.[^rc-3b21] The target check size of \$500K–\$2M+ reflects a portfolio approach consistent with early-stage venture capital focused on specific theses rather than broad diversification.
+Lionheart Ventures has made more than fifty investments to date,[^rc-b0be] with 53 portfolio companies publicly listed on its website as of July 2026.[^rc-3b21] The firm's early-stage, thesis-driven approach favors concentration on specific theses rather than broad diversification.
 
 The firm operates primarily in the United States market, though with a stated global scope and investments spanning multiple continents through companies like GroupSpaces (which Langer previously co-founded and served 100+ countries).[^rc-c5ee]
 


### PR DESCRIPTION
**Disclosure: I work at Lionheart Ventures (Associate).** This PR corrects factual data on our entry, sourced to public pages. Happy to adjust format or route any of it through the feedback pipeline instead.

Changes, all as of July 2026:

- Stage and check size: pre-seed to Series A, target $500K-$2M+ per deal. The previous $2.5M-$20M range came from venturecapitalarchive.com and was already flagged by your citation checker; the $11.5M max and $791,900 average figures from WaveUp Hub are also incorrect.
- Investment count: corrected from "33 investments as of August 2024" to "more than fifty" (matching the jobs.lionheart.vc posting already cited, which your checker flagged as contradicting the 33), plus 53 portfolio companies publicly listed on lionheart.vc/investments.
- Offices: the firm has no physical offices; now reads "headquartered in California and operating as a distributed team."
- Philosophy: added def/acc framing with the verbatim site quote "defend and enhance human flourishing, agency, and resilience."
- Portfolio: refreshed AI-safety-relevant investments (Goodfire, Gray Swan, Lucid Computing, Softmax, Nuanced, Reprompt AI), mental health examples (Pelago, Journey Clinical), and climate examples (Twelve, Wright, Heart Aerospace); descriptions paraphrase lionheart.vc/investments.
- Team: partners are David Langer, Shelby Clark, Brandon Goldman, Jurgen Herre, and Tim Mullen; Ben Lee and Sierra Peterson are no longer listed; Carlos López Enríquez is CFO. Milan Griffes moved to past tense. Added Zvi Mowshowitz to the AI advisors (per lionheart.vc/team).
- Removed the claim that Lionheart supports the Anthropic Fellows Program: jobs.lionheart.vc is a portfolio-wide job board and that posting is an Anthropic role syndicated there, not a Lionheart program.
- Removed the "Various AgTech, FoodTech, and CleanTech companies" line your checker flagged as unsupported.

Citations: existing rc IDs are reused where the same source supports the updated claim (lionheart.vc pages, the job posting, PEI); archived copies predate the current site so several need re-fetching. The check-size sentence is currently uncited; we can add the figure to lionheart.vc if that helps verification. I did not touch Criticisms and Limitations or Key Uncertainties beyond the stale numbers; those assessments are yours to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Lionheart Ventures knowledge-base page with current descriptions, dates, portfolio figures, and investment details.
  * Revised information about investment focus, AI safety and climate activities, team development, portfolio growth, and ecosystem connections.
  * Refreshed investment strategy, check-size guidance, performance context, and key uncertainties to reflect newer publicly available information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->